### PR TITLE
feat: add Codex subagent linkage

### DIFF
--- a/docs/SESSION_FORMAT_ANALYSIS.md
+++ b/docs/SESSION_FORMAT_ANALYSIS.md
@@ -22,6 +22,7 @@ Cross-tool comparison of Claude Code, Codex, OpenCode, and Mistral Vibe session 
 - ✅ Codex parser implemented
 - ✅ Mistral Vibe parser implemented
 - ✅ OpenCode parent-child detection implemented (`parentID` sessions are indexed as subagents)
+- ✅ Codex collab/thread-spawn linkage implemented (child sessions + parent-side subagent rows)
 - ✅ Tool-call wire formats documented for Claude, OpenCode, Mistral Vibe, and Codex rollouts
 - ✅ LLM model metadata availability mapped (per message vs per turn vs per session)
 - ✅ Current parser behavior: tool-call/tool-result content is indexed (Phase 6 delivered)
@@ -178,9 +179,8 @@ Goal: determine whether model information is available per message, per turn, an
    - Or displayed as separate sessions with parent reference?
    - How deep can nesting go?
 
-3. **Codex Collaboration Mapping**:
-   - Should Codex `collab_*` events map to the same "subagent" concept as OpenCode `parentID` sessions?
-   - Do we show child thread IDs as navigable links in the UI?
+3. **Codex Retry / Duplicate Thread Display**:
+   - When multiple Codex parent subagent rows share the same child session, should the UI surface them as separate attempts or collapse them behind one child-session link?
 
 4. **OpenCode Session Diffs**:
    - Should `session_diff/ses_xxx.json` be ingested for richer "changes made" previews?
@@ -233,10 +233,8 @@ Each tool can persist token usage metrics, but **the granularity and presence ar
    - Keep existing user/assistant + current tool/subagent indexing as baseline behavior
 
 2. **Subagent graph model**:
-   - Prototype a unified parent-child relation that can represent:
-     - OpenCode session-level `parentID`
-     - Codex collab/thread-spawn links
-     - Claude sidechain indicators
+   - Extend the unified parent-child relation beyond the current OpenCode + Codex + Claude linkage primitives
+   - Revisit whether the UI should expose Codex duplicate-thread / retry history explicitly when multiple parent subagent rows point at the same child session
 
 3. **UI surfacing experiment**:
    - Add optional expandable "Tool Activity" and "Subtasks/Subagents" sections in session details

--- a/docs/session-formats/codex.md
+++ b/docs/session-formats/codex.md
@@ -341,9 +341,10 @@ Current implementation: `src/parsers/codex.rs`
 
 - Indexes `event_msg.payload.type == user_message|agent_message`
 - Indexes tool lifecycle pairs for `mcp_tool_call_begin|end` and `exec_command_begin|end`
-- Currently does not map `collab_*` events into subagent records
-- Does not yet extract Codex skill invocations from `$skill-name` / `<skill>`
-  pairs
+- Indexes Codex child rollouts as subagent sessions when `session_meta.payload.source.sub_agent.thread_spawn.parent_thread_id` or `source.subagent.thread_spawn.parent_thread_id` is present
+- Indexes `collab_agent_spawn_end` as parent-side `Subagent` rows and transcript items
+- Enriches parent-side subagents from `collab_waiting_end`, `collab_close_end`, and `collab_agent_interaction_end`
+- Does not yet extract Codex skill invocations from `$skill-name` / `<skill>` pairs
 
 **Title extraction:** First `event_msg.payload.type == "user_message"` event (`payload.message`).
 
@@ -370,8 +371,7 @@ fn extract_content_codex_event_msg(event: &Value) -> Option<(Role, String)> {
 - Raw data is emitted via `event_msg.payload.type` variants: `exec_command_*`, `mcp_tool_call_*`,
   `web_search_*`, and collab `collab_*`.
 - Tool call correlation typically uses `call_id`.
-- Current parser behavior: indexes `exec_command_*` and `mcp_tool_call_*` begin/end pairs as
-  tool calls; `collab_*` events are not yet mapped to subagent records.
+- Current parser behavior: indexes `exec_command_*` and `mcp_tool_call_*` begin/end pairs as tool calls; maps Codex `collab_*` lifecycle events into parent `Subagent` rows plus child-session linkage when the child rollout is present.
 
 **Streaming:** Use `BufReader` line-by-line iteration — do not load entire JSONL into memory.
 

--- a/src/database/indexer.rs
+++ b/src/database/indexer.rs
@@ -762,6 +762,7 @@ impl SessionIndexer {
         Self::upsert_session_row_tx(&tx, parsed, file_path, resolved_project_id)?;
         Self::replace_session_contents_tx(&tx, parsed)?;
         Self::link_claude_subagents_tx(&tx, parsed)?;
+        Self::link_codex_subagents_tx(&tx, parsed)?;
         Self::upsert_fingerprint_tx(&tx, fingerprint_path)?;
         tx.commit()?;
         Ok(())
@@ -820,6 +821,28 @@ impl SessionIndexer {
                 )?;
             }
         }
+
+        Ok(())
+    }
+
+    fn link_codex_subagents_tx(
+        tx: &rusqlite::Transaction<'_>,
+        parsed: &ParsedSession,
+    ) -> Result<()> {
+        if parsed.session.tool != AiAssistant::Codex || !parsed.session.is_subagent {
+            return Ok(());
+        }
+
+        let Some(parent_session_id) = parsed.session.parent_session_id.as_deref() else {
+            return Ok(());
+        };
+
+        tx.execute(
+            "UPDATE subagents
+             SET child_session_id = ?1
+             WHERE session_id = ?2 AND agent_id = ?3",
+            rusqlite::params![&parsed.session.id, parent_session_id, &parsed.session.id],
+        )?;
 
         Ok(())
     }

--- a/src/database/indexer.rs
+++ b/src/database/indexer.rs
@@ -829,7 +829,32 @@ impl SessionIndexer {
         tx: &rusqlite::Transaction<'_>,
         parsed: &ParsedSession,
     ) -> Result<()> {
-        if parsed.session.tool != AiAssistant::Codex || !parsed.session.is_subagent {
+        if parsed.session.tool != AiAssistant::Codex {
+            return Ok(());
+        }
+
+        if !parsed.session.is_subagent {
+            for subagent in &parsed.subagents {
+                let Some(agent_id) = subagent.agent_id.as_deref() else {
+                    continue;
+                };
+
+                let child_exists: bool = tx.query_row(
+                    "SELECT EXISTS(SELECT 1 FROM sessions WHERE id = ?1)",
+                    [agent_id],
+                    |row| row.get(0),
+                )?;
+
+                if child_exists {
+                    tx.execute(
+                        "UPDATE subagents
+                         SET child_session_id = ?1
+                         WHERE session_id = ?2 AND id = ?3",
+                        rusqlite::params![agent_id, &parsed.session.id, &subagent.id],
+                    )?;
+                }
+            }
+
             return Ok(());
         }
 

--- a/src/parsers/codex.rs
+++ b/src/parsers/codex.rs
@@ -7,7 +7,8 @@ use std::io::{BufRead, BufReader};
 use std::path::Path;
 
 use crate::models::{
-    AiAssistant, Message, ReasoningAttachment, Role, Session, TokenUsage, ToolCall, ToolCallStatus,
+    AiAssistant, Message, ReasoningAttachment, Role, Session, Subagent, TokenUsage, ToolCall,
+    ToolCallStatus,
 };
 use crate::models::{TranscriptItem, TranscriptItemKind};
 use crate::parsers::model::normalize_model;
@@ -34,11 +35,14 @@ struct ParseState {
     // Output collections
     messages: Vec<Message>,
     tool_calls: Vec<ToolCall>,
+    subagents: Vec<Subagent>,
     transcript_items: Vec<TranscriptItem>,
     reasoning_attachments: Vec<ReasoningAttachment>,
 
     // Correlation: call_id -> index in tool_calls
     call_id_to_tc_idx: HashMap<String, usize>,
+    subagent_idx_by_call_id: HashMap<String, usize>,
+    subagent_indexes_by_agent_id: HashMap<String, Vec<usize>>,
 
     // Counters
     msg_counter: i64,
@@ -56,9 +60,12 @@ impl ParseState {
             has_user_message: false,
             messages: Vec::new(),
             tool_calls: Vec::new(),
+            subagents: Vec::new(),
             transcript_items: Vec::new(),
             reasoning_attachments: Vec::new(),
             call_id_to_tc_idx: HashMap::new(),
+            subagent_idx_by_call_id: HashMap::new(),
+            subagent_indexes_by_agent_id: HashMap::new(),
             msg_counter: 0,
             item_counter: 0,
             pending_reasoning: PendingReasoning::default(),
@@ -144,6 +151,68 @@ impl ParseState {
 
     fn queue_reasoning(&mut self, reasoning: PendingReasoning) {
         self.pending_reasoning.merge(reasoning);
+    }
+
+    fn record_subagent_spawn(&mut self, payload: &Value) {
+        let call_id = match payload.get("call_id").and_then(|v| v.as_str()) {
+            Some(call_id) if !call_id.is_empty() => call_id,
+            _ => {
+                tracing::warn!("collab_agent_spawn_end missing call_id, skipping");
+                return;
+            }
+        };
+
+        if self.subagent_idx_by_call_id.contains_key(call_id) {
+            return;
+        }
+
+        let agent_id = payload
+            .get("new_thread_id")
+            .and_then(|v| v.as_str())
+            .filter(|value| !value.is_empty())
+            .map(str::to_string);
+        let title = payload
+            .get("nickname")
+            .and_then(|v| v.as_str())
+            .filter(|value| !value.is_empty())
+            .unwrap_or("Codex subagent")
+            .to_string();
+        let prompt = payload
+            .get("prompt")
+            .and_then(|v| v.as_str())
+            .filter(|value| !value.is_empty())
+            .map(str::to_string);
+
+        let subagent_idx = self.subagents.len();
+        self.subagents.push(Subagent {
+            id: call_id.to_string(),
+            agent_id: agent_id.clone(),
+            session_id: self.session_id.clone(),
+            title,
+            prompt,
+            result_summary: None,
+            child_session_id: None,
+            parser_ref: Some(call_id.to_string()),
+        });
+        self.subagent_idx_by_call_id
+            .insert(call_id.to_string(), subagent_idx);
+        if let Some(agent_id) = agent_id {
+            self.subagent_indexes_by_agent_id
+                .entry(agent_id)
+                .or_default()
+                .push(subagent_idx);
+        }
+
+        self.transcript_items.push(TranscriptItem {
+            session_id: self.session_id.clone(),
+            item_index: self.item_counter,
+            kind: TranscriptItemKind::Subagent,
+            message_index: None,
+            tool_call_id: None,
+            subagent_id: Some(call_id.to_string()),
+        });
+        self.flush_pending_reasoning_to_item(self.item_counter);
+        self.item_counter += 1;
     }
 
     fn flush_pending_reasoning_to_item(&mut self, transcript_item_index: i64) {
@@ -438,6 +507,12 @@ impl ParseState {
                 );
             }
 
+            Some("collab_agent_spawn_begin") => {}
+
+            Some("collab_agent_spawn_end") => {
+                self.record_subagent_spawn(payload);
+            }
+
             _ => {}
         }
     }
@@ -648,7 +723,7 @@ impl CodexParser {
             },
             messages: state.messages,
             tool_calls: state.tool_calls,
-            subagents: Vec::new(),
+            subagents: state.subagents,
             transcript_items: state.transcript_items,
             reasoning_attachments: state.reasoning_attachments,
             token_usage,
@@ -972,6 +1047,75 @@ mod tests {
             parsed.session.parent_session_id.as_deref(),
             Some("019da0bb-541a-74e2-ae0a-6693c5e4fe04")
         );
+    }
+
+    #[test]
+    fn parse_collab_agent_spawn_end_creates_subagent_and_transcript_item() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"{{"type":"session_meta","payload":{{"id":"codex-subagent","timestamp":"2026-01-01T00:00:00Z","cwd":"/tmp"}}}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            r#"{{"type":"event_msg","timestamp":"2026-01-01T00:00:01Z","payload":{{"type":"user_message","message":"Inspect parser behavior"}}}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            r#"{{"type":"event_msg","timestamp":"2026-01-01T00:00:02Z","payload":{{"type":"collab_agent_spawn_end","call_id":"call_spawn_1","new_thread_id":"019da0bd-3df2-7191-a1a8-e326b55fe052","nickname":"Kierkegaard","prompt":"Inspect the failing parser tests"}}}}"#
+        )
+        .unwrap();
+
+        let parsed = CodexParser.parse(file.path()).unwrap();
+
+        assert_eq!(parsed.subagents.len(), 1);
+        assert_eq!(parsed.subagents[0].id, "call_spawn_1");
+        assert_eq!(
+            parsed.subagents[0].agent_id.as_deref(),
+            Some("019da0bd-3df2-7191-a1a8-e326b55fe052")
+        );
+        assert_eq!(parsed.subagents[0].title, "Kierkegaard");
+        assert_eq!(
+            parsed.subagents[0].prompt.as_deref(),
+            Some("Inspect the failing parser tests")
+        );
+
+        assert_eq!(parsed.transcript_items.len(), 2);
+        assert!(matches!(
+            parsed.transcript_items[1].kind,
+            TranscriptItemKind::Subagent
+        ));
+        assert_eq!(
+            parsed.transcript_items[1].subagent_id.as_deref(),
+            Some("call_spawn_1")
+        );
+    }
+
+    #[test]
+    fn parse_collab_agent_spawn_begin_without_end_does_not_create_subagent() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"{{"type":"session_meta","payload":{{"id":"codex-subagent-begin-only","timestamp":"2026-01-01T00:00:00Z","cwd":"/tmp"}}}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            r#"{{"type":"event_msg","timestamp":"2026-01-01T00:00:01Z","payload":{{"type":"user_message","message":"Inspect parser behavior"}}}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            r#"{{"type":"event_msg","timestamp":"2026-01-01T00:00:02Z","payload":{{"type":"collab_agent_spawn_begin","call_id":"call_spawn_1","new_thread_id":"019da0bd-3df2-7191-a1a8-e326b55fe052","nickname":"Kierkegaard","prompt":"Inspect the failing parser tests"}}}}"#
+        )
+        .unwrap();
+
+        let parsed = CodexParser.parse(file.path()).unwrap();
+
+        assert!(parsed.subagents.is_empty());
+        assert_eq!(parsed.transcript_items.len(), 1);
     }
 
     #[derive(Clone, Default)]

--- a/src/parsers/codex.rs
+++ b/src/parsers/codex.rs
@@ -35,6 +35,9 @@ enum SubagentEventPriority {
 struct StatusUpdate {
     summary: Option<String>,
     terminal: bool,
+    // true for generic unit labels like "Shutdown"/"Not found" that should
+    // never overwrite a detailed summary from `completed`/`errored`.
+    coarse: bool,
 }
 
 fn parse_status_update(status: &Value) -> StatusUpdate {
@@ -43,18 +46,22 @@ fn parse_status_update(status: &Value) -> StatusUpdate {
             "pending_init" | "running" | "interrupted" => StatusUpdate {
                 summary: None,
                 terminal: false,
+                coarse: false,
             },
             "shutdown" => StatusUpdate {
                 summary: Some("Shutdown".to_string()),
                 terminal: true,
+                coarse: true,
             },
             "not_found" => StatusUpdate {
                 summary: Some("Not found".to_string()),
                 terminal: true,
+                coarse: true,
             },
             _ => StatusUpdate {
                 summary: None,
                 terminal: false,
+                coarse: false,
             },
         };
     }
@@ -63,6 +70,7 @@ fn parse_status_update(status: &Value) -> StatusUpdate {
         return StatusUpdate {
             summary: completed.as_str().map(str::to_string),
             terminal: true,
+            coarse: false,
         };
     }
 
@@ -70,12 +78,14 @@ fn parse_status_update(status: &Value) -> StatusUpdate {
         return StatusUpdate {
             summary: Some(format!("Error: {errored}")),
             terminal: true,
+            coarse: false,
         };
     }
 
     StatusUpdate {
         summary: None,
         terminal: false,
+        coarse: false,
     }
 }
 
@@ -99,6 +109,10 @@ struct ParseState {
     subagent_idx_by_call_id: HashMap<String, usize>,
     subagent_indexes_by_agent_id: HashMap<String, Vec<usize>>,
     subagent_priority_by_id: HashMap<String, SubagentEventPriority>,
+    // Tracks whether the current `result_summary` came from a coarse unit
+    // status label, so a later coarse terminal event cannot downgrade a
+    // detailed `completed`/`errored` summary.
+    subagent_summary_is_coarse: HashMap<String, bool>,
 
     // Counters
     msg_counter: i64,
@@ -123,6 +137,7 @@ impl ParseState {
             subagent_idx_by_call_id: HashMap::new(),
             subagent_indexes_by_agent_id: HashMap::new(),
             subagent_priority_by_id: HashMap::new(),
+            subagent_summary_is_coarse: HashMap::new(),
             msg_counter: 0,
             item_counter: 0,
             pending_reasoning: PendingReasoning::default(),
@@ -283,12 +298,18 @@ impl ParseState {
         status: &Value,
         priority: SubagentEventPriority,
     ) {
-        let subagent_index = call_id
-            .and_then(|id| self.subagent_idx_by_call_id.get(id).copied())
+        // Prefer per-thread resolution when the event carries an explicit
+        // thread_id: waiting_end fan-out shares a single call_id across
+        // multiple agent_statuses, so resolving by call_id first would
+        // funnel every status update onto the same subagent row.
+        let subagent_index = receiver_thread_id
+            .filter(|id| !id.is_empty())
+            .and_then(|thread_id| self.subagent_indexes_by_agent_id.get(thread_id))
+            .and_then(|indexes| indexes.last().copied())
             .or_else(|| {
-                receiver_thread_id
-                    .and_then(|thread_id| self.subagent_indexes_by_agent_id.get(thread_id))
-                    .and_then(|indexes| indexes.last().copied())
+                call_id
+                    .filter(|id| !id.is_empty())
+                    .and_then(|id| self.subagent_idx_by_call_id.get(id).copied())
             });
 
         let Some(index) = subagent_index else {
@@ -319,13 +340,35 @@ impl ParseState {
         }
 
         if let Some(summary) = update.summary.filter(|value| !value.is_empty()) {
+            let current_is_coarse = self
+                .subagent_summary_is_coarse
+                .get(&subagent_id)
+                .copied()
+                .unwrap_or(true);
+            let has_existing_summary = self.subagents[index]
+                .result_summary
+                .as_deref()
+                .is_some_and(|s| !s.is_empty());
+
+            // Never let a coarse unit label overwrite a detailed summary
+            // from `completed`/`errored`, even if the new event has higher
+            // priority (e.g. close_end:"shutdown" after waiting_end:completed).
+            if update.coarse && has_existing_summary && !current_is_coarse {
+                self.subagent_priority_by_id.insert(subagent_id, priority);
+                return;
+            }
+
             self.subagents[index].result_summary = Some(summary);
+            self.subagent_summary_is_coarse
+                .insert(subagent_id.clone(), update.coarse);
             self.subagent_priority_by_id.insert(subagent_id, priority);
             return;
         }
 
         if self.subagents[index].result_summary.is_none() {
             self.subagents[index].result_summary = Some(String::new());
+            self.subagent_summary_is_coarse
+                .insert(subagent_id.clone(), true);
         }
         self.subagent_priority_by_id.insert(subagent_id, priority);
     }
@@ -1538,6 +1581,133 @@ mod tests {
         assert_eq!(
             parsed.subagents[1].result_summary.as_deref(),
             Some("second attempt finished")
+        );
+    }
+
+    #[test]
+    fn parse_waiting_end_fans_out_per_thread_when_call_id_matches_a_spawn() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"session_meta","payload":{"id":"codex-fanout","timestamp":"2026-04-18T13:17:40Z","cwd":"/tmp/project"}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"event_msg","timestamp":"2026-04-18T13:17:41Z","payload":{"type":"user_message","message":"Delegate to two"}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"event_msg","timestamp":"2026-04-18T13:17:42Z","payload":{"type":"collab_agent_spawn_end","call_id":"call_spawn_1","sender_thread_id":"codex-fanout","new_thread_id":"child-1","new_agent_nickname":"Kierkegaard","new_agent_role":"default","prompt":"Inspect A","status":"running"}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"event_msg","timestamp":"2026-04-18T13:17:43Z","payload":{"type":"collab_agent_spawn_end","call_id":"call_spawn_2","sender_thread_id":"codex-fanout","new_thread_id":"child-2","new_agent_nickname":"Camus","new_agent_role":"default","prompt":"Inspect B","status":"running"}}"#
+        )
+        .unwrap();
+        // waiting_end reuses call_spawn_1 as its call_id, yet carries agent_statuses
+        // for BOTH threads. Resolver must fan out per thread, not funnel both
+        // updates onto call_spawn_1's row.
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"event_msg","timestamp":"2026-04-18T13:17:44Z","payload":{"type":"collab_waiting_end","call_id":"call_spawn_1","sender_thread_id":"codex-fanout","agent_statuses":[{"thread_id":"child-1","agent_nickname":"Kierkegaard","agent_role":"default","status":{"completed":"first done"}},{"thread_id":"child-2","agent_nickname":"Camus","agent_role":"default","status":{"completed":"second done"}}]}}"#
+        )
+        .unwrap();
+
+        let parsed = CodexParser.parse(file.path()).unwrap();
+        assert_eq!(parsed.subagents.len(), 2);
+        assert_eq!(
+            parsed.subagents[0].result_summary.as_deref(),
+            Some("first done")
+        );
+        assert_eq!(
+            parsed.subagents[1].result_summary.as_deref(),
+            Some("second done")
+        );
+    }
+
+    #[test]
+    fn parse_close_end_shutdown_does_not_overwrite_detailed_completed_summary() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"session_meta","payload":{"id":"codex-no-downgrade","timestamp":"2026-04-18T13:17:40Z","cwd":"/tmp/project"}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"event_msg","timestamp":"2026-04-18T13:17:41Z","payload":{"type":"user_message","message":"Delegate this"}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"event_msg","timestamp":"2026-04-18T13:17:42Z","payload":{"type":"collab_agent_spawn_end","call_id":"call_spawn_1","sender_thread_id":"codex-no-downgrade","new_thread_id":"child-1","new_agent_nickname":"Kierkegaard","new_agent_role":"default","prompt":"Inspect","status":"running"}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"event_msg","timestamp":"2026-04-18T13:17:43Z","payload":{"type":"collab_waiting_end","call_id":"call_spawn_1","sender_thread_id":"codex-no-downgrade","agent_statuses":[{"thread_id":"child-1","agent_nickname":"Kierkegaard","agent_role":"default","status":{"completed":"detailed delegated answer"}}]}}"#
+        )
+        .unwrap();
+        // close_end with coarse "shutdown" must not downgrade the detailed summary.
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"event_msg","timestamp":"2026-04-18T13:17:44Z","payload":{"type":"collab_close_end","call_id":"call_close_1","sender_thread_id":"codex-no-downgrade","receiver_thread_id":"child-1","receiver_agent_nickname":"Kierkegaard","receiver_agent_role":"default","status":"shutdown"}}"#
+        )
+        .unwrap();
+
+        let parsed = CodexParser.parse(file.path()).unwrap();
+        assert_eq!(parsed.subagents.len(), 1);
+        assert_eq!(
+            parsed.subagents[0].result_summary.as_deref(),
+            Some("detailed delegated answer")
+        );
+    }
+
+    #[test]
+    fn parse_close_end_shutdown_fills_empty_summary() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"session_meta","payload":{"id":"codex-coarse-only","timestamp":"2026-04-18T13:17:40Z","cwd":"/tmp/project"}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"event_msg","timestamp":"2026-04-18T13:17:41Z","payload":{"type":"user_message","message":"Delegate this"}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"event_msg","timestamp":"2026-04-18T13:17:42Z","payload":{"type":"collab_agent_spawn_end","call_id":"call_spawn_1","sender_thread_id":"codex-coarse-only","new_thread_id":"child-1","new_agent_nickname":"Kierkegaard","new_agent_role":"default","prompt":"Inspect","status":"running"}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"event_msg","timestamp":"2026-04-18T13:17:43Z","payload":{"type":"collab_close_end","call_id":"call_close_1","sender_thread_id":"codex-coarse-only","receiver_thread_id":"child-1","receiver_agent_nickname":"Kierkegaard","receiver_agent_role":"default","status":"shutdown"}}"#
+        )
+        .unwrap();
+
+        let parsed = CodexParser.parse(file.path()).unwrap();
+        assert_eq!(
+            parsed.subagents[0].result_summary.as_deref(),
+            Some("Shutdown")
         );
     }
 

--- a/src/parsers/codex.rs
+++ b/src/parsers/codex.rs
@@ -488,6 +488,25 @@ impl ParseState {
 
 pub struct CodexParser;
 
+fn extract_parent_thread_id(source: Option<&Value>) -> Option<String> {
+    let source = source?;
+
+    source
+        .get("subagent")
+        .and_then(|subagent| subagent.get("thread_spawn"))
+        .and_then(|spawn| spawn.get("parent_thread_id"))
+        .and_then(|value| value.as_str())
+        .map(str::to_string)
+        .or_else(|| {
+            source
+                .get("sub_agent")
+                .and_then(|subagent| subagent.get("thread_spawn"))
+                .and_then(|spawn| spawn.get("parent_thread_id"))
+                .and_then(|value| value.as_str())
+                .map(str::to_string)
+        })
+}
+
 impl CodexParser {
     pub fn parse(&self, file_path: &Path) -> Result<ParsedSession> {
         let file = File::open(file_path).context("Failed to open session file")?;
@@ -542,6 +561,8 @@ impl CodexParser {
             .get("cwd")
             .and_then(|v| v.as_str())
             .map(str::to_string);
+        let parent_session_id = extract_parent_thread_id(payload.get("source"));
+        let is_subagent = parent_session_id.is_some();
 
         let mut state = ParseState::new(session_id.clone(), start_time);
 
@@ -617,8 +638,8 @@ impl CodexParser {
                 last_updated: state.last_updated,
                 pinned_at: None,
                 first_prompt,
-                parent_session_id: None,
-                is_subagent: false,
+                parent_session_id,
+                is_subagent,
                 token_usage: None,
                 edit_count: 0,
                 read_count: 0,
@@ -919,6 +940,38 @@ mod tests {
         writeln!(file, r#"{{"type":"event_msg","timestamp":"2026-01-01T00:00:03Z","payload":{{"type":"agent_message","message":"Done"}}}}"#).unwrap();
         let parsed = CodexParser.parse(file.path()).unwrap();
         assert!(parsed.token_usage.is_none());
+    }
+
+    #[test]
+    fn parse_child_session_marks_session_as_subagent_for_sub_agent_source() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        writeln!(file, r#"{{"type":"session_meta","payload":{{"id":"child-sub-agent","timestamp":"2026-01-01T00:00:00Z","cwd":"/tmp","source":{{"sub_agent":{{"thread_spawn":{{"parent_thread_id":"019da0bb-541a-74e2-ae0a-6693c5e4fe04"}}}}}}}}}}"#).unwrap();
+        writeln!(file, r#"{{"type":"event_msg","timestamp":"2026-01-01T00:00:01Z","payload":{{"type":"user_message","message":"Hi"}}}}"#).unwrap();
+        writeln!(file, r#"{{"type":"event_msg","timestamp":"2026-01-01T00:00:02Z","payload":{{"type":"agent_message","message":"Done"}}}}"#).unwrap();
+
+        let parsed = CodexParser.parse(file.path()).unwrap();
+
+        assert!(parsed.session.is_subagent);
+        assert_eq!(
+            parsed.session.parent_session_id.as_deref(),
+            Some("019da0bb-541a-74e2-ae0a-6693c5e4fe04")
+        );
+    }
+
+    #[test]
+    fn parse_child_session_marks_session_as_subagent_for_subagent_source() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        writeln!(file, r#"{{"type":"session_meta","payload":{{"id":"child-subagent","timestamp":"2026-01-01T00:00:00Z","cwd":"/tmp","source":{{"subagent":{{"thread_spawn":{{"parent_thread_id":"019da0bb-541a-74e2-ae0a-6693c5e4fe04"}}}}}}}}}}"#).unwrap();
+        writeln!(file, r#"{{"type":"event_msg","timestamp":"2026-01-01T00:00:01Z","payload":{{"type":"user_message","message":"Hi"}}}}"#).unwrap();
+        writeln!(file, r#"{{"type":"event_msg","timestamp":"2026-01-01T00:00:02Z","payload":{{"type":"agent_message","message":"Done"}}}}"#).unwrap();
+
+        let parsed = CodexParser.parse(file.path()).unwrap();
+
+        assert!(parsed.session.is_subagent);
+        assert_eq!(
+            parsed.session.parent_session_id.as_deref(),
+            Some("019da0bb-541a-74e2-ae0a-6693c5e4fe04")
+        );
     }
 
     #[derive(Clone, Default)]

--- a/src/parsers/codex.rs
+++ b/src/parsers/codex.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use serde_json::Value;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
@@ -630,11 +630,18 @@ impl ParseState {
 
             Some("collab_waiting_end") => {
                 let call_id = payload.get("call_id").and_then(|v| v.as_str());
+                let mut thread_ids_with_agent_status = HashSet::new();
 
                 if let Some(agent_statuses) =
                     payload.get("agent_statuses").and_then(|v| v.as_array())
                 {
                     for agent_status in agent_statuses {
+                        if let Some(thread_id) =
+                            agent_status.get("thread_id").and_then(|v| v.as_str())
+                        {
+                            thread_ids_with_agent_status.insert(thread_id.to_string());
+                        }
+
                         self.update_subagent_from_status(
                             call_id,
                             agent_status.get("thread_id").and_then(|v| v.as_str()),
@@ -644,8 +651,14 @@ impl ParseState {
                             SubagentEventPriority::Waiting,
                         );
                     }
-                } else if let Some(statuses) = payload.get("statuses").and_then(|v| v.as_object()) {
+                }
+
+                if let Some(statuses) = payload.get("statuses").and_then(|v| v.as_object()) {
                     for (thread_id, status) in statuses {
+                        if thread_ids_with_agent_status.contains(thread_id) {
+                            continue;
+                        }
+
                         self.update_subagent_from_status(
                             call_id,
                             Some(thread_id.as_str()),
@@ -1436,6 +1449,52 @@ mod tests {
         assert_eq!(
             parsed.subagents[0].result_summary.as_deref(),
             Some("Error: permission denied")
+        );
+    }
+
+    #[test]
+    fn parse_waiting_end_falls_back_to_statuses_map_when_agent_statuses_is_partial() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"session_meta","payload":{"id":"codex-status-map-partial","timestamp":"2026-04-18T13:17:40Z","cwd":"/tmp/project"}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"event_msg","timestamp":"2026-04-18T13:17:41Z","payload":{"type":"user_message","message":"Delegate this"}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"event_msg","timestamp":"2026-04-18T13:17:42Z","payload":{"type":"collab_agent_spawn_end","call_id":"call_spawn_1","sender_thread_id":"codex-status-map-partial","new_thread_id":"child-1","new_agent_nickname":"Kierkegaard","new_agent_role":"default","prompt":"Inspect parser behavior","status":"running"}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"event_msg","timestamp":"2026-04-18T13:17:43Z","payload":{"type":"collab_agent_spawn_end","call_id":"call_spawn_2","sender_thread_id":"codex-status-map-partial","new_thread_id":"child-2","new_agent_nickname":"Camus","new_agent_role":"default","prompt":"Inspect parser behavior","status":"running"}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"event_msg","timestamp":"2026-04-18T13:17:44Z","payload":{"type":"collab_waiting_end","call_id":"call_wait_1","sender_thread_id":"codex-status-map-partial","agent_statuses":[{"thread_id":"child-1","agent_nickname":"Kierkegaard","agent_role":"default","status":{"completed":"first done"}}],"statuses":{"child-1":{"completed":"first done"},"child-2":{"errored":"second failed"}}}}"#
+        )
+        .unwrap();
+
+        let parsed = CodexParser.parse(file.path()).unwrap();
+        assert_eq!(parsed.subagents.len(), 2);
+        assert_eq!(
+            parsed.subagents[0].result_summary.as_deref(),
+            Some("first done")
+        );
+        assert_eq!(
+            parsed.subagents[1].result_summary.as_deref(),
+            Some("Error: second failed")
         );
     }
 

--- a/src/parsers/codex.rs
+++ b/src/parsers/codex.rs
@@ -790,6 +790,10 @@ impl ParseState {
 
 pub struct CodexParser;
 
+// Codex rollouts use two different keys for the subagent source variant:
+// upstream `SessionSource` serializes as `sub_agent` (snake_case), but older
+// rollouts emit `subagent` (no underscore). Both shapes appear in the wild,
+// so accept either.
 fn extract_parent_thread_id(source: Option<&Value>) -> Option<String> {
     let source = source?;
 

--- a/src/parsers/codex.rs
+++ b/src/parsers/codex.rs
@@ -24,6 +24,61 @@ pub enum ParseError {
     InvalidSessionMetaJson(String),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum SubagentEventPriority {
+    Interaction = 1,
+    Waiting = 2,
+    Close = 3,
+}
+
+#[derive(Debug, Clone)]
+struct StatusUpdate {
+    summary: Option<String>,
+    terminal: bool,
+}
+
+fn parse_status_update(status: &Value) -> StatusUpdate {
+    if let Some(unit) = status.as_str() {
+        return match unit {
+            "pending_init" | "running" | "interrupted" => StatusUpdate {
+                summary: None,
+                terminal: false,
+            },
+            "shutdown" => StatusUpdate {
+                summary: Some("Shutdown".to_string()),
+                terminal: true,
+            },
+            "not_found" => StatusUpdate {
+                summary: Some("Not found".to_string()),
+                terminal: true,
+            },
+            _ => StatusUpdate {
+                summary: None,
+                terminal: false,
+            },
+        };
+    }
+
+    if let Some(completed) = status.get("completed") {
+        return StatusUpdate {
+            summary: completed.as_str().map(str::to_string),
+            terminal: true,
+        };
+    }
+
+    if let Some(errored) = status.get("errored").and_then(|v| v.as_str()) {
+        return StatusUpdate {
+            summary: Some(format!("Error: {errored}")),
+            terminal: true,
+        };
+    }
+
+    StatusUpdate {
+        summary: None,
+        terminal: false,
+    }
+}
+
 /// Mutable parsing state accumulator for Codex sessions.
 struct ParseState {
     session_id: String,
@@ -43,6 +98,7 @@ struct ParseState {
     call_id_to_tc_idx: HashMap<String, usize>,
     subagent_idx_by_call_id: HashMap<String, usize>,
     subagent_indexes_by_agent_id: HashMap<String, Vec<usize>>,
+    subagent_priority_by_id: HashMap<String, SubagentEventPriority>,
 
     // Counters
     msg_counter: i64,
@@ -66,6 +122,7 @@ impl ParseState {
             call_id_to_tc_idx: HashMap::new(),
             subagent_idx_by_call_id: HashMap::new(),
             subagent_indexes_by_agent_id: HashMap::new(),
+            subagent_priority_by_id: HashMap::new(),
             msg_counter: 0,
             item_counter: 0,
             pending_reasoning: PendingReasoning::default(),
@@ -196,6 +253,8 @@ impl ParseState {
         });
         self.subagent_idx_by_call_id
             .insert(call_id.to_string(), subagent_idx);
+        self.subagent_priority_by_id
+            .insert(call_id.to_string(), SubagentEventPriority::Interaction);
         if let Some(agent_id) = agent_id {
             self.subagent_indexes_by_agent_id
                 .entry(agent_id)
@@ -213,6 +272,62 @@ impl ParseState {
         });
         self.flush_pending_reasoning_to_item(self.item_counter);
         self.item_counter += 1;
+    }
+
+    fn update_subagent_from_status(
+        &mut self,
+        call_id: Option<&str>,
+        receiver_thread_id: Option<&str>,
+        title: Option<&str>,
+        prompt: Option<&str>,
+        status: &Value,
+        priority: SubagentEventPriority,
+    ) {
+        let subagent_index = call_id
+            .and_then(|id| self.subagent_idx_by_call_id.get(id).copied())
+            .or_else(|| {
+                receiver_thread_id
+                    .and_then(|thread_id| self.subagent_indexes_by_agent_id.get(thread_id))
+                    .and_then(|indexes| indexes.last().copied())
+            });
+
+        let Some(index) = subagent_index else {
+            tracing::debug!("dropping orphan collab enrichment event with no matching spawn");
+            return;
+        };
+
+        let update = parse_status_update(status);
+        let subagent_id = self.subagents[index].id.clone();
+        let current_priority = self
+            .subagent_priority_by_id
+            .get(&subagent_id)
+            .copied()
+            .unwrap_or(SubagentEventPriority::Interaction);
+
+        {
+            let subagent = &mut self.subagents[index];
+            if let Some(title) = title.filter(|value| !value.is_empty()) {
+                subagent.title = title.to_string();
+            }
+            if subagent.prompt.is_none() {
+                subagent.prompt = prompt.map(str::to_string);
+            }
+        }
+
+        if !update.terminal || priority < current_priority {
+            return;
+        }
+
+        if let Some(summary) = update.summary.filter(|value| !value.is_empty()) {
+            self.subagents[index].result_summary = Some(summary);
+            self.subagent_priority_by_id.insert(subagent_id, priority);
+            return;
+        }
+
+        if self.subagents[index].result_summary.is_none() {
+            self.subagents[index].result_summary = Some(String::new());
+        }
+        self.subagent_priority_by_id.insert(subagent_id, priority);
     }
 
     fn flush_pending_reasoning_to_item(&mut self, transcript_item_index: i64) {
@@ -511,6 +626,62 @@ impl ParseState {
 
             Some("collab_agent_spawn_end") => {
                 self.record_subagent_spawn(payload);
+            }
+
+            Some("collab_waiting_end") => {
+                let call_id = payload.get("call_id").and_then(|v| v.as_str());
+
+                if let Some(agent_statuses) =
+                    payload.get("agent_statuses").and_then(|v| v.as_array())
+                {
+                    for agent_status in agent_statuses {
+                        self.update_subagent_from_status(
+                            call_id,
+                            agent_status.get("thread_id").and_then(|v| v.as_str()),
+                            agent_status.get("agent_nickname").and_then(|v| v.as_str()),
+                            None,
+                            agent_status.get("status").unwrap_or(&Value::Null),
+                            SubagentEventPriority::Waiting,
+                        );
+                    }
+                } else if let Some(statuses) = payload.get("statuses").and_then(|v| v.as_object()) {
+                    for (thread_id, status) in statuses {
+                        self.update_subagent_from_status(
+                            call_id,
+                            Some(thread_id.as_str()),
+                            None,
+                            None,
+                            status,
+                            SubagentEventPriority::Waiting,
+                        );
+                    }
+                }
+            }
+
+            Some("collab_close_end") => {
+                self.update_subagent_from_status(
+                    payload.get("call_id").and_then(|v| v.as_str()),
+                    payload.get("receiver_thread_id").and_then(|v| v.as_str()),
+                    payload
+                        .get("receiver_agent_nickname")
+                        .and_then(|v| v.as_str()),
+                    None,
+                    payload.get("status").unwrap_or(&Value::Null),
+                    SubagentEventPriority::Close,
+                );
+            }
+
+            Some("collab_agent_interaction_end") => {
+                self.update_subagent_from_status(
+                    payload.get("call_id").and_then(|v| v.as_str()),
+                    payload.get("receiver_thread_id").and_then(|v| v.as_str()),
+                    payload
+                        .get("receiver_agent_nickname")
+                        .and_then(|v| v.as_str()),
+                    payload.get("prompt").and_then(|v| v.as_str()),
+                    payload.get("status").unwrap_or(&Value::Null),
+                    SubagentEventPriority::Interaction,
+                );
             }
 
             _ => {}
@@ -1116,6 +1287,199 @@ mod tests {
 
         assert!(parsed.subagents.is_empty());
         assert_eq!(parsed.transcript_items.len(), 1);
+    }
+
+    #[test]
+    fn parse_close_end_overrides_waiting_end_summary_for_same_subagent() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"session_meta","payload":{"id":"019da0bb-541a-74e2-ae0a-6693c5e4fe04","timestamp":"2026-04-18T13:17:40Z","cwd":"/tmp/project"}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"event_msg","timestamp":"2026-04-18T13:17:41Z","payload":{"type":"user_message","message":"Delegate this"}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"event_msg","timestamp":"2026-04-18T13:17:42Z","payload":{"type":"collab_agent_spawn_end","call_id":"call_spawn_1","sender_thread_id":"019da0bb-541a-74e2-ae0a-6693c5e4fe04","new_thread_id":"019da0bd-3df2-7191-a1a8-e326b55fe052","new_agent_nickname":"Kierkegaard","new_agent_role":"default","prompt":"Inspect the failing parser tests","status":"running"}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"event_msg","timestamp":"2026-04-18T13:17:43Z","payload":{"type":"collab_waiting_end","call_id":"call_spawn_1","sender_thread_id":"019da0bb-541a-74e2-ae0a-6693c5e4fe04","agent_statuses":[{"thread_id":"019da0bd-3df2-7191-a1a8-e326b55fe052","agent_nickname":"Kierkegaard","agent_role":"default","status":{"completed":"intermediate summary"}}],"statuses":{"019da0bd-3df2-7191-a1a8-e326b55fe052":{"completed":"intermediate summary"}}}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"event_msg","timestamp":"2026-04-18T13:17:44Z","payload":{"type":"collab_close_end","call_id":"call_close_1","sender_thread_id":"019da0bb-541a-74e2-ae0a-6693c5e4fe04","receiver_thread_id":"019da0bd-3df2-7191-a1a8-e326b55fe052","receiver_agent_nickname":"Kierkegaard","receiver_agent_role":"default","status":{"completed":"final delegated answer"}}}"#
+        )
+        .unwrap();
+
+        let parsed = CodexParser.parse(file.path()).unwrap();
+        assert_eq!(parsed.subagents.len(), 1);
+        assert_eq!(
+            parsed.subagents[0].result_summary.as_deref(),
+            Some("final delegated answer")
+        );
+    }
+
+    #[test]
+    fn parse_running_status_does_not_overwrite_completed_summary() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"session_meta","payload":{"id":"codex-non-terminal","timestamp":"2026-04-18T13:17:40Z","cwd":"/tmp/project"}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"event_msg","timestamp":"2026-04-18T13:17:41Z","payload":{"type":"user_message","message":"Delegate this"}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"event_msg","timestamp":"2026-04-18T13:17:42Z","payload":{"type":"collab_agent_spawn_end","call_id":"call_spawn_1","sender_thread_id":"codex-non-terminal","new_thread_id":"child-1","new_agent_nickname":"Kierkegaard","new_agent_role":"default","prompt":"Inspect the failing parser tests","status":"running"}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"event_msg","timestamp":"2026-04-18T13:17:43Z","payload":{"type":"collab_waiting_end","call_id":"call_spawn_1","sender_thread_id":"codex-non-terminal","agent_statuses":[{"thread_id":"child-1","agent_nickname":"Kierkegaard","agent_role":"default","status":{"completed":"done already"}}],"statuses":{"child-1":{"completed":"done already"}}}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"event_msg","timestamp":"2026-04-18T13:17:44Z","payload":{"type":"collab_waiting_end","call_id":"call_spawn_1","sender_thread_id":"codex-non-terminal","agent_statuses":[{"thread_id":"child-1","agent_nickname":"Kierkegaard","agent_role":"default","status":"running"}],"statuses":{"child-1":"running"}}}"#
+        )
+        .unwrap();
+
+        let parsed = CodexParser.parse(file.path()).unwrap();
+        assert_eq!(
+            parsed.subagents[0].result_summary.as_deref(),
+            Some("done already")
+        );
+    }
+
+    #[test]
+    fn parse_unknown_agent_status_does_not_fail_session_parse() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"session_meta","payload":{"id":"codex-unknown-status","timestamp":"2026-04-18T13:17:40Z","cwd":"/tmp/project"}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"event_msg","timestamp":"2026-04-18T13:17:41Z","payload":{"type":"user_message","message":"Delegate this"}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"event_msg","timestamp":"2026-04-18T13:17:42Z","payload":{"type":"collab_agent_spawn_end","call_id":"call_spawn_1","sender_thread_id":"codex-unknown-status","new_thread_id":"child-1","new_agent_nickname":"Kierkegaard","new_agent_role":"default","prompt":"Inspect the failing parser tests","status":"running"}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"event_msg","timestamp":"2026-04-18T13:17:43Z","payload":{"type":"collab_close_end","call_id":"call_close_1","sender_thread_id":"codex-unknown-status","receiver_thread_id":"child-1","receiver_agent_nickname":"Kierkegaard","receiver_agent_role":"default","status":{"paused_for_human":"needs approval"}}}"#
+        )
+        .unwrap();
+
+        let parsed = CodexParser.parse(file.path()).unwrap();
+        assert_eq!(parsed.subagents.len(), 1);
+    }
+
+    #[test]
+    fn parse_waiting_end_falls_back_to_statuses_map_when_agent_statuses_is_missing() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"session_meta","payload":{"id":"codex-status-map","timestamp":"2026-04-18T13:17:40Z","cwd":"/tmp/project"}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"event_msg","timestamp":"2026-04-18T13:17:41Z","payload":{"type":"user_message","message":"Delegate this"}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"event_msg","timestamp":"2026-04-18T13:17:42Z","payload":{"type":"collab_agent_spawn_end","call_id":"call_spawn_1","sender_thread_id":"codex-status-map","new_thread_id":"child-1","new_agent_nickname":"Kierkegaard","new_agent_role":"default","prompt":"Inspect the failing parser tests","status":"running"}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"event_msg","timestamp":"2026-04-18T13:17:43Z","payload":{"type":"collab_waiting_end","call_id":"call_spawn_1","sender_thread_id":"codex-status-map","statuses":{"child-1":{"errored":"permission denied"}}}}"#
+        )
+        .unwrap();
+
+        let parsed = CodexParser.parse(file.path()).unwrap();
+        assert_eq!(
+            parsed.subagents[0].result_summary.as_deref(),
+            Some("Error: permission denied")
+        );
+    }
+
+    #[test]
+    fn parse_enrichment_without_call_id_updates_latest_matching_thread_row() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"session_meta","payload":{"id":"codex-retry","timestamp":"2026-04-18T13:17:40Z","cwd":"/tmp/project"}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"event_msg","timestamp":"2026-04-18T13:17:41Z","payload":{"type":"user_message","message":"Delegate twice"}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"event_msg","timestamp":"2026-04-18T13:17:42Z","payload":{"type":"collab_agent_spawn_end","call_id":"call_spawn_1","sender_thread_id":"codex-retry","new_thread_id":"child-1","new_agent_nickname":"Kierkegaard","new_agent_role":"default","prompt":"first attempt","status":"running"}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"event_msg","timestamp":"2026-04-18T13:17:43Z","payload":{"type":"collab_agent_spawn_end","call_id":"call_spawn_2","sender_thread_id":"codex-retry","new_thread_id":"child-1","new_agent_nickname":"Kierkegaard","new_agent_role":"default","prompt":"second attempt","status":"running"}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            r#"{"type":"event_msg","timestamp":"2026-04-18T13:17:44Z","payload":{"type":"collab_close_end","sender_thread_id":"codex-retry","receiver_thread_id":"child-1","receiver_agent_nickname":"Kierkegaard","receiver_agent_role":"default","status":{"completed":"second attempt finished"}}}"#
+        )
+        .unwrap();
+
+        let parsed = CodexParser.parse(file.path()).unwrap();
+        assert_eq!(parsed.subagents.len(), 2);
+        assert_eq!(parsed.subagents[0].result_summary, None);
+        assert_eq!(
+            parsed.subagents[1].result_summary.as_deref(),
+            Some("second attempt finished")
+        );
     }
 
     #[derive(Clone, Default)]

--- a/src/parsers/codex.rs
+++ b/src/parsers/codex.rs
@@ -172,7 +172,7 @@ impl ParseState {
             .filter(|value| !value.is_empty())
             .map(str::to_string);
         let title = payload
-            .get("nickname")
+            .get("new_agent_nickname")
             .and_then(|v| v.as_str())
             .filter(|value| !value.is_empty())
             .unwrap_or("Codex subagent")
@@ -1064,7 +1064,7 @@ mod tests {
         .unwrap();
         writeln!(
             file,
-            r#"{{"type":"event_msg","timestamp":"2026-01-01T00:00:02Z","payload":{{"type":"collab_agent_spawn_end","call_id":"call_spawn_1","new_thread_id":"019da0bd-3df2-7191-a1a8-e326b55fe052","nickname":"Kierkegaard","prompt":"Inspect the failing parser tests"}}}}"#
+            r#"{{"type":"event_msg","timestamp":"2026-01-01T00:00:02Z","payload":{{"type":"collab_agent_spawn_end","call_id":"call_spawn_1","new_thread_id":"019da0bd-3df2-7191-a1a8-e326b55fe052","new_agent_nickname":"Kierkegaard","prompt":"Inspect the failing parser tests"}}}}"#
         )
         .unwrap();
 
@@ -1108,7 +1108,7 @@ mod tests {
         .unwrap();
         writeln!(
             file,
-            r#"{{"type":"event_msg","timestamp":"2026-01-01T00:00:02Z","payload":{{"type":"collab_agent_spawn_begin","call_id":"call_spawn_1","new_thread_id":"019da0bd-3df2-7191-a1a8-e326b55fe052","nickname":"Kierkegaard","prompt":"Inspect the failing parser tests"}}}}"#
+            r#"{{"type":"event_msg","timestamp":"2026-01-01T00:00:02Z","payload":{{"type":"collab_agent_spawn_begin","call_id":"call_spawn_1","new_thread_id":"019da0bd-3df2-7191-a1a8-e326b55fe052","new_agent_nickname":"Kierkegaard","prompt":"Inspect the failing parser tests"}}}}"#
         )
         .unwrap();
 

--- a/tests/codex_subagent_linkage.rs
+++ b/tests/codex_subagent_linkage.rs
@@ -1,6 +1,10 @@
 use rusqlite::Connection;
 use sessions_chronicle::database::{SessionIndexer, load_session, load_subagent};
+use sessions_chronicle::models::AiAssistant;
+use sessions_chronicle::session_sources::SessionSources;
 use std::fs;
+use std::fs::OpenOptions;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use tempfile::{NamedTempFile, TempDir, tempdir};
 
@@ -28,6 +32,30 @@ fn fixture_dir(include_parent: bool, include_child: bool) -> TempDir {
     }
 
     dir
+}
+
+fn fixture_override_root() -> TempDir {
+    let root = tempdir().unwrap();
+    let target_dir = root.path().join("codex_sessions/2026/04/18");
+    fs::create_dir_all(&target_dir).unwrap();
+
+    fs::copy(fixture_file_path(PARENT_FILE), target_dir.join(PARENT_FILE)).unwrap();
+    fs::copy(fixture_file_path(CHILD_FILE), target_dir.join(CHILD_FILE)).unwrap();
+
+    root
+}
+
+fn append_harmless_parent_event(root: &TempDir) {
+    let parent_path = root
+        .path()
+        .join("codex_sessions/2026/04/18")
+        .join(PARENT_FILE);
+    let mut file = OpenOptions::new().append(true).open(parent_path).unwrap();
+    writeln!(
+        file,
+        "{{\"type\":\"event_msg\",\"timestamp\":\"2026-04-18T13:17:05Z\",\"payload\":{{\"type\":\"agent_message\",\"message\":\"No-op incremental marker\"}}}}"
+    )
+    .unwrap();
 }
 
 #[test]
@@ -151,4 +179,45 @@ fn indexing_codex_duplicate_thread_rows_share_the_same_child_session_id() {
         )
         .unwrap();
     assert_eq!(distinct_child_ids, 1);
+}
+
+#[test]
+fn codex_incremental_reindex_keeps_existing_child_link_when_child_file_is_skipped() {
+    let temp_db = NamedTempFile::new().unwrap();
+    let mut indexer = SessionIndexer::new(temp_db.path()).unwrap();
+    let root = fixture_override_root();
+    let sources = SessionSources::resolve(Some(root.path()));
+
+    let first_run = indexer.index_all_incremental(&sources).unwrap();
+    let first_codex = first_run
+        .per_source
+        .iter()
+        .find(|result| result.assistant == AiAssistant::Codex)
+        .expect("Codex source result should exist");
+    assert_eq!(first_codex.indexed, 2);
+
+    let initial_subagent = load_subagent(temp_db.path(), PARENT_SESSION_ID, "call_spawn_1")
+        .unwrap()
+        .expect("parent subagent should exist after initial index");
+    assert_eq!(
+        initial_subagent.child_session_id.as_deref(),
+        Some(CHILD_SESSION_ID)
+    );
+
+    append_harmless_parent_event(&root);
+
+    let second_run = indexer.index_all_incremental(&sources).unwrap();
+    let second_codex = second_run
+        .per_source
+        .iter()
+        .find(|result| result.assistant == AiAssistant::Codex)
+        .expect("Codex source result should exist");
+    assert_eq!(second_codex.indexed, 1);
+    assert_eq!(second_codex.skipped, 1);
+
+    let subagent = load_subagent(temp_db.path(), PARENT_SESSION_ID, "call_spawn_1")
+        .unwrap()
+        .expect("parent subagent should exist after incremental reindex");
+    assert_eq!(subagent.agent_id.as_deref(), Some(CHILD_SESSION_ID));
+    assert_eq!(subagent.child_session_id.as_deref(), Some(CHILD_SESSION_ID));
 }

--- a/tests/codex_subagent_linkage.rs
+++ b/tests/codex_subagent_linkage.rs
@@ -1,0 +1,154 @@
+use rusqlite::Connection;
+use sessions_chronicle::database::{SessionIndexer, load_session, load_subagent};
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::{NamedTempFile, TempDir, tempdir};
+
+const FIXTURE_BASE: &str = "tests/fixtures/codex_subagent_linkage/2026/04/18";
+const PARENT_FILE: &str = "rollout-2026-04-18T13-17-00-019da0bb-541a-74e2-ae0a-6693c5e4fe04.jsonl";
+const CHILD_FILE: &str = "rollout-2026-04-18T13-17-01-019da0bd-3df2-7191-a1a8-e326b55fe052.jsonl";
+const PARENT_SESSION_ID: &str = "019da0bb-541a-74e2-ae0a-6693c5e4fe04";
+const CHILD_SESSION_ID: &str = "019da0bd-3df2-7191-a1a8-e326b55fe052";
+
+fn fixture_file_path(file_name: &str) -> PathBuf {
+    Path::new(FIXTURE_BASE).join(file_name)
+}
+
+fn fixture_dir(include_parent: bool, include_child: bool) -> TempDir {
+    let dir = tempdir().unwrap();
+    let target_dir = dir.path().join("2026/04/18");
+    fs::create_dir_all(&target_dir).unwrap();
+
+    if include_parent {
+        fs::copy(fixture_file_path(PARENT_FILE), target_dir.join(PARENT_FILE)).unwrap();
+    }
+
+    if include_child {
+        fs::copy(fixture_file_path(CHILD_FILE), target_dir.join(CHILD_FILE)).unwrap();
+    }
+
+    dir
+}
+
+#[test]
+fn indexing_codex_parent_and_child_links_subagent_to_child_session() {
+    let temp_db = NamedTempFile::new().unwrap();
+    let mut indexer = SessionIndexer::new(temp_db.path()).unwrap();
+
+    indexer
+        .index_codex_sessions(Path::new("tests/fixtures/codex_subagent_linkage"))
+        .unwrap();
+
+    let parent = load_session(temp_db.path(), PARENT_SESSION_ID)
+        .unwrap()
+        .expect("parent session should be indexed");
+    assert!(!parent.is_subagent);
+
+    let child = load_session(temp_db.path(), CHILD_SESSION_ID)
+        .unwrap()
+        .expect("child session should be indexed");
+    assert!(child.is_subagent);
+    assert_eq!(child.parent_session_id.as_deref(), Some(PARENT_SESSION_ID));
+
+    let subagent = load_subagent(temp_db.path(), PARENT_SESSION_ID, "call_spawn_1")
+        .unwrap()
+        .expect("parent subagent should be indexed");
+    assert_eq!(subagent.agent_id.as_deref(), Some(CHILD_SESSION_ID));
+    assert_eq!(subagent.child_session_id.as_deref(), Some(CHILD_SESSION_ID));
+}
+
+#[test]
+fn indexing_codex_child_before_parent_still_links_on_second_pass() {
+    let temp_db = NamedTempFile::new().unwrap();
+    let mut indexer = SessionIndexer::new(temp_db.path()).unwrap();
+
+    let child_only_dir = fixture_dir(false, true);
+    let parent_only_dir = fixture_dir(true, false);
+
+    indexer.index_codex_sessions(child_only_dir.path()).unwrap();
+    indexer
+        .index_codex_sessions(parent_only_dir.path())
+        .unwrap();
+    indexer.index_codex_sessions(child_only_dir.path()).unwrap();
+
+    let subagent = load_subagent(temp_db.path(), PARENT_SESSION_ID, "call_spawn_1")
+        .unwrap()
+        .expect("parent subagent should exist after parent indexing");
+    assert_eq!(subagent.child_session_id.as_deref(), Some(CHILD_SESSION_ID));
+}
+
+#[test]
+fn indexing_codex_reindex_replaces_parent_subagents_without_duplicates() {
+    let temp_db = NamedTempFile::new().unwrap();
+    let mut indexer = SessionIndexer::new(temp_db.path()).unwrap();
+
+    let parent_only_dir = fixture_dir(true, false);
+    let child_only_dir = fixture_dir(false, true);
+
+    indexer
+        .index_codex_sessions(parent_only_dir.path())
+        .unwrap();
+    indexer.index_codex_sessions(child_only_dir.path()).unwrap();
+    indexer
+        .index_codex_sessions(parent_only_dir.path())
+        .unwrap();
+    indexer.index_codex_sessions(child_only_dir.path()).unwrap();
+
+    let conn = Connection::open(temp_db.path()).unwrap();
+    let subagent_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM subagents WHERE session_id = ?1",
+            [PARENT_SESSION_ID],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(subagent_count, 2);
+
+    let linked_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*)
+             FROM subagents
+             WHERE session_id = ?1 AND child_session_id = ?2",
+            rusqlite::params![PARENT_SESSION_ID, CHILD_SESSION_ID],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(linked_count, 2);
+}
+
+#[test]
+fn indexing_codex_duplicate_thread_rows_share_the_same_child_session_id() {
+    let temp_db = NamedTempFile::new().unwrap();
+    let mut indexer = SessionIndexer::new(temp_db.path()).unwrap();
+
+    let parent_only_dir = fixture_dir(true, false);
+    let child_only_dir = fixture_dir(false, true);
+
+    indexer
+        .index_codex_sessions(parent_only_dir.path())
+        .unwrap();
+    indexer.index_codex_sessions(child_only_dir.path()).unwrap();
+
+    let conn = Connection::open(temp_db.path()).unwrap();
+    let matching_rows: i64 = conn
+        .query_row(
+            "SELECT COUNT(*)
+             FROM subagents
+             WHERE session_id = ?1 AND agent_id = ?2",
+            rusqlite::params![PARENT_SESSION_ID, CHILD_SESSION_ID],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(matching_rows, 2);
+
+    let distinct_child_ids: i64 = conn
+        .query_row(
+            "SELECT COUNT(DISTINCT child_session_id)
+             FROM subagents
+             WHERE session_id = ?1 AND agent_id = ?2",
+            rusqlite::params![PARENT_SESSION_ID, CHILD_SESSION_ID],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(distinct_child_ids, 1);
+}

--- a/tests/fixtures/codex_subagent_linkage/2026/04/18/rollout-2026-04-18T13-17-00-019da0bb-541a-74e2-ae0a-6693c5e4fe04.jsonl
+++ b/tests/fixtures/codex_subagent_linkage/2026/04/18/rollout-2026-04-18T13-17-00-019da0bb-541a-74e2-ae0a-6693c5e4fe04.jsonl
@@ -1,0 +1,5 @@
+{"type":"session_meta","timestamp":"2026-04-18T13:17:00Z","payload":{"id":"019da0bb-541a-74e2-ae0a-6693c5e4fe04","timestamp":"2026-04-18T13:17:00Z","cwd":"/tmp/codex-parent"}}
+{"type":"event_msg","timestamp":"2026-04-18T13:17:01Z","payload":{"type":"user_message","message":"Delegate this task to subagents"}}
+{"type":"event_msg","timestamp":"2026-04-18T13:17:02Z","payload":{"type":"collab_agent_spawn_end","call_id":"call_spawn_1","sender_thread_id":"019da0bb-541a-74e2-ae0a-6693c5e4fe04","new_thread_id":"019da0bd-3df2-7191-a1a8-e326b55fe052","new_agent_nickname":"Kierkegaard","prompt":"Inspect parser tests"}}
+{"type":"event_msg","timestamp":"2026-04-18T13:17:03Z","payload":{"type":"collab_agent_spawn_end","call_id":"call_spawn_2","sender_thread_id":"019da0bb-541a-74e2-ae0a-6693c5e4fe04","new_thread_id":"019da0bd-3df2-7191-a1a8-e326b55fe052","new_agent_nickname":"Kierkegaard","prompt":"Double-check parser tests"}}
+{"type":"event_msg","timestamp":"2026-04-18T13:17:04Z","payload":{"type":"agent_message","message":"Delegation complete"}}

--- a/tests/fixtures/codex_subagent_linkage/2026/04/18/rollout-2026-04-18T13-17-01-019da0bd-3df2-7191-a1a8-e326b55fe052.jsonl
+++ b/tests/fixtures/codex_subagent_linkage/2026/04/18/rollout-2026-04-18T13-17-01-019da0bd-3df2-7191-a1a8-e326b55fe052.jsonl
@@ -1,0 +1,3 @@
+{"type":"session_meta","timestamp":"2026-04-18T13:17:01Z","payload":{"id":"019da0bd-3df2-7191-a1a8-e326b55fe052","timestamp":"2026-04-18T13:17:01Z","cwd":"/tmp/codex-child","source":{"subagent":{"thread_spawn":{"parent_thread_id":"019da0bb-541a-74e2-ae0a-6693c5e4fe04"}}}}}
+{"type":"event_msg","timestamp":"2026-04-18T13:17:02Z","payload":{"type":"user_message","message":"Working on delegated task"}}
+{"type":"event_msg","timestamp":"2026-04-18T13:17:03Z","payload":{"type":"agent_message","message":"Delegated task complete"}}


### PR DESCRIPTION
## Summary

cf #107 

- index Codex child rollouts as subagent sessions from structured `session_meta.payload.source`
- map Codex `collab_*` spawn and lifecycle events into parent-side subagent rows, transcript items, and result summaries
- link parent subagent rows back to child sessions in both indexing orders, cover reindex edge cases, and update Codex format docs

## Test Plan
- [x] cargo fmt --all -- --check
- [x] cargo clippy --all -- -D warnings
- [x] cargo test --all --no-fail-fast
- [x] cargo test --test codex_subagent_linkage