### PR TITLE
feat: add explicit session ID search in session list

### DIFF
--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -17,6 +17,12 @@ use crate::models::{
 pub use indexer::{IndexingStats, SessionIndexer};
 
 const SQLITE_BUSY_TIMEOUT_SECS: u64 = 5;
+const SESSION_SELECT_COLUMNS: &str =
+    "id, tool, project_path, project_id, start_time, message_count, file_path,
+        last_updated, pinned_at, first_prompt, parent_session_id, is_subagent,
+        input_tokens, output_tokens, cache_read_tokens,
+        cache_write_tokens, reasoning_tokens,
+        edit_count, read_count, command_count, ending_status";
 
 pub(crate) fn open_connection(db_path: &Path) -> Result<Connection> {
     let conn = Connection::open(db_path).context("Failed to open database")?;
@@ -221,17 +227,13 @@ pub fn load_session_by_id_for_filter(
     let (query, tool_strings): (String, Vec<String>) = if tools.len() == AiAssistant::ALL.len() {
         (
             format!(
-                "SELECT id, tool, project_path, project_id, start_time, message_count, file_path,
-                        last_updated, pinned_at, first_prompt, parent_session_id, is_subagent,
-                        input_tokens, output_tokens, cache_read_tokens,
-                        cache_write_tokens, reasoning_tokens,
-                        edit_count, read_count, command_count, ending_status
+                "SELECT {}
                  FROM sessions
                  WHERE id = ?
                    AND is_subagent = 0
                     {}
                  ORDER BY last_updated DESC",
-                project_clause
+                SESSION_SELECT_COLUMNS, project_clause
             ),
             vec![],
         )
@@ -240,17 +242,14 @@ pub fn load_session_by_id_for_filter(
         let tool_strings: Vec<String> = tools.iter().map(|t| t.to_storage()).collect::<Vec<_>>();
         (
             format!(
-                "SELECT id, tool, project_path, project_id, start_time, message_count, file_path,
-                        last_updated, pinned_at, first_prompt, parent_session_id, is_subagent,
-                        input_tokens, output_tokens, cache_read_tokens,
-                        cache_write_tokens, reasoning_tokens,
-                        edit_count, read_count, command_count, ending_status
+                "SELECT {}
                  FROM sessions
                  WHERE id = ?
                    AND tool IN ({})
                    AND is_subagent = 0
                     {}
                  ORDER BY last_updated DESC",
+                SESSION_SELECT_COLUMNS,
                 placeholders.join(","),
                 project_clause
             ),
@@ -470,16 +469,12 @@ pub fn load_sessions_for_filter(
     let (query, tool_strings): (String, Vec<String>) = if tools.len() == AiAssistant::ALL.len() {
         (
             format!(
-                "SELECT id, tool, project_path, project_id, start_time, message_count, file_path,
-                        last_updated, pinned_at, first_prompt, parent_session_id, is_subagent,
-                        input_tokens, output_tokens, cache_read_tokens,
-                        cache_write_tokens, reasoning_tokens,
-                        edit_count, read_count, command_count, ending_status
+                "SELECT {}
                  FROM sessions
                  WHERE is_subagent = 0
                     {}
                  ORDER BY last_updated DESC",
-                project_clause
+                SESSION_SELECT_COLUMNS, project_clause
             ),
             vec![],
         )
@@ -488,16 +483,13 @@ pub fn load_sessions_for_filter(
         let tool_strings: Vec<String> = tools.iter().map(|t| t.to_storage()).collect::<Vec<_>>();
         (
             format!(
-                "SELECT id, tool, project_path, project_id, start_time, message_count, file_path,
-                        last_updated, pinned_at, first_prompt, parent_session_id, is_subagent,
-                        input_tokens, output_tokens, cache_read_tokens,
-                        cache_write_tokens, reasoning_tokens,
-                        edit_count, read_count, command_count, ending_status
+                "SELECT {}
                  FROM sessions
                  WHERE tool IN ({})
                    AND is_subagent = 0
                     {}
                  ORDER BY last_updated DESC",
+                SESSION_SELECT_COLUMNS,
                 placeholders.join(","),
                 project_clause
             ),

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -190,6 +190,98 @@ pub fn search_sessions_for_filter(
     }
 }
 
+pub fn load_session_by_id_for_filter(
+    db_path: &Path,
+    tools: &[AiAssistant],
+    project_filter: &ProjectFilter,
+    session_id: &str,
+) -> Result<Vec<Session>> {
+    if !db_path.exists() {
+        return Ok(Vec::new());
+    }
+
+    if tools.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let session_id = session_id.trim();
+    if session_id.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let db = open_connection(db_path)?;
+
+    let project_clause = match project_filter {
+        ProjectFilter::AllSessions => String::new(),
+        ProjectFilter::Pinned => " AND pinned_at IS NOT NULL".to_string(),
+        ProjectFilter::Project(_) => " AND project_id = ?".to_string(),
+        ProjectFilter::Unassigned => " AND project_id IS NULL".to_string(),
+    };
+
+    let (query, tool_strings): (String, Vec<String>) = if tools.len() == AiAssistant::ALL.len() {
+        (
+            format!(
+                "SELECT id, tool, project_path, project_id, start_time, message_count, file_path,
+                        last_updated, pinned_at, first_prompt, parent_session_id, is_subagent,
+                        input_tokens, output_tokens, cache_read_tokens,
+                        cache_write_tokens, reasoning_tokens,
+                        edit_count, read_count, command_count, ending_status
+                 FROM sessions
+                 WHERE id = ?
+                   AND is_subagent = 0
+                    {}
+                 ORDER BY last_updated DESC",
+                project_clause
+            ),
+            vec![],
+        )
+    } else {
+        let placeholders: Vec<String> = tools.iter().map(|_| "?".to_string()).collect();
+        let tool_strings: Vec<String> = tools.iter().map(|t| t.to_storage()).collect::<Vec<_>>();
+        (
+            format!(
+                "SELECT id, tool, project_path, project_id, start_time, message_count, file_path,
+                        last_updated, pinned_at, first_prompt, parent_session_id, is_subagent,
+                        input_tokens, output_tokens, cache_read_tokens,
+                        cache_write_tokens, reasoning_tokens,
+                        edit_count, read_count, command_count, ending_status
+                 FROM sessions
+                 WHERE id = ?
+                   AND tool IN ({})
+                   AND is_subagent = 0
+                    {}
+                 ORDER BY last_updated DESC",
+                placeholders.join(","),
+                project_clause
+            ),
+            tool_strings,
+        )
+    };
+
+    let mut stmt = db.prepare(&query)?;
+
+    let mut params: Vec<&dyn ToSql> = Vec::with_capacity(2 + tool_strings.len());
+    params.push(&session_id);
+    for tool in &tool_strings {
+        params.push(tool as &dyn ToSql);
+    }
+    let project_id = match project_filter {
+        ProjectFilter::Project(id) => Some(*id),
+        _ => None,
+    };
+    if let Some(project_id) = project_id.as_ref() {
+        params.push(project_id as &dyn ToSql);
+    }
+
+    let sessions = stmt
+        .query_map(params.as_slice(), session_from_row)
+        .context("Failed to query session by ID")?
+        .collect::<Result<Vec<_>, _>>()
+        .context("Failed to load session by ID")?;
+
+    Ok(sessions)
+}
+
 pub fn find_session_match_positions(
     db: &Connection,
     session_id: &str,

--- a/src/ui/session_list.rs
+++ b/src/ui/session_list.rs
@@ -3,7 +3,9 @@ use relm4::factory::FactoryVecDeque;
 use relm4::{ComponentParts, ComponentSender, SimpleComponent, adw, gtk};
 use std::path::{Path, PathBuf};
 
-use crate::database::{load_sessions_for_filter, search_sessions_for_filter};
+use crate::database::{
+    load_session_by_id_for_filter, load_sessions_for_filter, search_sessions_for_filter,
+};
 use crate::models::{AiAssistant, PerSourceResult, ProjectFilter, Session, SourceStatus};
 use crate::ui::session_row::{SessionRow, SessionRowInit, SessionRowOutput};
 
@@ -57,6 +59,10 @@ struct EmptyStateViewModel {
     show_source_results: bool,
 }
 
+fn parse_session_id_query(query: &str) -> Option<&str> {
+    query.trim().strip_prefix("id:").map(str::trim)
+}
+
 fn compute_empty_state(
     sessions_empty: bool,
     search_query: &str,
@@ -74,8 +80,17 @@ fn compute_empty_state(
         };
     }
 
+    let session_id_lookup = parse_session_id_query(search_query).is_some();
     let has_search = !search_query.trim().is_empty();
     let pinned_selected = *project_filter == ProjectFilter::Pinned;
+
+    if session_id_lookup {
+        return EmptyStateViewModel {
+            title: "No session found with this ID",
+            description: "Try a different session ID or adjust filters",
+            show_source_results: false,
+        };
+    }
 
     if has_search && pinned_selected {
         return EmptyStateViewModel {
@@ -435,6 +450,8 @@ impl SessionList {
         let query = query.trim();
         let sessions = if query.is_empty() {
             load_sessions_for_filter(db_path, tools, project_filter)
+        } else if let Some(session_id) = parse_session_id_query(query) {
+            load_session_by_id_for_filter(db_path, tools, project_filter, session_id)
         } else {
             search_sessions_for_filter(db_path, tools, project_filter, query)
         };
@@ -909,6 +926,75 @@ mod tests {
         assert!(SessionList::search_query_changed("needle", "other"));
     }
 
+    #[test]
+    fn parse_session_id_query_recognizes_lowercase_prefix_and_trims_suffix() {
+        assert_eq!(parse_session_id_query("id:abc"), Some("abc"));
+        assert_eq!(parse_session_id_query(" id: abc "), Some("abc"));
+        assert_eq!(parse_session_id_query("id:   "), Some(""));
+        assert_eq!(parse_session_id_query("ID:abc"), None);
+        assert_eq!(parse_session_id_query("abc"), None);
+    }
+
+    #[test]
+    fn session_id_search_empty_state_has_specific_copy() {
+        let state = compute_empty_state(
+            true,
+            "id:missing-session",
+            true,
+            false,
+            false,
+            true,
+            &ProjectFilter::AllSessions,
+        );
+
+        assert_eq!(state.title, "No session found with this ID");
+        assert_eq!(
+            state.description,
+            "Try a different session ID or adjust filters"
+        );
+        assert!(!state.show_source_results);
+    }
+
+    #[test]
+    fn session_id_search_empty_state_overrides_pinned_search_copy() {
+        let state = compute_empty_state(
+            true,
+            "id:missing-session",
+            true,
+            false,
+            false,
+            false,
+            &ProjectFilter::Pinned,
+        );
+
+        assert_eq!(state.title, "No session found with this ID");
+        assert_eq!(
+            state.description,
+            "Try a different session ID or adjust filters"
+        );
+        assert!(!state.show_source_results);
+    }
+
+    #[test]
+    fn blank_session_id_search_empty_state_has_specific_copy() {
+        let state = compute_empty_state(
+            true,
+            "id:   ",
+            true,
+            false,
+            false,
+            false,
+            &ProjectFilter::AllSessions,
+        );
+
+        assert_eq!(state.title, "No session found with this ID");
+        assert_eq!(
+            state.description,
+            "Try a different session ID or adjust filters"
+        );
+        assert!(!state.show_source_results);
+    }
+
     #[gtk::test]
     fn explicit_reload_refreshes_even_when_filters_are_unchanged() {
         let temp_db = TempDatabase::new();
@@ -991,6 +1077,61 @@ mod tests {
         };
 
         assert_eq!(ids, vec!["beta-claude", "alpha-claude-new"]);
+    }
+
+    #[gtk::test]
+    fn session_list_id_search_filters_to_exact_session_id() {
+        let temp_db = TempDatabase::new();
+        temp_db.seed_project_sidebar_fixture();
+
+        let controller = SessionList::builder().launch(temp_db.path.clone());
+
+        controller.emit(SessionListMsg::SetSearchQuery(
+            " id: alpha-claude-old ".to_string(),
+        ));
+
+        pump_main_context(|| {
+            let parts = controller.state().get();
+            parts.model.sessions.len() == 1
+        });
+
+        let ids: Vec<String> = {
+            let parts = controller.state().get();
+            (0..parts.model.sessions.len())
+                .filter_map(|index| parts.model.sessions.get(index))
+                .map(|row| row.session_id().to_string())
+                .collect()
+        };
+
+        assert_eq!(ids, vec!["alpha-claude-old"]);
+    }
+
+    #[gtk::test]
+    fn session_list_id_search_respects_active_filters() {
+        let temp_db = TempDatabase::new();
+        temp_db.seed_project_sidebar_fixture();
+
+        let controller = SessionList::builder().launch(temp_db.path.clone());
+
+        controller.emit(SessionListMsg::SetFilters {
+            tools: vec![AiAssistant::OpenCode],
+            project_filter: ProjectFilter::AllSessions,
+        });
+        controller.emit(SessionListMsg::SetSearchQuery(
+            "id:alpha-claude-old".to_string(),
+        ));
+
+        pump_main_context(|| {
+            let parts = controller.state().get();
+            parts.model.sessions.is_empty()
+        });
+
+        let title = {
+            let parts = controller.state().get();
+            parts.widgets.empty_state.title().to_string()
+        };
+
+        assert_eq!(title, "No session found with this ID");
     }
 
     #[gtk::test]

--- a/tests/search_sessions.rs
+++ b/tests/search_sessions.rs
@@ -3,7 +3,9 @@ use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use sessions_chronicle::database::schema::initialize_database;
-use sessions_chronicle::database::{find_session_match_positions, search_sessions_for_filter};
+use sessions_chronicle::database::{
+    find_session_match_positions, load_session_by_id_for_filter, search_sessions_for_filter,
+};
 use sessions_chronicle::models::{AiAssistant, ProjectFilter};
 
 struct TempDatabase {
@@ -249,6 +251,136 @@ fn search_sessions_sanitizes_invalid_query() {
     assert_eq!(sessions.len(), 1);
     assert_eq!(sessions[0].id, "session-a");
     assert_eq!(sessions[0].project_id, Some(1));
+}
+
+#[test]
+fn load_session_by_id_for_filter_matches_exact_id() {
+    let db = TempDatabase::new();
+    db.seed();
+
+    let sessions = load_session_by_id_for_filter(
+        &db.path,
+        &AiAssistant::ALL,
+        &ProjectFilter::AllSessions,
+        "session-b",
+    )
+    .expect("Session ID lookup failed");
+    let ids: Vec<&str> = sessions.iter().map(|session| session.id.as_str()).collect();
+
+    assert_eq!(ids, vec!["session-b"]);
+}
+
+#[test]
+fn load_session_by_id_for_filter_requires_exact_id() {
+    let db = TempDatabase::new();
+    db.seed();
+
+    let sessions = load_session_by_id_for_filter(
+        &db.path,
+        &AiAssistant::ALL,
+        &ProjectFilter::AllSessions,
+        "session",
+    )
+    .expect("Session ID lookup failed");
+
+    assert!(sessions.is_empty());
+}
+
+#[test]
+fn load_session_by_id_for_filter_respects_tool_filter() {
+    let db = TempDatabase::new();
+    db.seed();
+
+    let matching = load_session_by_id_for_filter(
+        &db.path,
+        &[AiAssistant::OpenCode],
+        &ProjectFilter::AllSessions,
+        "session-b",
+    )
+    .expect("Session ID lookup with matching tool failed");
+    let blocked = load_session_by_id_for_filter(
+        &db.path,
+        &[AiAssistant::ClaudeCode],
+        &ProjectFilter::AllSessions,
+        "session-b",
+    )
+    .expect("Session ID lookup with blocked tool failed");
+
+    assert_eq!(matching.len(), 1);
+    assert_eq!(matching[0].id, "session-b");
+    assert!(blocked.is_empty());
+}
+
+#[test]
+fn load_session_by_id_for_filter_respects_project_filter() {
+    let db = TempDatabase::new();
+    db.seed();
+
+    let matching = load_session_by_id_for_filter(
+        &db.path,
+        &AiAssistant::ALL,
+        &ProjectFilter::Project(2),
+        "session-b",
+    )
+    .expect("Session ID lookup with matching project failed");
+    let blocked = load_session_by_id_for_filter(
+        &db.path,
+        &AiAssistant::ALL,
+        &ProjectFilter::Project(1),
+        "session-b",
+    )
+    .expect("Session ID lookup with blocked project failed");
+
+    assert_eq!(matching.len(), 1);
+    assert_eq!(matching[0].id, "session-b");
+    assert!(blocked.is_empty());
+}
+
+#[test]
+fn load_session_by_id_for_filter_respects_pinned_filter() {
+    let db = TempDatabase::new();
+    db.seed();
+    db.connection
+        .execute(
+            "UPDATE sessions SET pinned_at = ?1 WHERE id = ?2",
+            rusqlite::params![123_i64, "session-b"],
+        )
+        .expect("Failed to pin fixture session");
+
+    let matching = load_session_by_id_for_filter(
+        &db.path,
+        &AiAssistant::ALL,
+        &ProjectFilter::Pinned,
+        "session-b",
+    )
+    .expect("Pinned session ID lookup failed");
+    let blocked = load_session_by_id_for_filter(
+        &db.path,
+        &AiAssistant::ALL,
+        &ProjectFilter::Pinned,
+        "session-a",
+    )
+    .expect("Unpinned session ID lookup failed");
+
+    assert_eq!(matching.len(), 1);
+    assert_eq!(matching[0].id, "session-b");
+    assert!(blocked.is_empty());
+}
+
+#[test]
+fn load_session_by_id_for_filter_returns_empty_for_unknown_id() {
+    let db = TempDatabase::new();
+    db.seed();
+
+    let sessions = load_session_by_id_for_filter(
+        &db.path,
+        &AiAssistant::ALL,
+        &ProjectFilter::AllSessions,
+        "missing-session",
+    )
+    .expect("Unknown session ID lookup failed");
+
+    assert!(sessions.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
Closes #135 

## Summary
- Add explicit `id:` query parsing in `SessionList` and route those queries to an exact `sessions.id` lookup instead of FTS.
- Add `load_session_by_id_for_filter` in `src/database/mod.rs` that preserves existing assistant/project/pinned/subagent filter behavior.
- Add focused tests for parser + empty-state behavior in `src/ui/session_list.rs` and integration coverage in `tests/search_sessions.rs`.

## Verification
- `cargo test --test search_sessions load_session_by_id_for_filter -- --nocapture`
- `cargo test session_list_id_search -- --nocapture`
- `cargo test session_id -- --nocapture`