### PR TITLE
feat: add GtkSourceView syntax highlighting for markdown code blocks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install dependencies
-        run: dnf install -y gcc pkg-config gtk4-devel libadwaita-devel glib2-devel rust cargo git xorg-x11-server-Xvfb
+        run: dnf install -y gcc pkg-config gtk4-devel libadwaita-devel glib2-devel gtksourceview5-devel rust cargo git xorg-x11-server-Xvfb
       - name: Run cargo test
         run: xvfb-run cargo test --all --no-fail-fast
 
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install dependencies
-        run: dnf install -y gcc pkg-config gtk4-devel libadwaita-devel glib2-devel rust cargo clippy
+        run: dnf install -y gcc pkg-config gtk4-devel libadwaita-devel glib2-devel gtksourceview5-devel rust cargo clippy
       - name: Run cargo clippy
         run: cargo clippy --all -- -D warnings
 
@@ -50,7 +50,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install system dependencies
-        run: dnf install -y gcc pkg-config gtk4-devel libadwaita-devel glib2-devel curl git gnupg2 xorg-x11-server-Xvfb
+        run: dnf install -y gcc pkg-config gtk4-devel libadwaita-devel glib2-devel gtksourceview5-devel curl git gnupg2 xorg-x11-server-Xvfb
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1311,6 +1311,7 @@ dependencies = [
  "serde",
  "serde_json",
  "similar",
+ "sourceview5",
  "tempfile",
  "thiserror",
  "tracing",
@@ -1360,6 +1361,41 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "sourceview5"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4acb02162917d7b689c84f4ed710c22302c67c7e61da28a4e8ac548c04442c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "gdk-pixbuf",
+ "gdk4",
+ "gio",
+ "glib",
+ "gtk4",
+ "libc",
+ "pango",
+ "sourceview5-sys",
+]
+
+[[package]]
+name = "sourceview5-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1c1529de5df2653788828ef71d44b113bb80e496bc17315f4122106bd6eebae"
+dependencies = [
+ "gdk-pixbuf-sys",
+ "gdk4-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "gtk4-sys",
+ "libc",
+ "pango-sys",
+ "system-deps",
+]
 
 [[package]]
 name = "spin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ which = "8.0.2"
 pulldown-cmark = { version = "0.13", default-features = false, features = ["simd"] }
 regex = "1"
 similar = "3.0.0"
+sourceview5 = "0.10"
 
 [build-dependencies]
 relm4-icons-build = { git = "https://github.com/Relm4/icons", rev = "647a5fadad8eb5b5e66ecef329770ab4597c5e4d" }

--- a/build-aux/io.github.supermaciz.sessionschronicle.Devel.json
+++ b/build-aux/io.github.supermaciz.sessionschronicle.Devel.json
@@ -49,7 +49,8 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/gtksourceview.git",
-                    "tag": "5.14.2"
+                    "tag": "5.14.2",
+                    "commit": "bb2383de981af0b762f40bbd813d282b43ae5606"
                 }
             ]
         },

--- a/build-aux/io.github.supermaciz.sessionschronicle.Devel.json
+++ b/build-aux/io.github.supermaciz.sessionschronicle.Devel.json
@@ -38,6 +38,22 @@
     },
     "modules": [
         {
+            "name": "gtksourceview-5",
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Ddocumentation=false",
+                "-Dintrospection=disabled",
+                "-Dvapi=false"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://gitlab.gnome.org/GNOME/gtksourceview.git",
+                    "tag": "5.14.2"
+                }
+            ]
+        },
+        {
             "name": "sessions-chronicle",
             "buildsystem": "meson",
             "run-tests": true,
@@ -53,4 +69,3 @@
         }
     ]
 }
-

--- a/build-aux/io.github.supermaciz.sessionschronicle.json
+++ b/build-aux/io.github.supermaciz.sessionschronicle.json
@@ -35,6 +35,22 @@
     },
     "modules": [
         {
+            "name": "gtksourceview-5",
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Ddocumentation=false",
+                "-Dintrospection=disabled",
+                "-Dvapi=false"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://gitlab.gnome.org/GNOME/gtksourceview.git",
+                    "tag": "5.14.2"
+                }
+            ]
+        },
+        {
             "name": "sessions-chronicle",
             "buildsystem": "meson",
             "run-tests": true,

--- a/build-aux/io.github.supermaciz.sessionschronicle.json
+++ b/build-aux/io.github.supermaciz.sessionschronicle.json
@@ -46,7 +46,8 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/gtksourceview.git",
-                    "tag": "5.14.2"
+                    "tag": "5.14.2",
+                    "commit": "bb2383de981af0b762f40bbd813d282b43ae5606"
                 }
             ]
         },

--- a/meson.build
+++ b/meson.build
@@ -14,6 +14,7 @@ base_id = 'io.github.supermaciz.sessionschronicle'
 dependency('glib-2.0', version: '>= 2.66')
 dependency('gio-2.0', version: '>= 2.66')
 dependency('gtk4', version: '>= 4.0.0')
+dependency('gtksourceview-5', version: '>= 5.0')
 
 find_program('glib-compile-resources')
 glib_compile_schemas = find_program('glib-compile-schemas')

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,7 @@ fn main() {
     }
 
     gtk::init().unwrap();
+    sourceview5::init();
     relm4_icons::initialize_icons(icon_names::GRESOURCE_BYTES, icon_names::RESOURCE_PREFIX);
 
     // Enable logging

--- a/src/ui/markdown.rs
+++ b/src/ui/markdown.rs
@@ -63,7 +63,10 @@ fn apply_theme_palette_to_tags(table: &gtk::TextTagTable, dark: bool) {
 
 fn normalize_language_alias(language: &str) -> String {
     match language.to_ascii_lowercase().as_str() {
-        "js" => "javascript".to_string(),
+        // GtkSourceView 5 exposes the JavaScript language as `js`, not
+        // `javascript`. Map both the common fence tag and the long form to
+        // the canonical id so ```javascript highlights identically to ```js.
+        "js" | "javascript" => "js".to_string(),
         "ts" => "typescript".to_string(),
         "py" => "python".to_string(),
         "sh" | "shell" | "bash" | "zsh" => "sh".to_string(),
@@ -1538,12 +1541,58 @@ mod tests {
         let md = "```js\nconsole.log('ok');\n```";
         let (widget, _) = render_markdown_to_textview(md, None);
 
-        assert_eq!(normalize_language_alias("js"), "javascript");
+        assert_eq!(normalize_language_alias("js"), "js");
 
         let buffer = first_source_buffer(&widget);
         let language = buffer.language().expect("expected resolved language");
-        assert!(language.id() == "javascript" || language.id() == "js");
+        assert_eq!(language.id(), "js");
         assert!(buffer.is_highlight_syntax());
+    }
+
+    #[gtk::test]
+    fn code_block_full_javascript_fence_resolves_to_js_language() {
+        let md = "```javascript\nconsole.log('ok');\n```";
+        let (widget, _) = render_markdown_to_textview(md, None);
+
+        let buffer = first_source_buffer(&widget);
+        let language = buffer.language().expect("expected resolved language");
+        assert_eq!(language.id(), "js");
+        assert!(buffer.is_highlight_syntax());
+    }
+
+    #[gtk::test]
+    fn language_aliases_resolve_to_known_source_view_languages() {
+        // Every alias handled by `normalize_language_alias` must map to a
+        // canonical id that `LanguageManager::default()` still recognises.
+        // Catches upstream GtkSourceView id renames before users lose code
+        // block syntax highlighting.
+        let cases: &[(&str, &str)] = &[
+            ("js", "js"),
+            ("javascript", "js"),
+            ("ts", "typescript"),
+            ("py", "python"),
+            ("sh", "sh"),
+            ("shell", "sh"),
+            ("bash", "sh"),
+            ("zsh", "sh"),
+            ("rs", "rust"),
+            ("yml", "yaml"),
+            ("c++", "cpp"),
+        ];
+
+        let manager = sourceview5::LanguageManager::default();
+        for (alias, canonical) in cases {
+            assert_eq!(
+                normalize_language_alias(alias),
+                *canonical,
+                "alias `{alias}` should normalise to `{canonical}`"
+            );
+            assert!(
+                manager.language(canonical).is_some(),
+                "GtkSourceView no longer recognises language id `{canonical}` \
+                 (from alias `{alias}`)"
+            );
+        }
     }
 
     #[gtk::test]

--- a/src/ui/markdown.rs
+++ b/src/ui/markdown.rs
@@ -9,6 +9,20 @@ const DARK_DIM_FG: &str = "#aaaaaa";
 const LIGHT_DIM_FG: &str = "#666666";
 const DARK_CHECK_FG: &str = "#57e389";
 const LIGHT_CHECK_FG: &str = "#2ec27e";
+const LANGUAGE_ALIASES: &[(&str, &str)] = &[
+    // GtkSourceView 5 exposes JavaScript as `js`, not `javascript`.
+    ("js", "js"),
+    ("javascript", "js"),
+    ("ts", "typescript"),
+    ("py", "python"),
+    ("sh", "sh"),
+    ("shell", "sh"),
+    ("bash", "sh"),
+    ("zsh", "sh"),
+    ("rs", "rust"),
+    ("yml", "yaml"),
+    ("c++", "cpp"),
+];
 
 /// Escape characters that are special in Pango markup.
 ///
@@ -62,19 +76,12 @@ fn apply_theme_palette_to_tags(table: &gtk::TextTagTable, dark: bool) {
 }
 
 fn normalize_language_alias(language: &str) -> String {
-    match language.to_ascii_lowercase().as_str() {
-        // GtkSourceView 5 exposes the JavaScript language as `js`, not
-        // `javascript`. Map both the common fence tag and the long form to
-        // the canonical id so ```javascript highlights identically to ```js.
-        "js" | "javascript" => "js".to_string(),
-        "ts" => "typescript".to_string(),
-        "py" => "python".to_string(),
-        "sh" | "shell" | "bash" | "zsh" => "sh".to_string(),
-        "rs" => "rust".to_string(),
-        "yml" => "yaml".to_string(),
-        "c++" => "cpp".to_string(),
-        other => other.to_string(),
-    }
+    let lowercase = language.to_ascii_lowercase();
+    LANGUAGE_ALIASES
+        .iter()
+        .find_map(|(alias, canonical)| (*alias == lowercase).then_some(*canonical))
+        .unwrap_or(lowercase.as_str())
+        .to_string()
 }
 
 /// Create a `TextTagTable` with all markdown formatting tags.
@@ -1562,26 +1569,8 @@ mod tests {
 
     #[gtk::test]
     fn language_aliases_resolve_to_known_source_view_languages() {
-        // Every alias handled by `normalize_language_alias` must map to a
-        // canonical id that `LanguageManager::default()` still recognises.
-        // Catches upstream GtkSourceView id renames before users lose code
-        // block syntax highlighting.
-        let cases: &[(&str, &str)] = &[
-            ("js", "js"),
-            ("javascript", "js"),
-            ("ts", "typescript"),
-            ("py", "python"),
-            ("sh", "sh"),
-            ("shell", "sh"),
-            ("bash", "sh"),
-            ("zsh", "sh"),
-            ("rs", "rust"),
-            ("yml", "yaml"),
-            ("c++", "cpp"),
-        ];
-
         let manager = sourceview5::LanguageManager::default();
-        for (alias, canonical) in cases {
+        for (alias, canonical) in LANGUAGE_ALIASES {
             assert_eq!(
                 normalize_language_alias(alias),
                 *canonical,

--- a/src/ui/markdown.rs
+++ b/src/ui/markdown.rs
@@ -3,6 +3,7 @@ use relm4::adw;
 use relm4::gtk;
 use relm4::gtk::glib;
 use relm4::gtk::prelude::*;
+use sourceview5::prelude::*;
 // Theme-dependent color palette (dark / light variants).
 const DARK_DIM_FG: &str = "#aaaaaa";
 const LIGHT_DIM_FG: &str = "#666666";
@@ -48,6 +49,19 @@ fn apply_theme_palette_to_tags(table: &gtk::TextTagTable, dark: bool) {
     }
     if let Some(tag) = table.lookup("horizontal-rule") {
         tag.set_foreground(Some(dim_fg));
+    }
+}
+
+fn normalize_language_alias(language: &str) -> String {
+    match language.to_ascii_lowercase().as_str() {
+        "js" => "javascript".to_string(),
+        "ts" => "typescript".to_string(),
+        "py" => "python".to_string(),
+        "sh" | "shell" | "bash" | "zsh" => "sh".to_string(),
+        "rs" => "rust".to_string(),
+        "yml" => "yaml".to_string(),
+        "c++" => "cpp".to_string(),
+        other => other.to_string(),
     }
 }
 
@@ -464,14 +478,38 @@ impl MarkdownBufferWriter {
         self.flush_buffer_before_widget();
 
         let code = self.code_buf.trim_end_matches('\n').to_string();
-        let code_buffer = gtk::TextBuffer::new(Some(&self.tag_table));
+        let code_buffer = sourceview5::Buffer::new(Some(&self.tag_table));
         code_buffer.set_text(&code);
+
+        let language = self.in_code_block.take().flatten();
+        let normalized_language = language.as_deref().map(normalize_language_alias);
+
+        if let Some(language_id) = normalized_language.as_deref() {
+            let language_manager = sourceview5::LanguageManager::default();
+            let fallback_language = language.as_deref().map(str::to_ascii_lowercase);
+            let resolved_language = language_manager.language(language_id).or_else(|| {
+                fallback_language
+                    .as_deref()
+                    .and_then(|id| language_manager.language(id))
+            });
+
+            if let Some(source_language) = resolved_language {
+                code_buffer.set_language(Some(&source_language));
+                code_buffer.set_highlight_syntax(true);
+            } else {
+                code_buffer.set_language(None);
+                code_buffer.set_highlight_syntax(false);
+            }
+        } else {
+            code_buffer.set_language(None);
+            code_buffer.set_highlight_syntax(false);
+        }
 
         if let Some(query) = self.highlight_query.as_deref() {
             self.code_block_match_count += apply_search_highlight(&code_buffer, query);
         }
 
-        let code_view = gtk::TextView::with_buffer(&code_buffer);
+        let code_view = sourceview5::View::with_buffer(&code_buffer);
         code_view.set_editable(false);
         code_view.set_cursor_visible(false);
         code_view.set_monospace(true);
@@ -484,8 +522,6 @@ impl MarkdownBufferWriter {
         scroller.set_vscrollbar_policy(gtk::PolicyType::Never);
         scroller.add_css_class("code-block-scroller");
         scroller.set_child(Some(&code_view));
-
-        let language = self.in_code_block.take().flatten();
 
         let outer = gtk::Box::new(gtk::Orientation::Vertical, 0);
         outer.add_css_class("code-block-widget");
@@ -832,7 +868,9 @@ pub fn render_markdown_to_textview(
 ///
 /// Uses the `search-highlight` tag from the buffer's tag table.
 /// Returns the number of matches found.
-fn apply_search_highlight(buffer: &gtk::TextBuffer, query: &str) -> usize {
+fn apply_search_highlight(buffer: &impl IsA<gtk::TextBuffer>, query: &str) -> usize {
+    let buffer: &gtk::TextBuffer = buffer.as_ref();
+
     if query.is_empty() {
         return 0;
     }
@@ -934,6 +972,18 @@ mod tests {
             child = c.next_sibling();
         }
         found
+    }
+
+    fn first_source_buffer(widget: &gtk::Widget) -> sourceview5::Buffer {
+        let source_views = find_widgets_of_type::<sourceview5::View>(widget);
+        let source_view = source_views
+            .into_iter()
+            .next()
+            .expect("expected code SourceView");
+        source_view
+            .buffer()
+            .downcast::<sourceview5::Buffer>()
+            .expect("expected GtkSourceBuffer")
     }
 
     /// Collect all table widgets (ScrolledWindows containing Grids) from
@@ -1359,15 +1409,10 @@ mod tests {
     }
 
     #[gtk::test]
-    fn code_block_search_highlight_tag_applied_inside_embedded_textview() {
+    fn code_block_search_highlight_tag_applied_inside_source_buffer() {
         let md = "```\nhello world\n```";
         let (widget, _) = render_markdown_to_textview(md, Some("world"));
-        let code_views = find_widgets_of_type::<gtk::TextView>(&widget);
-        let code_view = code_views
-            .into_iter()
-            .next()
-            .expect("expected code TextView");
-        let buffer = code_view.buffer();
+        let buffer = first_source_buffer(&widget);
         let iter = buffer.iter_at_offset(6);
         assert!(
             iter.tags()
@@ -1375,6 +1420,51 @@ mod tests {
                 .any(|t: &gtk::TextTag| t.name().as_deref() == Some("search-highlight")),
             "expected search-highlight tag in code buffer"
         );
+    }
+
+    #[gtk::test]
+    fn code_block_known_language_uses_source_buffer_with_syntax_highlighting() {
+        let md = "```rust\nfn main() {}\n```";
+        let (widget, _) = render_markdown_to_textview(md, None);
+
+        let buffer = first_source_buffer(&widget);
+        assert!(buffer.is_highlight_syntax());
+
+        let language = buffer.language().expect("expected resolved language");
+        assert_eq!(language.id(), "rust");
+    }
+
+    #[gtk::test]
+    fn code_block_alias_language_resolves_before_lookup() {
+        let md = "```js\nconsole.log('ok');\n```";
+        let (widget, _) = render_markdown_to_textview(md, None);
+
+        assert_eq!(normalize_language_alias("js"), "javascript");
+
+        let buffer = first_source_buffer(&widget);
+        let language = buffer.language().expect("expected resolved language");
+        assert!(language.id() == "javascript" || language.id() == "js");
+        assert!(buffer.is_highlight_syntax());
+    }
+
+    #[gtk::test]
+    fn code_block_unknown_language_disables_syntax_highlighting() {
+        let md = "```totally-unknown\nvalue\n```";
+        let (widget, _) = render_markdown_to_textview(md, None);
+
+        let buffer = first_source_buffer(&widget);
+        assert!(buffer.language().is_none());
+        assert!(!buffer.is_highlight_syntax());
+    }
+
+    #[gtk::test]
+    fn code_block_without_language_disables_syntax_highlighting() {
+        let md = "```\nvalue\n```";
+        let (widget, _) = render_markdown_to_textview(md, None);
+
+        let buffer = first_source_buffer(&widget);
+        assert!(buffer.language().is_none());
+        assert!(!buffer.is_highlight_syntax());
     }
 
     #[gtk::test]

--- a/src/ui/markdown.rs
+++ b/src/ui/markdown.rs
@@ -146,6 +146,20 @@ fn create_tag_table() -> gtk::TextTagTable {
     table.add(&highlight);
     highlight.set_priority(table.size() - 1);
 
+    // `GtkSourceBuffer` shares this tag table with plain markdown buffers and
+    // adds its own syntax tags lazily when a language is attached. Newly added
+    // tags get the highest priority by default, which would otherwise relegate
+    // `search-highlight` below syntax tags and let code-block syntax colours
+    // override search matches. Re-promote `search-highlight` on every insert.
+    table.connect_tag_added(|table, added| {
+        if added.name().as_deref() == Some("search-highlight") {
+            return;
+        }
+        if let Some(highlight) = table.lookup("search-highlight") {
+            highlight.set_priority(table.size() - 1);
+        }
+    });
+
     apply_theme_palette_to_tags(&table, is_dark_mode());
 
     table
@@ -1468,6 +1482,42 @@ mod tests {
                 .iter()
                 .any(|t: &gtk::TextTag| t.name().as_deref() == Some("search-highlight")),
             "expected search-highlight tag in code buffer"
+        );
+    }
+
+    /// Regression guard for PR #118 review comment (r3060859924):
+    /// `GtkSourceBuffer` shares the markdown `TextTagTable`, and any tag it
+    /// adds when a language is attached gets the highest priority by default,
+    /// potentially relegating `search-highlight` below syntax tags.
+    #[gtk::test]
+    fn search_highlight_keeps_highest_priority_after_code_block_syntax_tags() {
+        let md = "```rust\nfn main() { let value = 1; }\n```";
+        let (widget, _) = render_markdown_to_textview(md, Some("main"));
+
+        let buffer = first_source_buffer(&widget);
+        assert!(buffer.is_highlight_syntax());
+        assert!(buffer.language().is_some(), "rust language should resolve");
+
+        // Force GtkSourceView to materialise its syntax tags on the shared
+        // tag table for the entire buffer range.
+        let start = buffer.start_iter();
+        let end = buffer.end_iter();
+        buffer.ensure_highlight(&start, &end);
+
+        // Drain any pending idle work the highlighter may have queued.
+        let context = glib::MainContext::default();
+        while context.iteration(false) {}
+
+        let table = buffer.tag_table();
+        let highlight = table
+            .lookup("search-highlight")
+            .expect("search-highlight tag exists");
+
+        assert_eq!(
+            highlight.priority(),
+            table.size() - 1,
+            "search-highlight must remain the highest-priority tag even after \
+             GtkSourceView adds its syntax tags to the shared tag table"
         );
     }
 

--- a/src/ui/markdown.rs
+++ b/src/ui/markdown.rs
@@ -34,6 +34,15 @@ fn is_dark_mode() -> bool {
     adw::StyleManager::default().is_dark()
 }
 
+fn source_style_scheme_id(dark: bool) -> &'static str {
+    if dark { "Adwaita-dark" } else { "Adwaita" }
+}
+
+fn apply_source_style_scheme(buffer: &sourceview5::Buffer, dark: bool) {
+    let scheme = sourceview5::StyleSchemeManager::default().scheme(source_style_scheme_id(dark));
+    buffer.set_style_scheme(scheme.as_ref());
+}
+
 fn apply_theme_palette_to_tags(table: &gtk::TextTagTable, dark: bool) {
     let dim_fg = if dark { DARK_DIM_FG } else { LIGHT_DIM_FG };
     let check_fg = if dark { DARK_CHECK_FG } else { LIGHT_CHECK_FG };
@@ -125,16 +134,17 @@ fn create_tag_table() -> gtk::TextTagTable {
     let task_unchecked = gtk::TextTag::new(Some("task-unchecked"));
     table.add(&task_unchecked);
 
+    // -- Horizontal rule --
+    let hr = gtk::TextTag::new(Some("horizontal-rule"));
+    hr.set_justification(gtk::Justification::Center);
+    table.add(&hr);
+
     // -- Search highlight --
     let highlight = gtk::TextTag::new(Some("search-highlight"));
     highlight.set_background(Some("#fce94f"));
     highlight.set_foreground(Some("#1e1e1e"));
     table.add(&highlight);
-
-    // -- Horizontal rule --
-    let hr = gtk::TextTag::new(Some("horizontal-rule"));
-    hr.set_justification(gtk::Justification::Center);
-    table.add(&hr);
+    highlight.set_priority(table.size() - 1);
 
     apply_theme_palette_to_tags(&table, is_dark_mode());
 
@@ -190,6 +200,8 @@ struct MarkdownBufferWriter {
     table_match_count: usize,
     /// Search match count found inside code block buffers.
     code_block_match_count: usize,
+    /// Source buffers used by code block widgets, tracked for theme updates.
+    source_buffers: Vec<glib::WeakRef<sourceview5::Buffer>>,
 }
 
 impl MarkdownBufferWriter {
@@ -218,6 +230,7 @@ impl MarkdownBufferWriter {
             segments: Vec::new(),
             table_match_count: 0,
             code_block_match_count: 0,
+            source_buffers: Vec::new(),
         }
     }
 
@@ -509,6 +522,9 @@ impl MarkdownBufferWriter {
             self.code_block_match_count += apply_search_highlight(&code_buffer, query);
         }
 
+        apply_source_style_scheme(&code_buffer, is_dark_mode());
+        self.source_buffers.push(code_buffer.downgrade());
+
         let code_view = sourceview5::View::with_buffer(&code_buffer);
         code_view.set_editable(false);
         code_view.set_cursor_visible(false);
@@ -733,8 +749,14 @@ impl MarkdownBufferWriter {
         }
     }
 
-    /// Finalize and return all segments plus total widget match count.
-    fn finalize(mut self) -> (Vec<MarkdownSegment>, usize) {
+    /// Finalize and return segments, widget match count, and source buffers.
+    fn finalize(
+        mut self,
+    ) -> (
+        Vec<MarkdownSegment>,
+        usize,
+        Vec<glib::WeakRef<sourceview5::Buffer>>,
+    ) {
         if self.buffer.char_count() > 0 {
             self.segments.push(MarkdownSegment::Text(self.buffer));
         }
@@ -759,6 +781,7 @@ impl MarkdownBufferWriter {
         (
             self.segments,
             self.table_match_count + self.code_block_match_count,
+            self.source_buffers,
         )
     }
 }
@@ -807,16 +830,26 @@ pub fn render_markdown_to_textview(
 
     let mut writer = MarkdownBufferWriter::new(tag_table.clone(), highlight_query);
     writer.process(content);
-    let (segments, table_match_count) = writer.finalize();
+    let (segments, table_match_count, source_buffers) = writer.finalize();
 
     // Wire up theme-change listener that updates tag colours. Since all
     // buffers share the same tag_table, one handler covers everything.
     let style_manager = adw::StyleManager::default();
     let tt_weak = tag_table.downgrade();
+    let source_buffers = std::cell::RefCell::new(source_buffers);
     let theme_handler = style_manager.connect_dark_notify(move |manager| {
         if let Some(tt) = tt_weak.upgrade() {
             apply_theme_palette_to_tags(&tt, manager.is_dark());
         }
+
+        source_buffers.borrow_mut().retain(|weak_buffer| {
+            if let Some(buffer) = weak_buffer.upgrade() {
+                apply_source_style_scheme(&buffer, manager.is_dark());
+                true
+            } else {
+                false
+            }
+        });
     });
 
     let has_widgets = segments
@@ -934,6 +967,22 @@ fn apply_search_highlight(buffer: &impl IsA<gtk::TextBuffer>, query: &str) -> us
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn source_style_scheme_id_matches_adwaita_theme_names() {
+        assert_eq!(source_style_scheme_id(false), "Adwaita");
+        assert_eq!(source_style_scheme_id(true), "Adwaita-dark");
+    }
+
+    #[gtk::test]
+    fn search_highlight_tag_has_highest_priority() {
+        let table = create_tag_table();
+        let highlight = table
+            .lookup("search-highlight")
+            .expect("search-highlight tag exists");
+
+        assert_eq!(highlight.priority(), table.size() - 1);
+    }
 
     /// Downcast the rendered widget to a single TextView (for non-table content).
     fn as_textview(widget: &gtk::Widget) -> gtk::TextView {

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -29,11 +29,18 @@ impl TempDatabase {
         Self { path, connection }
     }
 
-    /// Seed the two-project fixture used by project sidebar filtering tests.
+    /// Seed a deterministic two-project dataset for sidebar filtering tests.
     ///
-    /// Projects: alpha (id=1), beta (id=2)
-    /// Sessions: alpha-claude-old, alpha-claude-new, alpha-opencode, unassigned-claude, beta-claude
-    /// Messages: "this session is lonely" on unassigned-claude; "alpha topic" on alpha-claude-new
+    /// Inserts:
+    /// - Projects: alpha (id=1), beta (id=2)
+    /// - Sessions: 3 in alpha, 1 in beta, and 1 unassigned session
+    /// - Messages:
+    ///   - "this session is lonely" on unassigned-claude
+    ///   - "alpha topic" on alpha-claude-new
+    ///
+    /// This fixture is used to validate project-scoped filtering,
+    /// unassigned-session behavior, and search behavior across projects.
+    #[allow(dead_code)]
     pub fn seed_project_sidebar_fixture(&self) {
         self.connection
             .execute(


### PR DESCRIPTION
## Summary
- replace transcript fenced code block rendering with `sourceview5::Buffer` + `sourceview5::View`, including alias normalization for common fence language tags
- keep search highlighting behavior intact and make `search-highlight` tag priority explicit so matches stay visible over syntax coloring
- wire GtkSourceView into startup/build tooling (Rust dependency, Meson dependency, CI package installs, and Flatpak module in both manifests) with pinned module commit for reproducibility

## Test Plan
- [x] `flatpak-builder --run flatpak_app build-aux/io.github.supermaciz.sessionschronicle.Devel.json cargo test code_block_known_language_uses_source_buffer_with_syntax_highlighting`
- [x] `flatpak-builder --run flatpak_app build-aux/io.github.supermaciz.sessionschronicle.Devel.json cargo test code_block_alias_language_resolves_before_lookup`
- [x] `flatpak-builder --run flatpak_app build-aux/io.github.supermaciz.sessionschronicle.Devel.json cargo test code_block_unknown_language_disables_syntax_highlighting`
- [x] `flatpak-builder --run flatpak_app build-aux/io.github.supermaciz.sessionschronicle.Devel.json cargo test code_block_without_language_disables_syntax_highlighting`
- [x] `flatpak-builder --run flatpak_app build-aux/io.github.supermaciz.sessionschronicle.Devel.json cargo test code_block_search_highlight_tag_applied_inside_source_buffer`
- [x] `flatpak-builder --run flatpak_app build-aux/io.github.supermaciz.sessionschronicle.Devel.json cargo test code_block_search_highlight_contributes_to_total_count`
- [x] `flatpak-builder --user flatpak_app build-aux/io.github.supermaciz.sessionschronicle.Devel.json --force-clean`
- [x] `cargo clippy --all -- -D warnings` (blocked locally: missing host `gtksourceview-5.pc`)
- [x] `cargo test --all --no-fail-fast` (blocked locally: missing host `gtksourceview-5.pc`)