### PR TITLE
feat(parser/opencode): map tool==task to subagent, dedup subtask

### DIFF
--- a/docs/PARSER_DESIGN.md
+++ b/docs/PARSER_DESIGN.md
@@ -177,11 +177,15 @@ This is critical for sessions with thousands of messages.
 
 - Tool calls are explicit `part.type == "tool"` records with lifecycle state
   (`pending`/`running`/`completed`/`error`)
-- Delegated subagent work is currently visible in two distinct shapes: `part.type == "tool"`
-  with `tool == "task"`, and separate `part.type == "subtask"` records
-- Current parser behavior: indexes `tool` parts as tool calls, indexes `subtask` parts as
-  subagent records, and keeps `parentID` sessions as `is_subagent`; it does not yet
-  special-case `tool == "task"` into subagent rows linked by `state.metadata.sessionId`
+- Delegated subagent work appears in two shapes: `part.type == "tool"` with
+  `tool == "task"` (the full record, with child session ID in
+  `state.metadata.sessionId`), and `part.type == "subtask"` (a lighter
+  announcement, without child session link in most observed sessions)
+- Current parser behavior: maps `tool == "task"` to subagent rows (title from
+  `state.input.description`, `child_session_id` from `state.metadata.sessionId`);
+  indexes other `tool` parts as tool calls; indexes `subtask` parts as subagent
+  records but skips them when the session also contains any `tool == "task"` part
+  (dedup); keeps `parentID` sessions as `is_subagent`
 
 **Mistral Vibe:**
 

--- a/docs/session-formats/opencode.md
+++ b/docs/session-formats/opencode.md
@@ -543,10 +543,13 @@ Current indexing strategy is **SQLite-first dual-read with JSON fallback**:
 
 - Indexes sessions with `parentID` as subagent sessions (`is_subagent = 1`)
 - Converts `part.type == text` into transcript messages
-- Extracts `part.type == tool` into indexed tool-call records and `part.type == subtask` into subagent records
-- Current parser does not yet special-case `part.type == tool && tool == "task"`,
-  so task-tool subagent launches are currently indexed as generic tool calls
-  instead of subagent rows linked to `state.metadata.sessionId`
+- Extracts `part.type == tool` into indexed tool-call records, with the exception
+  that `tool == "task"` is mapped to subagent records (title from
+  `state.input.description`, prompt from `state.input.prompt`, `child_session_id`
+  from `state.metadata.sessionId`, result from `state.output`)
+- Extracts `part.type == subtask` into subagent records; when a session also
+  contains any `tool == "task"` part, `subtask` records are skipped to avoid
+  duplication (legacy sessions without `tool == "task"` continue to use `subtask`)
 - Non-message parts like `reasoning`, `step-start`, `step-finish`, `snapshot`, `compaction`, `file`, `agent`, `retry`, and `patch` are currently not rendered as transcript messages
 - Current official schema also includes optional `workspaceID` on sessions and optional `overflow` on `compaction` parts
 

--- a/src/parsers/opencode/mod.rs
+++ b/src/parsers/opencode/mod.rs
@@ -170,6 +170,7 @@ impl OpenCodeParser {
         let mut step_finish_tokens: Vec<MessageTokens> = Vec::new();
         let mut pending_reasoning = PendingReasoning::default();
 
+        let mut loaded: Vec<(&MessageMetadata, Vec<PartData>)> = Vec::with_capacity(messages.len());
         for message in &messages {
             let mut parts = backend.load_parts(&message.id)?;
             parts.sort_by(|a, b| match (a.order, b.order) {
@@ -178,7 +179,16 @@ impl OpenCodeParser {
                 (None, Some(_)) => Ordering::Greater,
                 (None, None) => a.id.cmp(&b.id),
             });
+            loaded.push((message, parts));
+        }
 
+        let has_task_tool_in_session = loaded.iter().any(|(_, parts)| {
+            parts.iter().any(|p| {
+                p.kind == "tool" && p.raw.get("tool").and_then(|v| v.as_str()) == Some("task")
+            })
+        });
+
+        for (message, parts) in &loaded {
             for part in parts {
                 let outcome = Self::process_part(
                     &metadata.id,
@@ -186,8 +196,9 @@ impl OpenCodeParser {
                     message.role,
                     message.model.as_deref(),
                     message.time_created,
-                    &part,
+                    part,
                     &mut has_user_message,
+                    has_task_tool_in_session,
                 );
 
                 let item_idx = transcript_items.len() as i64;
@@ -354,6 +365,7 @@ impl OpenCodeParser {
         timestamp: DateTime<Utc>,
         part: &PartData,
         has_user_message: &mut bool,
+        has_task_tool_in_session: bool,
     ) -> PartOutcome {
         match part.kind.as_str() {
             "text" => {
@@ -482,6 +494,9 @@ impl OpenCodeParser {
                 })
             }
             "subtask" => {
+                if has_task_tool_in_session {
+                    return PartOutcome::Nothing;
+                }
                 let title = part
                     .raw
                     .get("description")
@@ -1204,6 +1219,7 @@ mod tests {
                 .with_timezone(&Utc),
             &part,
             &mut has_user_message,
+            false,
         );
 
         match outcome {

--- a/src/parsers/opencode/mod.rs
+++ b/src/parsers/opencode/mod.rs
@@ -357,6 +357,7 @@ impl OpenCodeParser {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn process_part(
         session_id: &str,
         message_id: &str,

--- a/src/parsers/opencode/mod.rs
+++ b/src/parsers/opencode/mod.rs
@@ -1442,6 +1442,114 @@ mod tests {
     }
 
     #[test]
+    fn task_tool_produces_subagent_entry() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        let session_path = write_session_file(
+            root,
+            "project-a",
+            "session-task.json",
+            json!({
+                "id": "session-task",
+                "directory": "/projects/alpha",
+                "time": { "created": 1_704_067_200_000i64, "updated": 1_704_067_260_000i64 }
+            }),
+        );
+
+        write_message_file(
+            root,
+            "session-task",
+            "msg-user.json",
+            json!({
+                "id": "msg-user",
+                "sessionID": "session-task",
+                "role": "user",
+                "time": { "created": 1_704_067_200_000i64 }
+            }),
+        );
+
+        write_message_file(
+            root,
+            "session-task",
+            "msg-asst.json",
+            json!({
+                "id": "msg-asst",
+                "sessionID": "session-task",
+                "role": "assistant",
+                "time": { "created": 1_704_067_260_000i64 }
+            }),
+        );
+
+        write_part_file(
+            root,
+            "msg-user",
+            "part-user.json",
+            json!({
+                "id": "part-user",
+                "order": 1,
+                "type": "text",
+                "text": "Please delegate"
+            }),
+        );
+
+        write_part_file(
+            root,
+            "msg-asst",
+            "part-task.json",
+            json!({
+                "id": "part-task",
+                "order": 1,
+                "type": "tool",
+                "tool": "task",
+                "callID": "call_abc",
+                "state": {
+                    "status": "completed",
+                    "input": {
+                        "description": "Explore parser layout",
+                        "prompt": "Find all parser files",
+                        "subagent_type": "explore"
+                    },
+                    "metadata": {
+                        "sessionId": "ses_child123"
+                    },
+                    "output": "task_id: ses_child123\n\n<task_result>done</task_result>"
+                }
+            }),
+        );
+
+        let parser = OpenCodeParser::new(root);
+        let parsed = parser.parse(&session_path).unwrap();
+
+        assert_eq!(
+            parsed.subagents.len(),
+            1,
+            "expected one subagent from tool==task"
+        );
+        assert_eq!(parsed.subagents[0].title, "Explore parser layout");
+        assert_eq!(
+            parsed.subagents[0].prompt.as_deref(),
+            Some("Find all parser files")
+        );
+        assert_eq!(
+            parsed.subagents[0].child_session_id.as_deref(),
+            Some("ses_child123")
+        );
+        assert!(
+            parsed.subagents[0]
+                .result_summary
+                .as_deref()
+                .unwrap_or_default()
+                .contains("task_result"),
+            "result_summary should carry state.output"
+        );
+        assert!(
+            parsed.tool_calls.iter().all(|tc| tc.tool_name != "task"),
+            "tool==task should not also appear as a generic tool call"
+        );
+    }
+
+    #[test]
     fn opencode_assistant_message_gets_model() {
         use crate::parsers::opencode::json_backend::JsonBackend;
 

--- a/src/parsers/opencode/mod.rs
+++ b/src/parsers/opencode/mod.rs
@@ -410,6 +410,43 @@ impl OpenCodeParser {
 
                 let state = part.raw.get("state");
 
+                if tool_name == "task" {
+                    let input = state.and_then(|s| s.get("input"));
+                    let title = input
+                        .and_then(|i| i.get("description"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default()
+                        .to_string();
+                    let prompt = input
+                        .and_then(|i| i.get("prompt"))
+                        .and_then(|v| v.as_str())
+                        .map(str::to_string);
+                    let child_session_id = state
+                        .and_then(|s| s.get("metadata"))
+                        .and_then(|m| m.get("sessionId"))
+                        .and_then(|v| v.as_str())
+                        .map(str::to_string);
+                    let output_text = state
+                        .and_then(|s| s.get("output"))
+                        .and_then(|v| v.as_str())
+                        .map(str::to_string);
+                    let error_text = state
+                        .and_then(|s| s.get("error"))
+                        .and_then(|v| v.as_str())
+                        .map(str::to_string);
+                    let result_summary = output_text.or(error_text);
+
+                    return PartOutcome::Subagent(Subagent {
+                        id: format!("{}-{}-{}", session_id, message_id, part.id),
+                        session_id: session_id.to_string(),
+                        title,
+                        prompt,
+                        result_summary,
+                        child_session_id,
+                        parser_ref: None,
+                    });
+                }
+
                 let status = match state.and_then(|s| s.get("status")).and_then(|v| v.as_str()) {
                     Some("completed") => ToolCallStatus::Completed,
                     Some("failed") | Some("error") => ToolCallStatus::Error,

--- a/src/parsers/opencode/mod.rs
+++ b/src/parsers/opencode/mod.rs
@@ -1587,6 +1587,114 @@ mod tests {
     }
 
     #[test]
+    fn task_and_subtask_coexist_dedup() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        let session_path = write_session_file(
+            root,
+            "project-a",
+            "session-dedup.json",
+            json!({
+                "id": "session-dedup",
+                "directory": "/projects/alpha",
+                "time": { "created": 1_704_067_200_000i64, "updated": 1_704_067_260_000i64 }
+            }),
+        );
+
+        write_message_file(
+            root,
+            "session-dedup",
+            "msg-user.json",
+            json!({
+                "id": "msg-user",
+                "sessionID": "session-dedup",
+                "role": "user",
+                "time": { "created": 1_704_067_200_000i64 }
+            }),
+        );
+
+        write_message_file(
+            root,
+            "session-dedup",
+            "msg-asst.json",
+            json!({
+                "id": "msg-asst",
+                "sessionID": "session-dedup",
+                "role": "assistant",
+                "time": { "created": 1_704_067_260_000i64 }
+            }),
+        );
+
+        write_part_file(
+            root,
+            "msg-user",
+            "part-user.json",
+            json!({
+                "id": "part-user",
+                "order": 1,
+                "type": "text",
+                "text": "Please delegate"
+            }),
+        );
+
+        // Legacy subtask announcement
+        write_part_file(
+            root,
+            "msg-asst",
+            "part-subtask.json",
+            json!({
+                "id": "part-subtask",
+                "order": 1,
+                "type": "subtask",
+                "description": "Same title",
+                "prompt": "legacy announcement",
+                "agent": "explore",
+                "childSessionID": "ses_child_legacy"
+            }),
+        );
+
+        // Full task-tool record
+        write_part_file(
+            root,
+            "msg-asst",
+            "part-task.json",
+            json!({
+                "id": "part-task",
+                "order": 2,
+                "type": "tool",
+                "tool": "task",
+                "callID": "call_abc",
+                "state": {
+                    "status": "completed",
+                    "input": {
+                        "description": "Same title",
+                        "prompt": "real prompt",
+                        "subagent_type": "explore"
+                    },
+                    "metadata": { "sessionId": "ses_child_real" },
+                    "output": "done"
+                }
+            }),
+        );
+
+        let parser = OpenCodeParser::new(root);
+        let parsed = parser.parse(&session_path).unwrap();
+
+        assert_eq!(
+            parsed.subagents.len(),
+            1,
+            "subtask should be deduped when tool==task is present"
+        );
+        assert_eq!(
+            parsed.subagents[0].child_session_id.as_deref(),
+            Some("ses_child_real"),
+            "surviving subagent must come from tool==task"
+        );
+        assert_eq!(parsed.subagents[0].prompt.as_deref(), Some("real prompt"));
+    }
+
+    #[test]
     fn opencode_assistant_message_gets_model() {
         use crate::parsers::opencode::json_backend::JsonBackend;
 

--- a/src/parsers/opencode/mod.rs
+++ b/src/parsers/opencode/mod.rs
@@ -1492,6 +1492,12 @@ mod tests {
             parsed.transcript_items[1].kind,
             TranscriptItemKind::Subagent
         );
+        // Dedup guard: subtask-only session must still produce the legacy subagent
+        assert_eq!(
+            parsed.subagents.len(),
+            1,
+            "subtask-only session must still produce the legacy subagent"
+        );
     }
 
     #[test]

--- a/src/parsers/opencode/mod.rs
+++ b/src/parsers/opencode/mod.rs
@@ -106,6 +106,28 @@ pub(crate) trait OpenCodeBackend {
     fn load_session_metadata(&self, entry: &SessionEntry) -> Result<SessionMetadata>;
     fn load_messages(&self, session_id: &str) -> Result<Vec<MessageMetadata>>;
     fn load_parts(&self, message_id: &str) -> Result<Vec<PartData>>;
+
+    /// Returns true if the session has any `part.type == "tool"` part with
+    /// `tool == "task"`. Used by the parser to dedup legacy `subtask` parts.
+    ///
+    /// Default impl streams one message at a time so memory stays O(message),
+    /// matching the parser's streaming constraint. Backends that can answer
+    /// this with a single query should override.
+    fn session_has_task_tool(
+        &self,
+        _session_id: &str,
+        messages: &[MessageMetadata],
+    ) -> Result<bool> {
+        for message in messages {
+            let parts = self.load_parts(&message.id)?;
+            if parts.iter().any(|p| {
+                p.kind == "tool" && p.raw.get("tool").and_then(|v| v.as_str()) == Some("task")
+            }) {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
 }
 
 pub(crate) fn read_json(path: &Path) -> Result<Value> {
@@ -170,7 +192,8 @@ impl OpenCodeParser {
         let mut step_finish_tokens: Vec<MessageTokens> = Vec::new();
         let mut pending_reasoning = PendingReasoning::default();
 
-        let mut loaded: Vec<(&MessageMetadata, Vec<PartData>)> = Vec::with_capacity(messages.len());
+        let has_task_tool_in_session = backend.session_has_task_tool(&metadata.id, &messages)?;
+
         for message in &messages {
             let mut parts = backend.load_parts(&message.id)?;
             parts.sort_by(|a, b| match (a.order, b.order) {
@@ -179,16 +202,7 @@ impl OpenCodeParser {
                 (None, Some(_)) => Ordering::Greater,
                 (None, None) => a.id.cmp(&b.id),
             });
-            loaded.push((message, parts));
-        }
 
-        let has_task_tool_in_session = loaded.iter().any(|(_, parts)| {
-            parts.iter().any(|p| {
-                p.kind == "tool" && p.raw.get("tool").and_then(|v| v.as_str()) == Some("task")
-            })
-        });
-
-        for (message, parts) in &loaded {
             for part in parts {
                 let outcome = Self::process_part(
                     &metadata.id,
@@ -196,7 +210,7 @@ impl OpenCodeParser {
                     message.role,
                     message.model.as_deref(),
                     message.time_created,
-                    part,
+                    &part,
                     &mut has_user_message,
                     has_task_tool_in_session,
                 );

--- a/src/parsers/opencode/sqlite_backend.rs
+++ b/src/parsers/opencode/sqlite_backend.rs
@@ -141,6 +141,23 @@ impl OpenCodeBackend for SqliteBackend {
         Ok(messages)
     }
 
+    fn session_has_task_tool(
+        &self,
+        session_id: &str,
+        _messages: &[MessageMetadata],
+    ) -> Result<bool> {
+        let mut stmt = self.conn.prepare(
+            "SELECT EXISTS(\
+                 SELECT 1 FROM part \
+                 WHERE session_id = ?1 \
+                 AND json_extract(data, '$.type') = 'tool' \
+                 AND json_extract(data, '$.tool') = 'task'\
+             )",
+        )?;
+        let exists: i64 = stmt.query_row([session_id], |row| row.get(0))?;
+        Ok(exists != 0)
+    }
+
     fn load_parts(&self, message_id: &str) -> Result<Vec<PartData>> {
         let mut stmt = self
             .conn

--- a/src/parsers/opencode/sqlite_backend.rs
+++ b/src/parsers/opencode/sqlite_backend.rs
@@ -28,6 +28,16 @@ impl SqliteBackend {
             db_path: db_path.to_path_buf(),
         })
     }
+
+    fn part_table_has_session_id(&self) -> Result<bool> {
+        let mut stmt = self.conn.prepare("PRAGMA table_info(part)")?;
+        let columns = stmt
+            .query_map([], |row| row.get::<_, String>(1))?
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .context("Failed to inspect OpenCode part table")?;
+
+        Ok(columns.iter().any(|column| column == "session_id"))
+    }
 }
 
 impl OpenCodeBackend for SqliteBackend {
@@ -146,14 +156,30 @@ impl OpenCodeBackend for SqliteBackend {
         session_id: &str,
         _messages: &[MessageMetadata],
     ) -> Result<bool> {
-        let mut stmt = self.conn.prepare(
-            "SELECT EXISTS(\
-                 SELECT 1 FROM part \
-                 WHERE session_id = ?1 \
-                 AND json_extract(data, '$.type') = 'tool' \
-                 AND json_extract(data, '$.tool') = 'task'\
-             )",
-        )?;
+        let query = if self.part_table_has_session_id()? {
+            r#"
+            SELECT EXISTS(
+                SELECT 1
+                FROM part p
+                WHERE p.session_id = ?1
+                  AND CASE WHEN json_valid(p.data) THEN json_extract(p.data, '$.type') END = 'tool'
+                  AND CASE WHEN json_valid(p.data) THEN json_extract(p.data, '$.tool') END = 'task'
+            )
+            "#
+        } else {
+            r#"
+            SELECT EXISTS(
+                SELECT 1
+                FROM part p
+                INNER JOIN message m ON m.id = p.message_id
+                WHERE m.session_id = ?1
+                  AND CASE WHEN json_valid(p.data) THEN json_extract(p.data, '$.type') END = 'tool'
+                  AND CASE WHEN json_valid(p.data) THEN json_extract(p.data, '$.tool') END = 'task'
+            )
+            "#
+        };
+
+        let mut stmt = self.conn.prepare(query)?;
         let exists: i64 = stmt.query_row([session_id], |row| row.get(0))?;
         Ok(exists != 0)
     }
@@ -210,10 +236,81 @@ impl OpenCodeBackend for SqliteBackend {
 mod tests {
     use super::*;
     use crate::parsers::opencode::OpenCodeBackend;
+    use rusqlite::Connection;
     use std::path::{Path, PathBuf};
+    use tempfile::NamedTempFile;
 
     fn fixture_db() -> PathBuf {
         PathBuf::from("tests/fixtures/opencode_storage/opencode.db")
+    }
+
+    fn create_task_tool_backend(
+        part_has_session_id: bool,
+        part_rows: &[(&str, &str, &str, Option<&str>)],
+    ) -> (NamedTempFile, SqliteBackend) {
+        let db_file = NamedTempFile::new().unwrap();
+        {
+            let conn = Connection::open(db_file.path()).unwrap();
+            conn.execute_batch(
+                "
+                CREATE TABLE message (
+                    id TEXT PRIMARY KEY,
+                    session_id TEXT NOT NULL
+                );
+                ",
+            )
+            .unwrap();
+
+            if part_has_session_id {
+                conn.execute_batch(
+                    "
+                    CREATE TABLE part (
+                        id TEXT PRIMARY KEY,
+                        message_id TEXT NOT NULL,
+                        session_id TEXT NOT NULL,
+                        data TEXT NOT NULL
+                    );
+                    ",
+                )
+                .unwrap();
+            } else {
+                conn.execute_batch(
+                    "
+                    CREATE TABLE part (
+                        id TEXT PRIMARY KEY,
+                        message_id TEXT NOT NULL,
+                        data TEXT NOT NULL
+                    );
+                    ",
+                )
+                .unwrap();
+            }
+
+            for (part_id, message_id, session_id, data) in part_rows {
+                conn.execute(
+                    "INSERT OR IGNORE INTO message (id, session_id) VALUES (?1, ?2)",
+                    (*message_id, *session_id),
+                )
+                .unwrap();
+
+                if part_has_session_id {
+                    conn.execute(
+                        "INSERT INTO part (id, message_id, session_id, data) VALUES (?1, ?2, ?3, ?4)",
+                        (*part_id, *message_id, *session_id, data.unwrap_or("not-json")),
+                    )
+                    .unwrap();
+                } else {
+                    conn.execute(
+                        "INSERT INTO part (id, message_id, data) VALUES (?1, ?2, ?3)",
+                        (*part_id, *message_id, data.unwrap_or("not-json")),
+                    )
+                    .unwrap();
+                }
+            }
+        }
+
+        let backend = SqliteBackend::open(db_file.path()).unwrap();
+        (db_file, backend)
     }
 
     #[test]
@@ -283,6 +380,45 @@ mod tests {
             parts[0].raw.get("text").and_then(|v| v.as_str()),
             Some("This session only exists in SQLite")
         );
+    }
+
+    #[test]
+    fn session_has_task_tool_supports_part_tables_without_session_id() {
+        let (_db_file, backend) = create_task_tool_backend(
+            false,
+            &[(
+                "part-task",
+                "msg-task",
+                "session-task",
+                Some(r#"{"type":"tool","tool":"task"}"#),
+            )],
+        );
+
+        assert!(backend.session_has_task_tool("session-task", &[]).unwrap());
+        assert!(!backend.session_has_task_tool("other-session", &[]).unwrap());
+    }
+
+    #[test]
+    fn session_has_task_tool_supports_part_session_id_schema() {
+        let (_db_file, backend) = create_task_tool_backend(
+            true,
+            &[(
+                "part-task",
+                "msg-task",
+                "session-task",
+                Some(r#"{"type":"tool","tool":"task"}"#),
+            )],
+        );
+
+        assert!(backend.session_has_task_tool("session-task", &[]).unwrap());
+    }
+
+    #[test]
+    fn session_has_task_tool_ignores_malformed_part_json() {
+        let (_db_file, backend) =
+            create_task_tool_backend(true, &[("bad-part", "msg-task", "session-task", None)]);
+
+        assert!(!backend.session_has_task_tool("session-task", &[]).unwrap());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A prerequisite for #107 ?

- `part.type == \"tool\" && tool == \"task\"` is now mapped to a `Subagent` record instead of a generic tool call, with `child_session_id` from `state.metadata.sessionId`, title from `state.input.description`, and result from `state.output`
- `part.type == \"subtask\"` records are skipped when the session also contains any `tool == \"task\"` part, avoiding duplication (legacy sessions without `tool == \"task\"` are unaffected)
- Backed by 3 new TDD tests covering the happy path, the dedup case, and the legacy-only subtask path

## Context

OpenCode emits two shapes for subagent delegation: `tool == \"task\"` (full record with child session ID and output) and `subtask` (lighter announcement). Local DB scan showed 629 `tool==task` parts and 73 `subtask` parts; all sessions containing `subtask` also contain `tool==task`, with no child-session ID overlap between the two shapes.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all -- -D warnings` passes
- [x] `cargo test --all --no-fail-fast` passes (491 unit + 198 lib tests)
- [ ] Manual: build Flatpak and open session `ses_3a5dcdb64ffeGPbxTI3zajgYa8` — verify task-tool delegations appear in the subagents panel with child-session drill-down, not in the generic tool call list

## Related

- Design spec: `docs/superpowers/specs/2026-04-14-opencode-task-tool-as-subagent-design.md`
- Docs updated: `docs/session-formats/opencode.md`, `docs/PARSER_DESIGN.md`