### PR TITLE
feat: link Claude Code subagent transcripts to child sessions

### DIFF
--- a/docs/session-formats/claude-code.md
+++ b/docs/session-formats/claude-code.md
@@ -217,6 +217,18 @@ derives a local child session ID from the parent session ID plus `agentId`, then
 stores that derived ID in `Subagent.child_session_id` so the existing inspector
 navigation can open the indexed child transcript.
 
+The bridge from the parent transcript to the nested file is the `agentId` token
+emitted inside the `Agent`/`Task` `tool_result` text, e.g.:
+
+```
+Async agent launched successfully.
+agentId: a41c0fb07beb52ed6
+```
+
+The parser captures that value onto the parent `Subagent.agent_id`, and the
+indexer matches it against nested `agent-<agentId>.jsonl` files to populate
+`child_session_id`.
+
 ---
 
 ## Metadata Available in Events

--- a/docs/session-formats/claude-code.md
+++ b/docs/session-formats/claude-code.md
@@ -206,6 +206,17 @@ Tree structure via `uuid`/`parentUuid` + `isSidechain` flag.
 Sidechain/subagent context appears through `isSidechain` and parent links (`parentUuid`).
 Some recent `system/compact_boundary` events also include `logicalParentUuid`.
 
+### Nested Subagent Transcript Linkage
+
+Claude Code stores subagent transcripts as nested files under:
+
+`<session-id>/subagents/agent-<agentId>.jsonl`
+
+The nested transcript reuses the parent `sessionId`. Sessions Chronicle therefore
+derives a local child session ID from the parent session ID plus `agentId`, then
+stores that derived ID in `Subagent.child_session_id` so the existing inspector
+navigation can open the indexed child transcript.
+
 ---
 
 ## Metadata Available in Events

--- a/src/database/indexer.rs
+++ b/src/database/indexer.rs
@@ -1156,8 +1156,12 @@ impl SessionIndexer {
             .and_then(|stem| stem.to_str())
             .is_some_and(|stem| stem.starts_with("agent-"));
 
-        let nested_subagent =
-            components.len() == 3 && components[1].as_os_str() == "subagents" && has_agent_prefix;
+        let nested_subagent = components.len() >= 3
+            && components[components.len() - 2].as_os_str() == "subagents"
+            && !components
+                .first()
+                .is_some_and(|component| component.as_os_str() == "subagents")
+            && has_agent_prefix;
 
         if nested_subagent {
             return false;
@@ -1836,6 +1840,18 @@ mod tests {
         let sessions_dir = PathBuf::from("/home/user/.claude/sessions");
         let path = PathBuf::from(
             "/home/user/.claude/sessions/65ce34ec-2589-4f2a-aad3-f536cf8b2906/subagents/agent-a41c0fb07beb52ed6.jsonl",
+        );
+        assert!(!SessionIndexer::is_prunable_claude_sidechain_file(
+            &path,
+            &sessions_dir
+        ));
+    }
+
+    #[test]
+    fn is_prunable_claude_sidechain_file_allows_nested_subagent_transcripts_in_project_tree() {
+        let sessions_dir = PathBuf::from("/home/user/.claude/projects");
+        let path = PathBuf::from(
+            "/home/user/.claude/projects/-home-user-repo/65ce34ec-2589-4f2a-aad3-f536cf8b2906/subagents/agent-a41c0fb07beb52ed6.jsonl",
         );
         assert!(!SessionIndexer::is_prunable_claude_sidechain_file(
             &path,

--- a/src/database/indexer.rs
+++ b/src/database/indexer.rs
@@ -191,7 +191,7 @@ impl SessionIndexer {
                 continue;
             }
 
-            if Self::is_sidechain_file(path, sessions_dir) {
+            if Self::is_prunable_claude_sidechain_file(path, sessions_dir) {
                 self.prune_sidechain_session(AiAssistant::ClaudeCode, path, errors_detail);
                 continue;
             }
@@ -761,8 +761,66 @@ impl SessionIndexer {
         let resolved_project_id = Self::upsert_project_tx(&tx, session.project_path.as_deref())?;
         Self::upsert_session_row_tx(&tx, parsed, file_path, resolved_project_id)?;
         Self::replace_session_contents_tx(&tx, parsed)?;
+        Self::link_claude_subagents_tx(&tx, parsed)?;
         Self::upsert_fingerprint_tx(&tx, fingerprint_path)?;
         tx.commit()?;
+        Ok(())
+    }
+
+    fn link_claude_subagents_tx(
+        tx: &rusqlite::Transaction<'_>,
+        parsed: &ParsedSession,
+    ) -> Result<()> {
+        if parsed.session.tool != AiAssistant::ClaudeCode {
+            return Ok(());
+        }
+
+        if parsed.session.is_subagent {
+            let Some(parent_session_id) = parsed.session.parent_session_id.as_deref() else {
+                return Ok(());
+            };
+
+            let agent_id = parsed
+                .session
+                .id
+                .rsplit("::")
+                .next()
+                .filter(|value| !value.is_empty())
+                .context("Claude child session id missing agent suffix")?;
+
+            tx.execute(
+                "UPDATE subagents
+                 SET child_session_id = ?1
+                 WHERE session_id = ?2 AND agent_id = ?3",
+                rusqlite::params![&parsed.session.id, parent_session_id, agent_id],
+            )?;
+
+            return Ok(());
+        }
+
+        for subagent in &parsed.subagents {
+            let Some(agent_id) = subagent.agent_id.as_deref() else {
+                continue;
+            };
+
+            let child_session_id = format!("claude-subagent::{}::{}", parsed.session.id, agent_id);
+
+            let child_exists: bool = tx.query_row(
+                "SELECT EXISTS(SELECT 1 FROM sessions WHERE id = ?1)",
+                [&child_session_id],
+                |row| row.get(0),
+            )?;
+
+            if child_exists {
+                tx.execute(
+                    "UPDATE subagents
+                     SET child_session_id = ?1
+                     WHERE session_id = ?2 AND id = ?3",
+                    rusqlite::params![child_session_id, &parsed.session.id, &subagent.id],
+                )?;
+            }
+        }
+
         Ok(())
     }
 
@@ -1086,20 +1144,28 @@ impl SessionIndexer {
         }
     }
 
-    fn is_sidechain_file(file_path: &Path, sessions_dir: &Path) -> bool {
-        let is_agent_file = file_path
+    fn is_prunable_claude_sidechain_file(file_path: &Path, sessions_dir: &Path) -> bool {
+        let relative = match file_path.strip_prefix(sessions_dir) {
+            Ok(relative) => relative,
+            Err(_) => return false,
+        };
+
+        let components: Vec<_> = relative.components().collect();
+        let nested_subagent = components.len() >= 3
+            && components[1].as_os_str() == "subagents"
+            && file_path
+                .file_stem()
+                .and_then(|stem| stem.to_str())
+                .is_some_and(|stem| stem.starts_with("agent-"));
+
+        if nested_subagent {
+            return false;
+        }
+
+        file_path
             .file_stem()
             .and_then(|stem| stem.to_str())
-            .is_some_and(|stem| stem.starts_with("agent-"));
-
-        // Check if path is under sessions_dir/subagents/
-        let is_subagent = file_path
-            .strip_prefix(sessions_dir)
-            .ok()
-            .and_then(|rel| rel.components().next())
-            .is_some_and(|first| first.as_os_str() == "subagents");
-
-        is_agent_file || is_subagent
+            .is_some_and(|stem| stem.starts_with("agent-"))
     }
 
     /// Clear all indexed sessions and messages.
@@ -1751,40 +1817,67 @@ mod tests {
     }
 
     #[test]
-    fn is_sidechain_file_detects_agent_prefix() {
+    fn is_prunable_claude_sidechain_file_detects_agent_prefix() {
         let sessions_dir = PathBuf::from("/home/user/.claude/sessions");
         let path = PathBuf::from("/home/user/.claude/sessions/agent-abc123.jsonl");
-        assert!(SessionIndexer::is_sidechain_file(&path, &sessions_dir));
+        assert!(SessionIndexer::is_prunable_claude_sidechain_file(
+            &path,
+            &sessions_dir
+        ));
     }
 
     #[test]
-    fn is_sidechain_file_detects_subagents_directory() {
+    fn is_prunable_claude_sidechain_file_allows_nested_subagent_transcripts() {
         let sessions_dir = PathBuf::from("/home/user/.claude/sessions");
-        let path = PathBuf::from("/home/user/.claude/sessions/subagents/some-session.jsonl");
-        assert!(SessionIndexer::is_sidechain_file(&path, &sessions_dir));
+        let path = PathBuf::from(
+            "/home/user/.claude/sessions/65ce34ec-2589-4f2a-aad3-f536cf8b2906/subagents/agent-a41c0fb07beb52ed6.jsonl",
+        );
+        assert!(!SessionIndexer::is_prunable_claude_sidechain_file(
+            &path,
+            &sessions_dir
+        ));
     }
 
     #[test]
-    fn is_sidechain_file_allows_regular_sessions() {
+    fn is_prunable_claude_sidechain_file_detects_legacy_subagents_root_file() {
+        let sessions_dir = PathBuf::from("/home/user/.claude/sessions");
+        let path = PathBuf::from("/home/user/.claude/sessions/subagents/agent-abc123.jsonl");
+        assert!(SessionIndexer::is_prunable_claude_sidechain_file(
+            &path,
+            &sessions_dir
+        ));
+    }
+
+    #[test]
+    fn is_prunable_claude_sidechain_file_allows_regular_sessions() {
         let sessions_dir = PathBuf::from("/home/user/.claude/sessions");
         let path = PathBuf::from("/home/user/.claude/sessions/abc123.jsonl");
-        assert!(!SessionIndexer::is_sidechain_file(&path, &sessions_dir));
+        assert!(!SessionIndexer::is_prunable_claude_sidechain_file(
+            &path,
+            &sessions_dir
+        ));
     }
 
     #[test]
-    fn is_sidechain_file_allows_agent_in_middle_of_name() {
+    fn is_prunable_claude_sidechain_file_allows_agent_in_middle_of_name() {
         // "agent-" prefix is required, not just containing "agent"
         let sessions_dir = PathBuf::from("/home/user/.claude/sessions");
         let path = PathBuf::from("/home/user/.claude/sessions/my-agent-session.jsonl");
-        assert!(!SessionIndexer::is_sidechain_file(&path, &sessions_dir));
+        assert!(!SessionIndexer::is_prunable_claude_sidechain_file(
+            &path,
+            &sessions_dir
+        ));
     }
 
     #[test]
-    fn is_sidechain_file_allows_subagents_in_project_name() {
+    fn is_prunable_claude_sidechain_file_allows_subagents_in_project_name() {
         // "subagents" in an encoded project path should not trigger filtering
         let sessions_dir = PathBuf::from("/home/user/.claude/projects");
         let path = PathBuf::from("/home/user/.claude/projects/-home-user-subagents/session.jsonl");
-        assert!(!SessionIndexer::is_sidechain_file(&path, &sessions_dir));
+        assert!(!SessionIndexer::is_prunable_claude_sidechain_file(
+            &path,
+            &sessions_dir
+        ));
     }
 
     #[test]

--- a/src/database/indexer.rs
+++ b/src/database/indexer.rs
@@ -1145,32 +1145,29 @@ impl SessionIndexer {
     }
 
     fn is_prunable_claude_sidechain_file(file_path: &Path, sessions_dir: &Path) -> bool {
-        let relative = match file_path.strip_prefix(sessions_dir) {
-            Ok(relative) => relative,
-            Err(_) => return false,
+        let Ok(relative) = file_path.strip_prefix(sessions_dir) else {
+            return false;
         };
 
-        let components: Vec<_> = relative.components().collect();
         let has_agent_prefix = relative
             .file_stem()
             .and_then(|stem| stem.to_str())
             .is_some_and(|stem| stem.starts_with("agent-"));
 
-        let nested_subagent = components.len() >= 3
-            && components[components.len() - 2].as_os_str() == "subagents"
-            && components
-                .first()
-                .is_none_or(|component| component.as_os_str() != "subagents")
-            && has_agent_prefix;
+        let mut rev = relative.components().rev();
+        rev.next(); // skip filename
+        let parent = rev.next();
+        let grandparent = rev.next();
 
-        if nested_subagent {
+        let parent_is_subagents = parent.is_some_and(|c| c.as_os_str() == "subagents");
+
+        // Nested subagent transcript (<parent-uuid>/subagents/agent-*.jsonl): index it.
+        if parent_is_subagents && grandparent.is_some() && has_agent_prefix {
             return false;
         }
 
-        if components
-            .first()
-            .is_some_and(|component| component.as_os_str() == "subagents")
-        {
+        // Legacy root-level sidechain (sessions_dir/subagents/...): prune.
+        if parent_is_subagents && grandparent.is_none() {
             return true;
         }
 

--- a/src/database/indexer.rs
+++ b/src/database/indexer.rs
@@ -1158,9 +1158,9 @@ impl SessionIndexer {
 
         let nested_subagent = components.len() >= 3
             && components[components.len() - 2].as_os_str() == "subagents"
-            && !components
+            && components
                 .first()
-                .is_some_and(|component| component.as_os_str() == "subagents")
+                .is_none_or(|component| component.as_os_str() != "subagents")
             && has_agent_prefix;
 
         if nested_subagent {

--- a/src/database/indexer.rs
+++ b/src/database/indexer.rs
@@ -147,10 +147,14 @@ fn is_codex_error(err: &anyhow::Error) -> bool {
     err.downcast_ref::<CodexParseError>().is_some()
 }
 
-fn is_claude_empty_session_error(err: &anyhow::Error) -> bool {
+fn is_claude_skippable_error(err: &anyhow::Error) -> bool {
     matches!(
         err.downcast_ref::<ClaudeCodeParseError>(),
-        Some(ClaudeCodeParseError::NoMessages | ClaudeCodeParseError::NoUserMessages)
+        Some(
+            ClaudeCodeParseError::NoMessages
+                | ClaudeCodeParseError::NoUserMessages
+                | ClaudeCodeParseError::MalformedNestedSubagentFile
+        )
     )
 }
 
@@ -399,12 +403,8 @@ impl SessionIndexer {
         match self.index_session_file(path, parser) {
             Ok(()) => stats.indexed += 1,
             Err(err) => {
-                if is_claude_empty_session_error(&err) {
-                    tracing::debug!(
-                        "Skipped empty Claude Code session {}: {}",
-                        path.display(),
-                        err
-                    );
+                if is_claude_skippable_error(&err) {
+                    tracing::debug!("Skipped Claude Code session {}: {}", path.display(), err);
                     self.prune_session_after_parse_skip(
                         AiAssistant::ClaudeCode,
                         path,

--- a/src/database/indexer.rs
+++ b/src/database/indexer.rs
@@ -1151,21 +1151,26 @@ impl SessionIndexer {
         };
 
         let components: Vec<_> = relative.components().collect();
-        let nested_subagent = components.len() >= 3
-            && components[1].as_os_str() == "subagents"
-            && file_path
-                .file_stem()
-                .and_then(|stem| stem.to_str())
-                .is_some_and(|stem| stem.starts_with("agent-"));
+        let has_agent_prefix = relative
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .is_some_and(|stem| stem.starts_with("agent-"));
+
+        let nested_subagent =
+            components.len() == 3 && components[1].as_os_str() == "subagents" && has_agent_prefix;
 
         if nested_subagent {
             return false;
         }
 
-        file_path
-            .file_stem()
-            .and_then(|stem| stem.to_str())
-            .is_some_and(|stem| stem.starts_with("agent-"))
+        if components
+            .first()
+            .is_some_and(|component| component.as_os_str() == "subagents")
+        {
+            return true;
+        }
+
+        has_agent_prefix
     }
 
     /// Clear all indexed sessions and messages.
@@ -1842,6 +1847,16 @@ mod tests {
     fn is_prunable_claude_sidechain_file_detects_legacy_subagents_root_file() {
         let sessions_dir = PathBuf::from("/home/user/.claude/sessions");
         let path = PathBuf::from("/home/user/.claude/sessions/subagents/agent-abc123.jsonl");
+        assert!(SessionIndexer::is_prunable_claude_sidechain_file(
+            &path,
+            &sessions_dir
+        ));
+    }
+
+    #[test]
+    fn is_prunable_claude_sidechain_file_detects_subagents_root_file_without_agent_prefix() {
+        let sessions_dir = PathBuf::from("/home/user/.claude/sessions");
+        let path = PathBuf::from("/home/user/.claude/sessions/subagents/some-session.jsonl");
         assert!(SessionIndexer::is_prunable_claude_sidechain_file(
             &path,
             &sessions_dir

--- a/src/database/indexer.rs
+++ b/src/database/indexer.rs
@@ -1166,8 +1166,12 @@ impl SessionIndexer {
             return false;
         }
 
-        // Legacy root-level sidechain (sessions_dir/subagents/...): prune.
-        if parent_is_subagents && grandparent.is_none() {
+        // Legacy sidechain tree (anything under sessions_dir/subagents/): prune.
+        if relative
+            .components()
+            .next()
+            .is_some_and(|c| c.as_os_str() == "subagents")
+        {
             return true;
         }
 
@@ -1870,6 +1874,16 @@ mod tests {
     fn is_prunable_claude_sidechain_file_detects_subagents_root_file_without_agent_prefix() {
         let sessions_dir = PathBuf::from("/home/user/.claude/sessions");
         let path = PathBuf::from("/home/user/.claude/sessions/subagents/some-session.jsonl");
+        assert!(SessionIndexer::is_prunable_claude_sidechain_file(
+            &path,
+            &sessions_dir
+        ));
+    }
+
+    #[test]
+    fn is_prunable_claude_sidechain_file_detects_nested_file_under_legacy_subagents_root() {
+        let sessions_dir = PathBuf::from("/home/user/.claude/sessions");
+        let path = PathBuf::from("/home/user/.claude/sessions/subagents/foo/some-session.jsonl");
         assert!(SessionIndexer::is_prunable_claude_sidechain_file(
             &path,
             &sessions_dir

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -861,10 +861,11 @@ pub fn insert_tool_call(conn: &Connection, tc: &ToolCall, session_id: &str) -> R
 pub fn insert_subagent(conn: &Connection, sa: &Subagent, session_id: &str) -> Result<()> {
     conn.execute(
         "INSERT OR REPLACE INTO subagents
-         (id, session_id, title, prompt, result_summary, child_session_id, parser_ref)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+         (id, agent_id, session_id, title, prompt, result_summary, child_session_id, parser_ref)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
         rusqlite::params![
             sa.id,
+            sa.agent_id,
             session_id,
             sa.title,
             sa.prompt,
@@ -977,9 +978,9 @@ pub fn load_subagent(
     }
     let db = open_connection(db_path)?;
     let mut stmt = db.prepare(
-        "SELECT id, session_id, title, prompt, result_summary, child_session_id, parser_ref
-         FROM subagents
-         WHERE session_id = ?1 AND id = ?2",
+        "SELECT id, agent_id, session_id, title, prompt, result_summary, child_session_id, parser_ref
+          FROM subagents
+          WHERE session_id = ?1 AND id = ?2",
     )?;
     let mut rows = stmt
         .query(rusqlite::params![session_id, subagent_id])
@@ -987,12 +988,13 @@ pub fn load_subagent(
     if let Some(row) = rows.next()? {
         Ok(Some(Subagent {
             id: row.get(0)?,
-            session_id: row.get(1)?,
-            title: row.get(2)?,
-            prompt: row.get(3)?,
-            result_summary: row.get(4)?,
-            child_session_id: row.get(5)?,
-            parser_ref: row.get(6)?,
+            agent_id: row.get(1)?,
+            session_id: row.get(2)?,
+            title: row.get(3)?,
+            prompt: row.get(4)?,
+            result_summary: row.get(5)?,
+            child_session_id: row.get(6)?,
+            parser_ref: row.get(7)?,
         }))
     } else {
         Ok(None)

--- a/src/database/schema.rs
+++ b/src/database/schema.rs
@@ -423,16 +423,33 @@ fn apply_v10_migration(conn: &Connection) -> Result<()> {
 /// `(session_id, agent_id)` for fast lookups. Clears `file_fingerprints` to
 /// force re-index so agent IDs are backfilled into persisted subagent rows.
 fn apply_v11_migration(conn: &Connection) -> Result<()> {
-    if !column_exists(conn, "subagents", "agent_id")? {
-        conn.execute("ALTER TABLE subagents ADD COLUMN agent_id TEXT", [])?;
+    let subagents_exists: bool = conn.query_row(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='subagents'",
+        [],
+        |row| row.get::<_, i64>(0),
+    )? > 0;
+
+    if subagents_exists {
+        if !column_exists(conn, "subagents", "agent_id")? {
+            conn.execute("ALTER TABLE subagents ADD COLUMN agent_id TEXT", [])?;
+        }
+
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_subagents_agent ON subagents(session_id, agent_id)",
+            [],
+        )?;
     }
 
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_subagents_agent ON subagents(session_id, agent_id)",
+    let file_fingerprints_exists: bool = conn.query_row(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='file_fingerprints'",
         [],
-    )?;
+        |row| row.get::<_, i64>(0),
+    )? > 0;
 
-    conn.execute("DELETE FROM file_fingerprints", [])?;
+    if file_fingerprints_exists {
+        conn.execute("DELETE FROM file_fingerprints", [])?;
+    }
+
     conn.execute_batch("PRAGMA user_version = 11")?;
     Ok(())
 }

--- a/src/database/schema.rs
+++ b/src/database/schema.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use rusqlite::Connection;
 
 #[cfg(test)]
-const CURRENT_DB_VERSION: i64 = 10;
+const CURRENT_DB_VERSION: i64 = 11;
 
 fn column_exists(conn: &Connection, table_name: &str, column_name: &str) -> Result<bool> {
     Ok(conn.query_row(
@@ -31,6 +31,7 @@ fn column_exists(conn: &Connection, table_name: &str, column_name: &str) -> Resu
 ///   8 – sessions gains nullable pinned_at metadata (no fingerprint clear)
 ///   9 – reasoning_attachments side table and clear file_fingerprints
 ///   10 – clear file_fingerprints to rebuild transcripts after parser changes
+///   11 – subagents gains nullable agent_id and clear file_fingerprints
 pub fn initialize_database(conn: &Connection) -> Result<()> {
     let version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
 
@@ -63,6 +64,9 @@ pub fn initialize_database(conn: &Connection) -> Result<()> {
     }
     if version < 10 {
         apply_v10_migration(conn)?;
+    }
+    if version < 11 {
+        apply_v11_migration(conn)?;
     }
 
     Ok(())
@@ -410,6 +414,26 @@ fn apply_v9_migration(conn: &Connection) -> Result<()> {
 fn apply_v10_migration(conn: &Connection) -> Result<()> {
     conn.execute("DELETE FROM file_fingerprints", [])?;
     conn.execute_batch("PRAGMA user_version = 10")?;
+    Ok(())
+}
+
+/// Migrate from v10 to v11.
+///
+/// Adds nullable durable `agent_id` to subagents and an index on
+/// `(session_id, agent_id)` for fast lookups. Clears `file_fingerprints` to
+/// force re-index so agent IDs are backfilled into persisted subagent rows.
+fn apply_v11_migration(conn: &Connection) -> Result<()> {
+    if !column_exists(conn, "subagents", "agent_id")? {
+        conn.execute("ALTER TABLE subagents ADD COLUMN agent_id TEXT", [])?;
+    }
+
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_subagents_agent ON subagents(session_id, agent_id)",
+        [],
+    )?;
+
+    conn.execute("DELETE FROM file_fingerprints", [])?;
+    conn.execute_batch("PRAGMA user_version = 11")?;
     Ok(())
 }
 
@@ -1025,6 +1049,51 @@ mod tests {
             .query_row("PRAGMA user_version", [], |row| row.get(0))
             .unwrap();
         assert_eq!(version, CURRENT_DB_VERSION);
+
+        let fingerprint_count: i64 = conn
+            .query_row("SELECT count(*) FROM file_fingerprints", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(fingerprint_count, 0);
+    }
+
+    #[test]
+    fn v10_to_v11_migration_adds_subagent_agent_id_column() {
+        let conn = Connection::open_in_memory().unwrap();
+        initialize_database(&conn).unwrap();
+
+        conn.execute_batch("PRAGMA user_version = 10").unwrap();
+        conn.execute(
+            "INSERT INTO file_fingerprints (file_path, mtime_ns, size) VALUES ('fixture.jsonl', 1, 1)",
+            [],
+        )
+        .unwrap();
+
+        initialize_database(&conn).unwrap();
+
+        let version: i64 = conn
+            .query_row("PRAGMA user_version", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(version, CURRENT_DB_VERSION);
+
+        let agent_id_column_count: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM pragma_table_info('subagents') WHERE name='agent_id'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(agent_id_column_count, 1);
+
+        let agent_index_count: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM sqlite_master WHERE type='index' AND name='idx_subagents_agent'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(agent_index_count, 1);
 
         let fingerprint_count: i64 = conn
             .query_row("SELECT count(*) FROM file_fingerprints", [], |row| {

--- a/src/models/subagent.rs
+++ b/src/models/subagent.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 pub struct Subagent {
     /// Session-scoped identifier
     pub id: String,
+    /// Durable Claude agent identifier (for Task/Agent tool calls)
+    pub agent_id: Option<String>,
     pub session_id: String,
     pub title: String,
     pub prompt: Option<String>,

--- a/src/parsers/claude_code.rs
+++ b/src/parsers/claude_code.rs
@@ -78,6 +78,12 @@ fn extract_agent_id_from_result_text(result_text: &str) -> Option<String> {
         if is_valid {
             return Some(token.to_string());
         }
+
+        tracing::warn!(
+            "Ignoring Claude agentId token {:?} that failed validation; \
+             upstream format may have drifted.",
+            token
+        );
     }
 
     None

--- a/src/parsers/claude_code.rs
+++ b/src/parsers/claude_code.rs
@@ -64,7 +64,7 @@ fn extract_agent_id_from_result_text(result_text: &str) -> Option<String> {
         let Some(value) = line.strip_prefix("agentId:") else {
             continue;
         };
-        let Some(token) = value.trim().split_whitespace().next() else {
+        let Some(token) = value.split_whitespace().next() else {
             continue;
         };
 

--- a/src/parsers/claude_code.rs
+++ b/src/parsers/claude_code.rs
@@ -38,6 +38,7 @@ fn claude_subagent_agent_id_from_path(file_path: &Path) -> Option<String> {
         .file_stem()
         .and_then(|stem| stem.to_str())
         .and_then(|stem| stem.strip_prefix("agent-"))
+        .filter(|suffix| !suffix.is_empty())
         .map(str::to_string)
 }
 
@@ -62,7 +63,7 @@ fn extract_agent_id_from_result_text(result_text: &str) -> Option<String> {
     result_text
         .lines()
         .map(str::trim)
-        .find_map(|line| line.strip_prefix("agentId: "))
+        .find_map(|line| line.strip_prefix("agentId:"))
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(str::to_string)
@@ -620,6 +621,7 @@ impl ParseState {
         let parent_session_id = claude_subagent_parent_session_id_from_path(file_path);
         let nested_agent_id = claude_subagent_agent_id_from_path(file_path);
         let is_subagent = parent_session_id.is_some() && nested_agent_id.is_some();
+        let parent_session_id = if is_subagent { parent_session_id } else { None };
 
         let final_session_id = match (&parent_session_id, &nested_agent_id) {
             (Some(parent_session_id), Some(agent_id)) => {
@@ -1245,6 +1247,74 @@ mod tests {
             Some("65ce34ec-2589-4f2a-aad3-f536cf8b2906")
         );
         assert!(parsed.session.is_subagent);
+    }
+
+    #[test]
+    fn parse_parent_transcript_is_not_marked_as_subagent() {
+        let file = create_temp_session(&[
+            r#"{"type":"user","timestamp":"2024-01-01T00:00:00Z","sessionId":"parent-plain-1","message":{"content":"Analyze repo"}}"#,
+            r#"{"type":"assistant","timestamp":"2024-01-01T00:00:01Z","sessionId":"parent-plain-1","message":{"content":"Done"}}"#,
+        ]);
+
+        let parsed = ClaudeCodeParser.parse(file.path()).unwrap();
+
+        assert_eq!(parsed.session.id, "parent-plain-1");
+        assert_eq!(parsed.session.parent_session_id, None);
+        assert!(!parsed.session.is_subagent);
+    }
+
+    #[test]
+    fn parse_extracts_agent_id_for_supported_spacing_variants() {
+        for result_text in [
+            "Async agent launched successfully.\nagentId:a41c0fb07beb52ed6",
+            "Async agent launched successfully.\nagentId: a41c0fb07beb52ed6",
+            "Async agent launched successfully.\nagentId:\ta41c0fb07beb52ed6",
+        ] {
+            assert_eq!(
+                extract_agent_id_from_result_text(result_text).as_deref(),
+                Some("a41c0fb07beb52ed6")
+            );
+        }
+    }
+
+    #[test]
+    fn parse_rejects_empty_agent_id_in_async_subagent_result() {
+        let file = create_temp_session(&[
+            r#"{"type":"user","timestamp":"2024-01-01T00:00:00Z","sessionId":"parent-1","message":{"content":"Analyze this"}}"#,
+            r#"{"type":"assistant","timestamp":"2024-01-01T00:00:01Z","sessionId":"parent-1","message":{"content":[{"type":"tool_use","id":"toolu_agent_001","name":"Agent","input":{"description":"Analyze project","prompt":"List all files"}}]}}"#,
+            r#"{"type":"user","timestamp":"2024-01-01T00:00:02Z","sessionId":"parent-1","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_agent_001","content":[{"type":"text","text":"Async agent launched successfully.\nagentId:   "}]}]}}"#,
+        ]);
+
+        let parsed = ClaudeCodeParser.parse(file.path()).unwrap();
+
+        assert_eq!(parsed.subagents.len(), 1);
+        assert_eq!(parsed.subagents[0].agent_id, None);
+    }
+
+    #[test]
+    fn parse_malformed_child_filename_does_not_mark_session_as_subagent() {
+        let temp = tempfile::tempdir().unwrap();
+        let parent_dir = temp.path().join("65ce34ec-2589-4f2a-aad3-f536cf8b2906");
+        let subagents_dir = parent_dir.join("subagents");
+        std::fs::create_dir_all(&subagents_dir).unwrap();
+
+        let malformed_child_path = subagents_dir.join("agent-.jsonl");
+        std::fs::write(
+            &malformed_child_path,
+            concat!(
+                r#"{"parentUuid":null,"isSidechain":true,"type":"user","message":{"role":"user","content":"Analyze repo"},"timestamp":"2024-01-01T00:00:00Z","cwd":"/tmp/project","sessionId":"65ce34ec-2589-4f2a-aad3-f536cf8b2906"}"#,
+                "\n",
+                r#"{"parentUuid":"msg-1","isSidechain":true,"type":"assistant","message":{"role":"assistant","content":"Done"},"timestamp":"2024-01-01T00:00:01Z","cwd":"/tmp/project","sessionId":"65ce34ec-2589-4f2a-aad3-f536cf8b2906"}"#,
+                "\n",
+            ),
+        )
+        .unwrap();
+
+        let parsed = ClaudeCodeParser.parse(&malformed_child_path).unwrap();
+
+        assert_eq!(parsed.session.id, "65ce34ec-2589-4f2a-aad3-f536cf8b2906");
+        assert_eq!(parsed.session.parent_session_id, None);
+        assert!(!parsed.session.is_subagent);
     }
 
     #[test]

--- a/src/parsers/claude_code.rs
+++ b/src/parsers/claude_code.rs
@@ -536,6 +536,7 @@ impl ParseState {
             });
             self.subagents.push(Subagent {
                 id: tool_use_id.clone(),
+                agent_id: Some(tool_use_id.clone()),
                 session_id: String::new(),
                 title,
                 prompt,

--- a/src/parsers/claude_code.rs
+++ b/src/parsers/claude_code.rs
@@ -64,9 +64,17 @@ fn extract_agent_id_from_result_text(result_text: &str) -> Option<String> {
         .lines()
         .map(str::trim)
         .find_map(|line| line.strip_prefix("agentId:"))
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(str::to_string)
+        .and_then(|value| {
+            let token = value.trim().split_whitespace().next()?;
+            if token
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+            {
+                Some(token.to_string())
+            } else {
+                None
+            }
+        })
 }
 
 /// Private parsing state accumulator for Claude Code sessions.
@@ -77,6 +85,7 @@ struct ParseState {
     latest_timestamp: Option<DateTime<Utc>>,
     project_path: Option<String>,
     session_id_from_event: Option<String>,
+    has_sidechain_evidence: bool,
     has_user_message: bool,
 
     // Output collections
@@ -110,6 +119,7 @@ impl ParseState {
             latest_timestamp: None,
             project_path: None,
             session_id_from_event: None,
+            has_sidechain_evidence: false,
             has_user_message: false,
             messages: Vec::new(),
             tool_calls: Vec::new(),
@@ -620,7 +630,8 @@ impl ParseState {
     ) -> Result<ParsedSession> {
         let parent_session_id = claude_subagent_parent_session_id_from_path(file_path);
         let nested_agent_id = claude_subagent_agent_id_from_path(file_path);
-        let is_subagent = parent_session_id.is_some() && nested_agent_id.is_some();
+        let is_subagent =
+            parent_session_id.is_some() && nested_agent_id.is_some() && self.has_sidechain_evidence;
         let parent_session_id = if is_subagent { parent_session_id } else { None };
 
         let final_session_id = match (&parent_session_id, &nested_agent_id) {
@@ -747,6 +758,9 @@ impl ClaudeCodeParser {
             state.maybe_capture_cwd(&event);
 
             let event_type = event.get("type").and_then(|v| v.as_str());
+            if event.get("isSidechain").and_then(|v| v.as_bool()) == Some(true) {
+                state.has_sidechain_evidence = true;
+            }
             let is_message_like = matches!(event_type, Some("user") | Some("assistant"));
 
             if is_message_like {
@@ -1278,6 +1292,27 @@ mod tests {
     }
 
     #[test]
+    fn parse_extracts_only_first_agent_id_token() {
+        assert_eq!(
+            extract_agent_id_from_result_text(
+                "Async agent launched successfully.\nagentId: abc123 extra"
+            )
+            .as_deref(),
+            Some("abc123")
+        );
+    }
+
+    #[test]
+    fn parse_rejects_agent_id_with_invalid_characters() {
+        assert_eq!(
+            extract_agent_id_from_result_text(
+                "Async agent launched successfully.\nagentId: abc$123"
+            ),
+            None
+        );
+    }
+
+    #[test]
     fn parse_rejects_empty_agent_id_in_async_subagent_result() {
         let file = create_temp_session(&[
             r#"{"type":"user","timestamp":"2024-01-01T00:00:00Z","sessionId":"parent-1","message":{"content":"Analyze this"}}"#,
@@ -1311,6 +1346,32 @@ mod tests {
         .unwrap();
 
         let parsed = ClaudeCodeParser.parse(&malformed_child_path).unwrap();
+
+        assert_eq!(parsed.session.id, "65ce34ec-2589-4f2a-aad3-f536cf8b2906");
+        assert_eq!(parsed.session.parent_session_id, None);
+        assert!(!parsed.session.is_subagent);
+    }
+
+    #[test]
+    fn parse_nested_subagent_file_without_sidechain_evidence_is_not_subagent() {
+        let temp = tempfile::tempdir().unwrap();
+        let parent_dir = temp.path().join("65ce34ec-2589-4f2a-aad3-f536cf8b2906");
+        let subagents_dir = parent_dir.join("subagents");
+        std::fs::create_dir_all(&subagents_dir).unwrap();
+
+        let child_path = subagents_dir.join("agent-a41c0fb07beb52ed6.jsonl");
+        std::fs::write(
+            &child_path,
+            concat!(
+                r#"{"parentUuid":null,"isSidechain":false,"agentId":"a41c0fb07beb52ed6","type":"user","message":{"role":"user","content":"Analyze repo"},"timestamp":"2024-01-01T00:00:00Z","cwd":"/tmp/project","sessionId":"65ce34ec-2589-4f2a-aad3-f536cf8b2906"}"#,
+                "\n",
+                r#"{"parentUuid":"msg-1","isSidechain":false,"agentId":"a41c0fb07beb52ed6","type":"assistant","message":{"role":"assistant","content":"Done"},"timestamp":"2024-01-01T00:00:01Z","cwd":"/tmp/project","sessionId":"65ce34ec-2589-4f2a-aad3-f536cf8b2906"}"#,
+                "\n",
+            ),
+        )
+        .unwrap();
+
+        let parsed = ClaudeCodeParser.parse(&child_path).unwrap();
 
         assert_eq!(parsed.session.id, "65ce34ec-2589-4f2a-aad3-f536cf8b2906");
         assert_eq!(parsed.session.parent_session_id, None);

--- a/src/parsers/claude_code.rs
+++ b/src/parsers/claude_code.rs
@@ -22,6 +22,8 @@ pub enum ParseError {
     NoMessages,
     #[error("Session contains no user messages")]
     NoUserMessages,
+    #[error("Nested subagent file has malformed agent id")]
+    MalformedNestedSubagentFile,
 }
 
 struct UsageEntry {
@@ -632,6 +634,15 @@ impl ParseState {
     ) -> Result<ParsedSession> {
         let parent_session_id = claude_subagent_parent_session_id_from_path(file_path);
         let nested_agent_id = claude_subagent_agent_id_from_path(file_path);
+
+        // A file under `<parent>/subagents/` whose name does not yield a valid
+        // agent id would otherwise fall back to the sessionId embedded in its
+        // events — which nested subagent transcripts copy from the parent.
+        // Indexing it would overwrite the parent's transcript. Reject instead.
+        if parent_session_id.is_some() && nested_agent_id.is_none() {
+            return Err(ParseError::MalformedNestedSubagentFile.into());
+        }
+
         let is_subagent = parent_session_id.is_some() && nested_agent_id.is_some();
         let parent_session_id = if is_subagent { parent_session_id } else { None };
 
@@ -1336,7 +1347,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_malformed_child_filename_does_not_mark_session_as_subagent() {
+    fn parse_malformed_child_filename_rejects_file_instead_of_colliding_with_parent() {
         let temp = tempfile::tempdir().unwrap();
         let parent_dir = temp.path().join("65ce34ec-2589-4f2a-aad3-f536cf8b2906");
         let subagents_dir = parent_dir.join("subagents");
@@ -1354,11 +1365,12 @@ mod tests {
         )
         .unwrap();
 
-        let parsed = ClaudeCodeParser.parse(&malformed_child_path).unwrap();
+        let result = ClaudeCodeParser.parse(&malformed_child_path);
 
-        assert_eq!(parsed.session.id, "65ce34ec-2589-4f2a-aad3-f536cf8b2906");
-        assert_eq!(parsed.session.parent_session_id, None);
-        assert!(!parsed.session.is_subagent);
+        assert!(matches!(
+            result.unwrap_err().downcast_ref::<ParseError>(),
+            Some(ParseError::MalformedNestedSubagentFile)
+        ));
     }
 
     #[test]

--- a/src/parsers/claude_code.rs
+++ b/src/parsers/claude_code.rs
@@ -60,21 +60,25 @@ fn claude_subagent_child_session_id(parent_session_id: &str, agent_id: &str) -> 
 }
 
 fn extract_agent_id_from_result_text(result_text: &str) -> Option<String> {
-    result_text
-        .lines()
-        .map(str::trim)
-        .find_map(|line| line.strip_prefix("agentId:"))
-        .and_then(|value| {
-            let token = value.trim().split_whitespace().next()?;
-            if token
+    for line in result_text.lines().map(str::trim) {
+        let Some(value) = line.strip_prefix("agentId:") else {
+            continue;
+        };
+        let Some(token) = value.trim().split_whitespace().next() else {
+            continue;
+        };
+
+        let is_valid = token.len() >= 6
+            && token.starts_with('a')
+            && token
                 .chars()
-                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
-            {
-                Some(token.to_string())
-            } else {
-                None
-            }
-        })
+                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-');
+        if is_valid {
+            return Some(token.to_string());
+        }
+    }
+
+    None
 }
 
 /// Private parsing state accumulator for Claude Code sessions.
@@ -85,7 +89,6 @@ struct ParseState {
     latest_timestamp: Option<DateTime<Utc>>,
     project_path: Option<String>,
     session_id_from_event: Option<String>,
-    has_sidechain_evidence: bool,
     has_user_message: bool,
 
     // Output collections
@@ -119,7 +122,6 @@ impl ParseState {
             latest_timestamp: None,
             project_path: None,
             session_id_from_event: None,
-            has_sidechain_evidence: false,
             has_user_message: false,
             messages: Vec::new(),
             tool_calls: Vec::new(),
@@ -630,8 +632,7 @@ impl ParseState {
     ) -> Result<ParsedSession> {
         let parent_session_id = claude_subagent_parent_session_id_from_path(file_path);
         let nested_agent_id = claude_subagent_agent_id_from_path(file_path);
-        let is_subagent =
-            parent_session_id.is_some() && nested_agent_id.is_some() && self.has_sidechain_evidence;
+        let is_subagent = parent_session_id.is_some() && nested_agent_id.is_some();
         let parent_session_id = if is_subagent { parent_session_id } else { None };
 
         let final_session_id = match (&parent_session_id, &nested_agent_id) {
@@ -758,9 +759,6 @@ impl ClaudeCodeParser {
             state.maybe_capture_cwd(&event);
 
             let event_type = event.get("type").and_then(|v| v.as_str());
-            if event.get("isSidechain").and_then(|v| v.as_bool()) == Some(true) {
-                state.has_sidechain_evidence = true;
-            }
             let is_message_like = matches!(event_type, Some("user") | Some("assistant"));
 
             if is_message_like {
@@ -1295,10 +1293,21 @@ mod tests {
     fn parse_extracts_only_first_agent_id_token() {
         assert_eq!(
             extract_agent_id_from_result_text(
-                "Async agent launched successfully.\nagentId: abc123 extra"
+                "Async agent launched successfully.\nagentId: a41c0f extra"
             )
             .as_deref(),
-            Some("abc123")
+            Some("a41c0f")
+        );
+    }
+
+    #[test]
+    fn parse_skips_malformed_agent_id_line_and_reads_next_valid_line() {
+        assert_eq!(
+            extract_agent_id_from_result_text(
+                "Async agent launched successfully.\nagentId: abc$123\nagentId: a41c0fb07beb52ed6"
+            )
+            .as_deref(),
+            Some("a41c0fb07beb52ed6")
         );
     }
 
@@ -1353,7 +1362,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_nested_subagent_file_without_sidechain_evidence_is_not_subagent() {
+    fn parse_nested_subagent_file_without_sidechain_evidence_is_still_subagent() {
         let temp = tempfile::tempdir().unwrap();
         let parent_dir = temp.path().join("65ce34ec-2589-4f2a-aad3-f536cf8b2906");
         let subagents_dir = parent_dir.join("subagents");
@@ -1373,9 +1382,15 @@ mod tests {
 
         let parsed = ClaudeCodeParser.parse(&child_path).unwrap();
 
-        assert_eq!(parsed.session.id, "65ce34ec-2589-4f2a-aad3-f536cf8b2906");
-        assert_eq!(parsed.session.parent_session_id, None);
-        assert!(!parsed.session.is_subagent);
+        assert_eq!(
+            parsed.session.id,
+            "claude-subagent::65ce34ec-2589-4f2a-aad3-f536cf8b2906::a41c0fb07beb52ed6"
+        );
+        assert_eq!(
+            parsed.session.parent_session_id.as_deref(),
+            Some("65ce34ec-2589-4f2a-aad3-f536cf8b2906")
+        );
+        assert!(parsed.session.is_subagent);
     }
 
     #[test]

--- a/src/parsers/claude_code.rs
+++ b/src/parsers/claude_code.rs
@@ -33,6 +33,41 @@ struct UsageEntry {
 
 pub struct ClaudeCodeParser;
 
+fn claude_subagent_agent_id_from_path(file_path: &Path) -> Option<String> {
+    file_path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .and_then(|stem| stem.strip_prefix("agent-"))
+        .map(str::to_string)
+}
+
+fn claude_subagent_parent_session_id_from_path(file_path: &Path) -> Option<String> {
+    let subagents_dir = file_path.parent()?;
+    if subagents_dir.file_name()?.to_str()? != "subagents" {
+        return None;
+    }
+
+    subagents_dir
+        .parent()?
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(str::to_string)
+}
+
+fn claude_subagent_child_session_id(parent_session_id: &str, agent_id: &str) -> String {
+    format!("claude-subagent::{parent_session_id}::{agent_id}")
+}
+
+fn extract_agent_id_from_result_text(result_text: &str) -> Option<String> {
+    result_text
+        .lines()
+        .map(str::trim)
+        .find_map(|line| line.strip_prefix("agentId: "))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
 /// Private parsing state accumulator for Claude Code sessions.
 /// Holds all mutable fields that were previously declared inside `parse()`.
 struct ParseState {
@@ -326,7 +361,10 @@ impl ParseState {
         } else if let Some(&sa_idx) = self.pending_subagents.get(tool_use_id)
             && let Some(sa) = self.subagents.get_mut(sa_idx)
         {
-            sa.result_summary = Some(result_text);
+            sa.result_summary = Some(result_text.clone());
+            if sa.agent_id.is_none() {
+                sa.agent_id = extract_agent_id_from_result_text(&result_text);
+            }
         }
     }
 
@@ -536,7 +574,7 @@ impl ParseState {
             });
             self.subagents.push(Subagent {
                 id: tool_use_id.clone(),
-                agent_id: Some(tool_use_id.clone()),
+                agent_id: None,
                 session_id: String::new(),
                 title,
                 prompt,
@@ -579,11 +617,20 @@ impl ParseState {
         file_stem_id: Option<String>,
         had_parse_errors: bool,
     ) -> Result<ParsedSession> {
-        let final_session_id = self
-            .session_id_from_event
-            .clone()
-            .or(file_stem_id)
-            .unwrap_or_else(|| "unknown".to_string());
+        let parent_session_id = claude_subagent_parent_session_id_from_path(file_path);
+        let nested_agent_id = claude_subagent_agent_id_from_path(file_path);
+        let is_subagent = parent_session_id.is_some() && nested_agent_id.is_some();
+
+        let final_session_id = match (&parent_session_id, &nested_agent_id) {
+            (Some(parent_session_id), Some(agent_id)) => {
+                claude_subagent_child_session_id(parent_session_id, agent_id)
+            }
+            _ => self
+                .session_id_from_event
+                .clone()
+                .or(file_stem_id)
+                .unwrap_or_else(|| "unknown".to_string()),
+        };
         self.drop_pending_reasoning_if_orphan();
 
         // Aggregate token usage from all deduplicated entries
@@ -645,8 +692,8 @@ impl ParseState {
             last_updated,
             pinned_at: None,
             first_prompt,
-            parent_session_id: None,
-            is_subagent: false,
+            parent_session_id,
+            is_subagent,
             token_usage: None,
             edit_count: 0,
             read_count: 0,
@@ -1149,6 +1196,55 @@ mod tests {
             parsed.transcript_items[2].kind,
             TranscriptItemKind::Subagent
         );
+    }
+
+    #[test]
+    fn parse_extracts_agent_id_from_async_subagent_result() {
+        let file = create_temp_session(&[
+            r#"{"type":"user","timestamp":"2024-01-01T00:00:00Z","sessionId":"parent-1","message":{"content":"Analyze this"}}"#,
+            r#"{"type":"assistant","timestamp":"2024-01-01T00:00:01Z","sessionId":"parent-1","message":{"content":[{"type":"tool_use","id":"toolu_agent_001","name":"Agent","input":{"description":"Analyze project","prompt":"List all files"}}]}}"#,
+            r#"{"type":"user","timestamp":"2024-01-01T00:00:02Z","sessionId":"parent-1","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_agent_001","content":[{"type":"text","text":"Async agent launched successfully.\nagentId: a41c0fb07beb52ed6"}]}]}}"#,
+        ]);
+
+        let parsed = ClaudeCodeParser.parse(file.path()).unwrap();
+
+        assert_eq!(parsed.subagents.len(), 1);
+        assert_eq!(
+            parsed.subagents[0].agent_id.as_deref(),
+            Some("a41c0fb07beb52ed6")
+        );
+    }
+
+    #[test]
+    fn parse_nested_subagent_file_marks_session_as_subagent() {
+        let temp = tempfile::tempdir().unwrap();
+        let parent_dir = temp.path().join("65ce34ec-2589-4f2a-aad3-f536cf8b2906");
+        let subagents_dir = parent_dir.join("subagents");
+        std::fs::create_dir_all(&subagents_dir).unwrap();
+
+        let child_path = subagents_dir.join("agent-a41c0fb07beb52ed6.jsonl");
+        std::fs::write(
+            &child_path,
+            concat!(
+                r#"{"parentUuid":null,"isSidechain":true,"agentId":"a41c0fb07beb52ed6","type":"user","message":{"role":"user","content":"Analyze repo"},"timestamp":"2024-01-01T00:00:00Z","cwd":"/tmp/project","sessionId":"65ce34ec-2589-4f2a-aad3-f536cf8b2906"}"#,
+                "\n",
+                r#"{"parentUuid":"msg-1","isSidechain":true,"agentId":"a41c0fb07beb52ed6","type":"assistant","message":{"role":"assistant","content":"Done"},"timestamp":"2024-01-01T00:00:01Z","cwd":"/tmp/project","sessionId":"65ce34ec-2589-4f2a-aad3-f536cf8b2906"}"#,
+                "\n",
+            ),
+        )
+        .unwrap();
+
+        let parsed = ClaudeCodeParser.parse(&child_path).unwrap();
+
+        assert_eq!(
+            parsed.session.id,
+            "claude-subagent::65ce34ec-2589-4f2a-aad3-f536cf8b2906::a41c0fb07beb52ed6"
+        );
+        assert_eq!(
+            parsed.session.parent_session_id.as_deref(),
+            Some("65ce34ec-2589-4f2a-aad3-f536cf8b2906")
+        );
+        assert!(parsed.session.is_subagent);
     }
 
     #[test]

--- a/src/parsers/opencode/mod.rs
+++ b/src/parsers/opencode/mod.rs
@@ -465,6 +465,7 @@ impl OpenCodeParser {
 
                     return PartOutcome::Subagent(Subagent {
                         id: format!("{}-{}-{}", session_id, message_id, part.id),
+                        agent_id: None,
                         session_id: session_id.to_string(),
                         title,
                         prompt,
@@ -535,6 +536,7 @@ impl OpenCodeParser {
 
                 PartOutcome::Subagent(Subagent {
                     id: format!("{}-{}-{}", session_id, message_id, part.id),
+                    agent_id: None,
                     session_id: session_id.to_string(),
                     title,
                     prompt: part

--- a/tests/claude_subagent_linkage.rs
+++ b/tests/claude_subagent_linkage.rs
@@ -1,0 +1,50 @@
+use rusqlite::Connection;
+use sessions_chronicle::database::{SessionIndexer, load_session, load_subagent};
+use std::path::Path;
+use tempfile::NamedTempFile;
+
+#[test]
+fn indexing_claude_nested_subagent_links_parent_to_child_session() {
+    let temp_db = NamedTempFile::new().unwrap();
+    let mut indexer = SessionIndexer::new(temp_db.path()).unwrap();
+
+    indexer
+        .index_claude_sessions(Path::new("tests/fixtures/claude_subagent_linkage"))
+        .unwrap();
+
+    let parent = load_session(temp_db.path(), "65ce34ec-2589-4f2a-aad3-f536cf8b2906")
+        .unwrap()
+        .expect("parent session should be indexed");
+    assert!(!parent.is_subagent);
+
+    let child = load_session(
+        temp_db.path(),
+        "claude-subagent::65ce34ec-2589-4f2a-aad3-f536cf8b2906::a41c0fb07beb52ed6",
+    )
+    .unwrap()
+    .expect("child session should be indexed");
+    assert!(child.is_subagent);
+    assert_eq!(
+        child.parent_session_id.as_deref(),
+        Some("65ce34ec-2589-4f2a-aad3-f536cf8b2906")
+    );
+
+    let subagent = load_subagent(
+        temp_db.path(),
+        "65ce34ec-2589-4f2a-aad3-f536cf8b2906",
+        "toolu_agent_001",
+    )
+    .unwrap()
+    .expect("parent subagent should exist");
+    assert_eq!(subagent.agent_id.as_deref(), Some("a41c0fb07beb52ed6"));
+    assert_eq!(
+        subagent.child_session_id.as_deref(),
+        Some("claude-subagent::65ce34ec-2589-4f2a-aad3-f536cf8b2906::a41c0fb07beb52ed6")
+    );
+
+    let conn = Connection::open(temp_db.path()).unwrap();
+    let session_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM sessions", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(session_count, 2);
+}

--- a/tests/fixtures/claude_subagent_linkage/65ce34ec-2589-4f2a-aad3-f536cf8b2906.jsonl
+++ b/tests/fixtures/claude_subagent_linkage/65ce34ec-2589-4f2a-aad3-f536cf8b2906.jsonl
@@ -1,0 +1,3 @@
+{"type":"user","timestamp":"2026-04-11T20:05:00.000Z","cwd":"/home/user/project","sessionId":"65ce34ec-2589-4f2a-aad3-f536cf8b2906","message":{"content":"Inspect the project"}}
+{"type":"assistant","timestamp":"2026-04-11T20:05:01.000Z","cwd":"/home/user/project","sessionId":"65ce34ec-2589-4f2a-aad3-f536cf8b2906","message":{"content":[{"type":"tool_use","id":"toolu_agent_001","name":"Agent","input":{"description":"Analyze project","prompt":"List all files"}}]}}
+{"type":"user","timestamp":"2026-04-11T20:05:02.000Z","cwd":"/home/user/project","sessionId":"65ce34ec-2589-4f2a-aad3-f536cf8b2906","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_agent_001","content":[{"type":"text","text":"Async agent launched successfully.\nagentId: a41c0fb07beb52ed6"}]}]}}

--- a/tests/fixtures/claude_subagent_linkage/65ce34ec-2589-4f2a-aad3-f536cf8b2906/subagents/agent-a41c0fb07beb52ed6.jsonl
+++ b/tests/fixtures/claude_subagent_linkage/65ce34ec-2589-4f2a-aad3-f536cf8b2906/subagents/agent-a41c0fb07beb52ed6.jsonl
@@ -1,0 +1,2 @@
+{"parentUuid":null,"isSidechain":true,"agentId":"a41c0fb07beb52ed6","type":"user","message":{"role":"user","content":"List all files"},"timestamp":"2026-04-11T20:05:03.000Z","cwd":"/home/user/project","sessionId":"65ce34ec-2589-4f2a-aad3-f536cf8b2906"}
+{"parentUuid":"msg-1","isSidechain":true,"agentId":"a41c0fb07beb52ed6","type":"assistant","message":{"role":"assistant","content":"Found 5 files"},"timestamp":"2026-04-11T20:05:04.000Z","cwd":"/home/user/project","sessionId":"65ce34ec-2589-4f2a-aad3-f536cf8b2906"}


### PR DESCRIPTION
## Summary

cf #107 

- add durable Claude `agent_id` persistence on subagents, including a new v11 schema migration and DB read/write wiring
- parse Claude nested `subagents/agent-*.jsonl` transcripts into deterministic child session IDs (`claude-subagent::<parent>::<agent>`), mark them as subagent sessions, and capture agent IDs from async launch results
- update indexing/linkage so nested Claude subagent transcripts are indexed (not pruned), parent subagent rows get `child_session_id` links, and docs/fixtures/integration tests cover the end-to-end flow

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --all -- -D warnings`
- `cargo test --all --no-fail-fast`