### PR TITLE
feat: instrument session detail responsiveness

### DIFF
--- a/docs/reports/2026-05-01-session-detail-issue-127-clean-run-log-report.md
+++ b/docs/reports/2026-05-01-session-detail-issue-127-clean-run-log-report.md
@@ -110,7 +110,7 @@ Recorded values:
 - `max_push_duration_ms=0`
 - `total_duration_ms=7558`
 - `max_schedule_gap_ms=1398`
-- `open_to_factory_push_ms=7875`
+- `first_page_load_to_factory_push_ms=7875`
 
 Relevant log line:
 
@@ -147,7 +147,7 @@ Instead, the delay is concentrated between the moment the first page is already 
 
 The two strongest signals are:
 
-- `open_to_factory_push_ms=7875`
+- `first_page_load_to_factory_push_ms=7875`
 - `max_schedule_gap_ms=1398`
 
 This strongly suggests that the bottleneck is in the incremental render pipeline and main-loop scheduling behavior, not in the database layer.

--- a/docs/reports/2026-05-01-session-detail-issue-127-clean-run-log-report.md
+++ b/docs/reports/2026-05-01-session-detail-issue-127-clean-run-log-report.md
@@ -1,0 +1,188 @@
+# Session Detail Issue 127 Clean Run Log Report
+
+## Scope
+
+- Date: 2026-05-01
+- Target session: `019dc51a-f0cd-79c1-ba79-45fedac889c2`
+- AI assistant: Codex
+- Source log file: `/tmp/sessions-chronicle-issue-127.log`
+- Relevant design: `docs/superpowers/specs/2026-05-01-session-detail-responsiveness-instrumentation-design.md`
+
+## Scenario
+
+This run was captured specifically to remove the main source of noise from the earlier manual verification.
+
+The workflow was:
+
+1. Launch the app with a fresh redirected log file.
+2. Wait for background indexing to complete.
+3. Click directly on session `019dc51a-f0cd-79c1-ba79-45fedac889c2`.
+4. Do not perform any search before opening the session detail view.
+
+The application was launched with:
+
+```bash
+RUST_LOG=info,sessions_chronicle=debug sessions-chronicle > /tmp/sessions-chronicle-issue-127.log 2>&1
+```
+
+## Cleanliness Checks
+
+This run is materially cleaner than the previous one.
+
+### Indexing finished before the click
+
+The app logged:
+
+- `Background indexing complete: indexed=1238, skipped=687, removed=0`
+
+Relevant log line:
+
+- `/tmp/sessions-chronicle-issue-127.log:2983`
+
+### The detail view opened with no active search query
+
+The `SetSession` payload shows:
+
+- `search_query: None`
+
+Relevant log lines:
+
+- `/tmp/sessions-chronicle-issue-127.log:3028-3031`
+
+### No search-driven reload noise was present
+
+This capture does not show the extra paths seen in the previous run:
+
+- no `SearchPositionsLoaded`
+- no `SetMatchPositions`
+- no `Ignoring stale transcript page`
+- no `Session detail search update started` around the open sequence
+
+That makes this run suitable as the baseline manual verification for the pure session-open path.
+
+## Key Measurements
+
+### 1. Session metadata loading was negligible
+
+When the session was selected, the app logged:
+
+- `load_session took 730.509µs`
+
+Relevant log lines:
+
+- `/tmp/sessions-chronicle-issue-127.log:3018-3023`
+
+### 2. First transcript page loading was also negligible
+
+The first transcript page load logged:
+
+- `load_duration_ms=2`
+
+Relevant log lines:
+
+- `/tmp/sessions-chronicle-issue-127.log:3044-3046`
+
+### 3. First-page preparation remained effectively free
+
+The preparation step logged:
+
+- `Prepared first transcript page`
+- `display_item_count=33`
+- `build_duration_ms=0`
+
+Relevant log line:
+
+- `/tmp/sessions-chronicle-issue-127.log:3048`
+
+### 4. The dominant delay was still in render completion
+
+The key issue-127 metric logged:
+
+- `First transcript page factory push complete`
+
+Recorded values:
+
+- `request_id=1`
+- `source_row_count=75`
+- `display_item_count=33`
+- `batch_count=11`
+- `total_push_duration_ms=1`
+- `max_push_duration_ms=0`
+- `total_duration_ms=7558`
+- `max_schedule_gap_ms=1398`
+- `open_to_factory_push_ms=7875`
+
+Relevant log line:
+
+- `/tmp/sessions-chronicle-issue-127.log:3158`
+
+## Timeline Summary
+
+From the log sequence:
+
+- `Session detail open started` at line `3031`
+- deferred load accepted at line `3041`
+- first page loaded at line `3046`
+- first page prepared at line `3048`
+- first page factory push complete at line `3158`
+
+This means:
+
+- session metadata lookup was sub-millisecond;
+- first-page transcript fetch was 2 ms;
+- first-page preparation was effectively 0 ms;
+- the end-to-end wait to first factory-push completion was about 7.9 seconds.
+
+## Interpretation
+
+This clean run confirms the core performance diagnosis from issue 127.
+
+The user-visible delay is not explained by:
+
+- loading session metadata;
+- querying the first transcript page;
+- preparing the first display-item batch.
+
+Instead, the delay is concentrated between the moment the first page is already available and the moment the row factory finishes receiving the first page worth of items.
+
+The two strongest signals are:
+
+- `open_to_factory_push_ms=7875`
+- `max_schedule_gap_ms=1398`
+
+This strongly suggests that the bottleneck is in the incremental render pipeline and main-loop scheduling behavior, not in the database layer.
+
+## Comparison With the Earlier Noisy Run
+
+Compared with the earlier capture, this run is more trustworthy for the pure open path because it removes search-driven reload interference.
+
+Even with that noise removed, the headline result is effectively unchanged:
+
+- database work remains tiny;
+- first-page fetch remains tiny;
+- first factory push completion still lands around 7.5 to 8 seconds.
+
+That consistency makes the diagnosis much stronger.
+
+## Recommended Next Steps
+
+1. Use this clean run as the reference manual verification artifact for issue 127.
+2. Keep future measurements on the same session so numbers remain comparable.
+3. Focus the next optimization pass on:
+   - render batch scheduling,
+   - expensive transcript row widget construction,
+   - Markdown or `TextView` heavy rows,
+   - any main-loop starvation between queued batches.
+4. Do not spend time on database optimization for this issue unless a different session produces contradictory evidence.
+
+## Summary
+
+For the clean direct-open run of session `019dc51a-f0cd-79c1-ba79-45fedac889c2`, the logs show:
+
+- `load_session took 730.509µs`
+- first transcript page load took `2 ms`
+- first-page preparation took `0 ms`
+- first transcript page factory push completion took about `7.9 s`
+- maximum observed scheduling gap was about `1.4 s`
+
+This is a clean confirmation that the remaining responsiveness problem in `SessionDetail` is render-pipeline bound rather than database bound.

--- a/docs/reports/2026-05-01-session-detail-issue-127-log-report.md
+++ b/docs/reports/2026-05-01-session-detail-issue-127-log-report.md
@@ -63,7 +63,7 @@ First open cycle:
 - `Loaded first transcript page` at line `3095`
 - `Prepared first transcript page` at line `3097`
 - `First transcript page factory push complete` at line `3211`
-- `open_to_factory_push_ms=7835`
+- `first_page_load_to_factory_push_ms=7835`
 - `total_duration_ms=7792`
 - `max_schedule_gap_ms=1409`
 
@@ -72,7 +72,7 @@ Second open/reload cycle:
 - `Loaded first transcript page` at line `3250`
 - `Prepared first transcript page` at line `3252`
 - `First transcript page factory push complete` at line `3362`
-- `open_to_factory_push_ms=19045`
+- `first_page_load_to_factory_push_ms=19045`
 - `total_duration_ms=7664`
 - `max_schedule_gap_ms=1380`
 
@@ -141,13 +141,13 @@ The `max_schedule_gap_ms` values above one second are especially important becau
 
 - This was not a clean-room run after indexing completion.
 - The capture included an active search query, which triggered an additional reload path.
-- The `open_to_factory_push_ms` value from the second cycle (`19045`) should not be treated as a pure session-open metric because it spans a reloaded state, not only the initial open.
+- The `first_page_load_to_factory_push_ms` value from the second cycle (`19045`) should not be treated as a pure session-open metric because it spans a reloaded state, not only the initial open.
 
 ## Recommended Next Steps
 
 1. Re-run the same scenario after indexing completes and with no active search query in `SessionDetail`.
 2. Capture a clean open of the same session and compare:
-   - `open_to_factory_push_ms`
+   - `first_page_load_to_factory_push_ms`
    - `total_duration_ms`
    - `max_schedule_gap_ms`
 3. If the clean run still shows multi-second delays, focus the next optimization pass on render scheduling and expensive row/widget construction rather than database work.

--- a/docs/reports/2026-05-01-session-detail-issue-127-log-report.md
+++ b/docs/reports/2026-05-01-session-detail-issue-127-log-report.md
@@ -1,0 +1,167 @@
+# Session Detail Issue 127 Log Report
+
+## Scope
+
+- Date: 2026-05-01
+- Target session: `019dc51a-f0cd-79c1-ba79-45fedac889c2`
+- AI assistant: Codex
+- Source log file: `/tmp/sessions-chronicle-issue-127.log`
+- Relevant design: `docs/superpowers/specs/2026-05-01-session-detail-responsiveness-instrumentation-design.md`
+
+## Scenario
+
+This run captured structured tracing for a long Codex session opened in `SessionDetail`.
+
+The session metadata visible in the logs was:
+
+- `session_id`: `019dc51a-f0cd-79c1-ba79-45fedac889c2`
+- `message_count`: `244`
+- `first_prompt`: `Ton avis sur la branche`
+- `file_path`: `/home/mcizo/.codex/sessions/2026/04/25/rollout-2026-04-25T16-46-10-019dc51a-f0cd-79c1-ba79-45fedac889c2.jsonl`
+
+The application was launched with:
+
+```bash
+RUST_LOG=info,sessions_chronicle=debug sessions-chronicle > /tmp/sessions-chronicle-issue-127.log 2>&1
+```
+
+## Key Observations
+
+### 1. Session loading from the database was not the bottleneck
+
+When the session was selected, the app logged:
+
+- `load_session took 755.427µs`
+
+This indicates the initial session metadata fetch was effectively negligible compared with the user-visible delay.
+
+Relevant log lines:
+
+- `/tmp/sessions-chronicle-issue-127.log:3062-3064`
+
+### 2. First transcript page query time was also very small
+
+The first transcript page loads recorded:
+
+- `load_duration_ms=1` for request `2`
+- `load_duration_ms=3` for request `4`
+
+This again suggests the dominant delay is not the transcript page query itself.
+
+Relevant log lines:
+
+- `/tmp/sessions-chronicle-issue-127.log:3093-3095`
+- `/tmp/sessions-chronicle-issue-127.log:3248-3250`
+
+### 3. The dominant cost was between page preparation and first factory push completion
+
+The strongest signal in this run was the gap between a fast first-page load and a much later `First transcript page factory push complete` event.
+
+First open cycle:
+
+- `Session detail open started` at line `3073`
+- `Loaded first transcript page` at line `3095`
+- `Prepared first transcript page` at line `3097`
+- `First transcript page factory push complete` at line `3211`
+- `open_to_factory_push_ms=7835`
+- `total_duration_ms=7792`
+- `max_schedule_gap_ms=1409`
+
+Second open/reload cycle:
+
+- `Loaded first transcript page` at line `3250`
+- `Prepared first transcript page` at line `3252`
+- `First transcript page factory push complete` at line `3362`
+- `open_to_factory_push_ms=19045`
+- `total_duration_ms=7664`
+- `max_schedule_gap_ms=1380`
+
+The consistent pattern is:
+
+- data load is fast;
+- preparation is fast;
+- user-visible readiness is delayed by the incremental render pipeline and/or main-loop scheduling gaps.
+
+### 4. Search state polluted this capture
+
+This run did not start from a perfectly clean detail state.
+
+The logs show an active search query for the same session ID:
+
+- `SearchQueryChanged("id:019dc51a-f0cd-79c1-ba79-45fedac889c2")`
+- `Session detail search update started`
+- `SearchPositionsLoaded`
+- `SetMatchPositions`
+
+The logs also show a stale request being ignored:
+
+- `Ignoring stale transcript page for session 019dc51a-f0cd-79c1-ba79-45fedac889c2 at offset 0`
+
+This means the capture includes at least one search-driven reload path in addition to the plain open path.
+
+Relevant log lines:
+
+- `/tmp/sessions-chronicle-issue-127.log:3043-3055`
+- `/tmp/sessions-chronicle-issue-127.log:3082-3092`
+- `/tmp/sessions-chronicle-issue-127.log:3243-3247`
+
+### 5. Tool inspector selection looked fast in this sample
+
+After selecting a tool call in the session detail view, the inspector emitted:
+
+- `Session detail inspector tool call selected`
+- `Inspector tool call selection started`
+- `ToolCall ... load_duration_ms: 1`
+
+This suggests the inspected tool-call fetch itself was fast for this sample and does not appear to be the main bottleneck compared with transcript rendering.
+
+Relevant log lines:
+
+- `/tmp/sessions-chronicle-issue-127.log:3369-3380`
+- `/tmp/sessions-chronicle-issue-127.log:3386`
+
+## Interpretation
+
+This log run supports the original issue-127 hypothesis:
+
+- the slow part is not session metadata loading;
+- the slow part is not first-page SQL retrieval;
+- the dominant delay is inside the `SessionDetail` render pipeline after data is already available.
+
+More specifically, the measured gap points to work and scheduling in this area:
+
+- transcript row construction;
+- Markdown or `TextView`-heavy row setup;
+- row factory push batching;
+- main-loop scheduling gaps between render batches.
+
+The `max_schedule_gap_ms` values above one second are especially important because they suggest the end-to-end wait is not just raw CPU time spent building rows. The main loop is also taking large pauses between scheduled render batches.
+
+## Limitations
+
+- This was not a clean-room run after indexing completion.
+- The capture included an active search query, which triggered an additional reload path.
+- The `open_to_factory_push_ms` value from the second cycle (`19045`) should not be treated as a pure session-open metric because it spans a reloaded state, not only the initial open.
+
+## Recommended Next Steps
+
+1. Re-run the same scenario after indexing completes and with no active search query in `SessionDetail`.
+2. Capture a clean open of the same session and compare:
+   - `open_to_factory_push_ms`
+   - `total_duration_ms`
+   - `max_schedule_gap_ms`
+3. If the clean run still shows multi-second delays, focus the next optimization pass on render scheduling and expensive row/widget construction rather than database work.
+4. Keep the inspector instrumentation, but prioritize transcript rendering analysis first because the current sample does not show inspector-side loading as the primary issue.
+
+## Summary
+
+For session `019dc51a-f0cd-79c1-ba79-45fedac889c2`, the logs show that `SessionDetail` responsiveness is dominated by first-page render completion rather than database access.
+
+The strongest metrics from this run were:
+
+- `load_session took 755.427µs`
+- first transcript page load in `1-3 ms`
+- first factory push completion in roughly `7.8 s`
+- large batch scheduling gaps of roughly `1.4 s`
+
+That is exactly the kind of signal issue 127 instrumentation was meant to expose.

--- a/docs/superpowers/specs/2026-05-01-session-detail-responsiveness-instrumentation-design.md
+++ b/docs/superpowers/specs/2026-05-01-session-detail-responsiveness-instrumentation-design.md
@@ -60,7 +60,7 @@ When `SessionDetailMsg::SetSession` is handled, log a `Session detail open start
 - whether a search query is already active;
 - `query_len` when applicable.
 
-Store `session_opened_at: Option<Instant>` for the active open cycle. This is intentionally the only cross-stage timing state in `SessionDetail`; it exists to report `open_to_factory_push_ms` when the first page finishes pushing into the row factory. Replace it on each new `SetSession` and clear it when the session is cleared.
+Store `first_page_load_started_at: Option<Instant>` for the active first-page load cycle. This is intentionally the only cross-stage timing state in `SessionDetail`; it exists to report `first_page_load_to_factory_push_ms` when the first page finishes pushing into the row factory. Replace it whenever a first-page load starts and clear it when the session is cleared.
 
 The deferred first-page load path should log `Session detail deferred first page load started` when the delayed message is accepted. Include:
 
@@ -85,7 +85,7 @@ Add a specific `First transcript page factory push complete` event immediately b
 - `total_push_duration_ms`;
 - `max_push_duration_ms`;
 - `max_schedule_gap_ms`;
-- `open_to_factory_push_ms` when the current session open timestamp is available.
+- `first_page_load_to_factory_push_ms` when the current first-page load timestamp is available.
 
 This event should not imply a GTK frame has been painted. It means the first page has been pushed into the transcript row factory and is available for GTK to render. The wording deliberately avoids `visible` so the logs do not overstate what is measured.
 
@@ -234,7 +234,7 @@ The resulting log should contain all issue-127 coverage areas: open, first trans
 
 ## Implementation Decisions
 
-- Do not add a broad metrics state object. Add at most one timestamp field, such as `session_opened_at: Option<Instant>`, so the first-page factory push event can report `open_to_factory_push_ms` directly. Invalidate or replace it whenever transcript requests are invalidated for a new session open.
+- Do not add a broad metrics state object. Add at most one timestamp field, such as `first_page_load_started_at: Option<Instant>`, so the first-page factory push event can report `first_page_load_to_factory_push_ms` directly. Invalidate or replace it whenever transcript requests are invalidated for a first-page load.
 - Measure clear duration with a small wrapper/helper around `clear_messages_safely` that accepts a static reason string. Avoid changing clear behavior.
 - Use `info` for lifecycle milestones that map to issue-127 acceptance criteria, and `debug` for high-frequency or noisy details such as individual inspector render passes.
 

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -921,7 +921,7 @@ impl Component for SessionDetail {
                     .as_ref()
                     .is_some_and(|session| session.id == session_id);
                 if request_id == self.transcript_request_id && active_session_matches {
-                    tracing::info!(
+                    tracing::debug!(
                         request_id,
                         session_id = session_id.as_str(),
                         configured_delay_ms = DEFERRED_FIRST_PAGE_LOAD_DELAY_MS,

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -42,7 +42,7 @@ const DEFERRED_CLEAR_DELAY_MS: u64 = 250;
 pub struct SessionDetail {
     db_path: Arc<PathBuf>,
     session: Option<Session>,
-    session_opened_at: Option<Instant>,
+    first_page_load_started_at: Option<Instant>,
     messages: FactoryVecDeque<TranscriptRow>,
     initial_page_size: usize,
     page_size: usize,
@@ -123,7 +123,7 @@ struct RenderMetrics {
     total_push_duration_ms: u128,
     max_push_duration_ms: u128,
     max_schedule_gap_ms: u128,
-    open_to_factory_push_ms: Option<u128>,
+    first_page_load_to_factory_push_ms: Option<u128>,
     message_count: usize,
     tool_call_count: usize,
     tool_burst_count: usize,
@@ -770,7 +770,7 @@ impl Component for SessionDetail {
         let model = Self {
             db_path,
             session: None,
-            session_opened_at: None,
+            first_page_load_started_at: None,
             messages,
             initial_page_size: INITIAL_PAGE_SIZE,
             page_size: NEXT_PAGE_SIZE,
@@ -990,7 +990,7 @@ impl Component for SessionDetail {
                 self.invalidate_transcript_requests();
                 self.invalidate_search_requests();
                 self.session = None;
-                self.session_opened_at = None;
+                self.first_page_load_started_at = None;
                 self.clear_messages_safely_with_metrics("component_clear");
                 self.loaded_count = 0;
                 self.has_more_messages = false;
@@ -1550,7 +1550,7 @@ impl SessionDetail {
         self.has_more_messages = false;
         self.clear_pending_boundary_tool_rows();
         self.clear_messages_safely_with_metrics(clear_reason);
-        self.session_opened_at = Some(Instant::now());
+        self.first_page_load_started_at = Some(Instant::now());
 
         let request_id = self.transcript_request_id;
         let session_id = session_id.to_string();
@@ -1634,7 +1634,7 @@ impl SessionDetail {
     fn clear_for_navigation_back(&mut self) {
         self.invalidate_search_requests();
         self.session = None;
-        self.session_opened_at = None;
+        self.first_page_load_started_at = None;
         self.clear_messages_safely_with_metrics("navigation_back");
         self.loaded_count = 0;
         self.has_more_messages = false;
@@ -1700,7 +1700,7 @@ impl SessionDetail {
             return;
         }
 
-        let session_opened_at = self.session_opened_at;
+        let first_page_load_started_at = self.first_page_load_started_at;
 
         let Some(batch) = &mut self.pending_render_batch else {
             return;
@@ -1760,8 +1760,8 @@ impl SessionDetail {
             );
             self.schedule_transcript_render_batch(sender, request_id);
         } else {
-            let open_to_factory_push_ms = if offset == 0 {
-                session_opened_at.map(|opened_at| opened_at.elapsed().as_millis())
+            let first_page_load_to_factory_push_ms = if offset == 0 {
+                first_page_load_started_at.map(|started_at| started_at.elapsed().as_millis())
             } else {
                 None
             };
@@ -1776,7 +1776,7 @@ impl SessionDetail {
                     max_push_duration_ms,
                     total_duration_ms,
                     max_schedule_gap_ms,
-                    open_to_factory_push_ms,
+                    first_page_load_to_factory_push_ms,
                     "First transcript page factory push complete"
                 );
             }
@@ -1806,7 +1806,7 @@ impl SessionDetail {
                 total_push_duration_ms,
                 max_push_duration_ms,
                 max_schedule_gap_ms,
-                open_to_factory_push_ms,
+                first_page_load_to_factory_push_ms,
                 message_count: row_kind_counts.message_count,
                 tool_call_count: row_kind_counts.tool_call_count,
                 tool_burst_count: row_kind_counts.tool_burst_count,
@@ -2725,12 +2725,33 @@ fn synthetic_measurement(input: &str) -> String {\n\
             search_query: None,
         });
 
-        pump_main_context(|| controller.state().get().model.session_opened_at.is_some());
-        assert!(controller.state().get().model.session_opened_at.is_some());
+        pump_main_context(|| {
+            controller
+                .state()
+                .get()
+                .model
+                .first_page_load_started_at
+                .is_some()
+        });
+        assert!(
+            controller
+                .state()
+                .get()
+                .model
+                .first_page_load_started_at
+                .is_some()
+        );
 
         controller.emit(SessionDetailMsg::Clear);
         pump_main_context(|| controller.state().get().model.session.is_none());
-        assert!(controller.state().get().model.session_opened_at.is_none());
+        assert!(
+            controller
+                .state()
+                .get()
+                .model
+                .first_page_load_started_at
+                .is_none()
+        );
     }
 
     #[gtk::test]
@@ -2862,7 +2883,7 @@ fn synthetic_measurement(input: &str) -> String {\n\
         assert_eq!(metrics.tool_call_count, 0);
         assert_eq!(metrics.tool_burst_count, 0);
         assert_eq!(metrics.subagent_count, 0);
-        assert!(metrics.open_to_factory_push_ms.is_some());
+        assert!(metrics.first_page_load_to_factory_push_ms.is_some());
     }
 
     #[test]

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -130,6 +130,13 @@ struct RenderMetrics {
     subagent_count: usize,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ClearMessagesMetrics {
+    row_count_before: usize,
+    had_pending_render: bool,
+    duration_ms: u128,
+}
+
 impl std::fmt::Debug for PendingRenderBatch {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("PendingRenderBatch")
@@ -221,6 +228,7 @@ pub enum SessionDetailCmd {
     SearchPositionsLoaded {
         request_id: u64,
         session_id: String,
+        load_duration_ms: u128,
         result: Result<Vec<MatchPosition>, String>,
     },
 }
@@ -253,6 +261,7 @@ impl std::fmt::Debug for SessionDetailCmd {
             Self::SearchPositionsLoaded {
                 request_id,
                 session_id,
+                load_duration_ms,
                 result,
             } => {
                 let result_summary = match result {
@@ -262,6 +271,7 @@ impl std::fmt::Debug for SessionDetailCmd {
                 f.debug_struct("SearchPositionsLoaded")
                     .field("request_id", request_id)
                     .field("session_id", session_id)
+                    .field("load_duration_ms", load_duration_ms)
                     .field("result", &result_summary)
                     .finish()
             }
@@ -832,7 +842,7 @@ impl Component for SessionDetail {
                 let query_len = normalized.as_ref().map(|query| query.len()).unwrap_or(0);
                 self.session_opened_at = Some(Instant::now());
                 self.session = Some(session);
-                self.start_first_page_load(&sender, &session_id, true);
+                self.start_first_page_load(&sender, &session_id, true, "open");
                 tracing::info!(
                     request_id = self.transcript_request_id,
                     session_id = session_id.as_str(),
@@ -853,6 +863,18 @@ impl Component for SessionDetail {
                     let trimmed = query.trim().to_string();
                     (!trimmed.is_empty()).then_some(trimmed)
                 });
+                let active_session_id = self.session.as_ref().map(|session| session.id.as_str());
+                let previous_match_count = self.match_positions.len();
+                let query_len = normalized.as_ref().map(|query| query.len()).unwrap_or(0);
+                let will_load_match_positions = self.session.is_some() && normalized.is_some();
+                tracing::info!(
+                    session_id = active_session_id,
+                    has_query = normalized.is_some(),
+                    query_len,
+                    previous_match_count,
+                    will_load_match_positions,
+                    "Session detail search update started"
+                );
                 self.search_query = normalized.clone();
                 self.invalidate_search_requests();
                 self.reset_search_matches();
@@ -861,7 +883,7 @@ impl Component for SessionDetail {
                     let request_id = self.search_request_id;
                     self.spawn_match_positions_load(&sender, request_id, session.id.clone(), query);
                 } else {
-                    self.reload_current_session(&sender);
+                    self.reload_current_session(&sender, "search");
                 }
             }
             SessionDetailMsg::SetMatchPositions {
@@ -882,11 +904,22 @@ impl Component for SessionDetail {
                     return;
                 }
 
+                let match_count = positions.len();
+                let will_schedule_initial_jump = match_count > 0;
+                tracing::info!(
+                    request_id,
+                    session_id = session_id.as_str(),
+                    match_count,
+                    will_schedule_initial_jump,
+                    loaded_count = self.loaded_count,
+                    "Session detail search positions applied"
+                );
+
                 self.match_positions = positions;
                 self.clamp_current_match();
                 self.pending_jump = None;
                 self.loading_jump = false;
-                self.start_first_page_load(&sender, &session_id, false);
+                self.start_first_page_load(&sender, &session_id, false, "search");
                 if !self.match_positions.is_empty() {
                     self.jump_to(0, &sender);
                 }
@@ -952,14 +985,14 @@ impl Component for SessionDetail {
                 self.search_query = None;
                 self.invalidate_search_requests();
                 self.reset_search_matches();
-                self.reload_current_session(&sender);
+                self.reload_current_session(&sender, "clear_search");
             }
             SessionDetailMsg::Clear => {
                 self.invalidate_transcript_requests();
                 self.invalidate_search_requests();
                 self.session = None;
                 self.session_opened_at = None;
-                self.clear_messages_safely();
+                self.clear_messages_safely_with_metrics("component_clear");
                 self.loaded_count = 0;
                 self.has_more_messages = false;
                 self.loading_first_page = false;
@@ -973,6 +1006,13 @@ impl Component for SessionDetail {
             }
             SessionDetailMsg::InspectToolCall(id) => {
                 if let Some(session_id) = self.session.as_ref().map(|s| s.id.clone()) {
+                    tracing::info!(
+                        session_id = session_id.as_str(),
+                        tool_call_id = id.as_str(),
+                        previous_open = self.inspector_open,
+                        new_open = true,
+                        "Session detail inspector tool call selected"
+                    );
                     self.inspector.emit(ToolInspectorPaneMsg::SelectToolCall {
                         session_id,
                         tool_call_id: id,
@@ -982,6 +1022,13 @@ impl Component for SessionDetail {
             }
             SessionDetailMsg::InspectSubagent(id) => {
                 if let Some(session_id) = self.session.as_ref().map(|s| s.id.clone()) {
+                    tracing::info!(
+                        session_id = session_id.as_str(),
+                        subagent_id = id.as_str(),
+                        previous_open = self.inspector_open,
+                        new_open = true,
+                        "Session detail inspector subagent selected"
+                    );
                     self.inspector.emit(ToolInspectorPaneMsg::SelectSubagent {
                         session_id,
                         subagent_id: id,
@@ -991,6 +1038,13 @@ impl Component for SessionDetail {
             }
             SessionDetailMsg::InspectReasoning(transcript_item_index) => {
                 if let Some(session_id) = self.session.as_ref().map(|s| s.id.clone()) {
+                    tracing::info!(
+                        session_id = session_id.as_str(),
+                        transcript_item_index,
+                        previous_open = self.inspector_open,
+                        new_open = true,
+                        "Session detail inspector reasoning selected"
+                    );
                     self.inspector.emit(ToolInspectorPaneMsg::SelectReasoning {
                         session_id,
                         transcript_item_index,
@@ -999,13 +1053,29 @@ impl Component for SessionDetail {
                 }
             }
             SessionDetailMsg::ToggleInspector => {
-                self.set_inspector_open(!self.inspector_open, &sender);
+                let new_open = !self.inspector_open;
+                tracing::info!(
+                    previous_open = self.inspector_open,
+                    new_open,
+                    "Session detail inspector toggled"
+                );
+                self.set_inspector_open(new_open, &sender);
             }
             SessionDetailMsg::CloseInspector => {
+                tracing::info!(
+                    previous_open = self.inspector_open,
+                    new_open = false,
+                    "Session detail inspector close requested"
+                );
                 self.set_inspector_open(false, &sender);
             }
             SessionDetailMsg::InspectorWidgetVisibilityChanged(visible) => {
                 if self.inspector_open != visible {
+                    tracing::info!(
+                        previous_open = self.inspector_open,
+                        new_open = visible,
+                        "Session detail inspector widget visibility changed"
+                    );
                     self.inspector_open = visible;
                     sender
                         .output(SessionDetailOutput::InspectorVisibilityChanged(visible))
@@ -1033,8 +1103,22 @@ impl Component for SessionDetail {
             SessionDetailCmd::SearchPositionsLoaded {
                 request_id,
                 session_id,
+                load_duration_ms,
                 result,
             } => {
+                let success = result.is_ok();
+                let match_count = result
+                    .as_ref()
+                    .map(|positions| positions.len())
+                    .unwrap_or(0);
+                tracing::info!(
+                    request_id,
+                    session_id = session_id.as_str(),
+                    success,
+                    match_count,
+                    load_duration_ms,
+                    "Session detail search positions loaded"
+                );
                 let positions = match result {
                     Ok(positions) => positions,
                     Err(err) => {
@@ -1416,13 +1500,16 @@ impl SessionDetail {
     ) {
         let db_path = self.db_path.clone();
         sender.spawn_oneshot_command(move || {
+            let started_at = Instant::now();
             let result = crate::database::open_connection(&db_path)
                 .and_then(|db| find_session_match_positions(&db, &session_id, &query))
                 .map_err(|err| format!("{err:#}"));
+            let load_duration_ms = started_at.elapsed().as_millis();
 
             SessionDetailCmd::SearchPositionsLoaded {
                 request_id,
                 session_id,
+                load_duration_ms,
                 result,
             }
         });
@@ -1455,6 +1542,7 @@ impl SessionDetail {
         sender: &ComponentSender<Self>,
         session_id: &str,
         defer: bool,
+        clear_reason: &'static str,
     ) {
         self.invalidate_transcript_requests();
         self.loading_first_page = true;
@@ -1462,7 +1550,7 @@ impl SessionDetail {
         self.loaded_count = 0;
         self.has_more_messages = false;
         self.clear_pending_boundary_tool_rows();
-        self.clear_messages_safely();
+        self.clear_messages_safely_with_metrics(clear_reason);
 
         let request_id = self.transcript_request_id;
         let session_id = session_id.to_string();
@@ -1547,7 +1635,7 @@ impl SessionDetail {
         self.invalidate_search_requests();
         self.session = None;
         self.session_opened_at = None;
-        self.clear_messages_safely();
+        self.clear_messages_safely_with_metrics("navigation_back");
         self.loaded_count = 0;
         self.has_more_messages = false;
         self.search_query = None;
@@ -1744,7 +1832,7 @@ impl SessionDetail {
         let highlight = self.search_query.clone();
         let db_path = self.db_path.clone();
         self.track_pending_boundary_tool_rows(&rows);
-        self.clear_messages_safely();
+        self.clear_messages_safely_with_metrics("first_page_apply");
         let build_started_at = Instant::now();
         let source_row_count = rows.len();
         let matched_item_indexes = self.current_match_item_indexes();
@@ -1786,7 +1874,7 @@ impl SessionDetail {
         );
 
         if offset == 0 {
-            self.clear_messages_safely();
+            self.clear_messages_safely_with_metrics("transcript_error");
             self.loaded_count = 0;
             self.has_more_messages = false;
             self.clear_pending_boundary_tool_rows();
@@ -1951,10 +2039,14 @@ impl SessionDetail {
         }
     }
 
-    fn reload_current_session(&mut self, sender: &ComponentSender<Self>) {
+    fn reload_current_session(
+        &mut self,
+        sender: &ComponentSender<Self>,
+        clear_reason: &'static str,
+    ) {
         if let Some(session) = &self.session {
             let session_id = session.id.clone();
-            self.start_first_page_load(sender, &session_id, false);
+            self.start_first_page_load(sender, &session_id, false, clear_reason);
         }
     }
 
@@ -2139,6 +2231,26 @@ impl SessionDetail {
         self.release_focus_from_transcript_if_needed();
         self.messages.guard().clear();
         self.display_targets_by_item_index.clear();
+    }
+
+    fn clear_messages_safely_with_metrics(&mut self, reason: &'static str) -> ClearMessagesMetrics {
+        let row_count_before = self.messages.len();
+        let had_pending_render = self.pending_render_batch.is_some();
+        let started_at = Instant::now();
+        self.clear_messages_safely();
+        let duration_ms = started_at.elapsed().as_millis();
+        tracing::info!(
+            reason,
+            row_count_before,
+            had_pending_render,
+            duration_ms,
+            "Cleared session detail transcript rows"
+        );
+        ClearMessagesMetrics {
+            row_count_before,
+            had_pending_render,
+            duration_ms,
+        }
     }
 
     /// Avoid GTK focus traversing a row subtree while it is being replaced.
@@ -2619,6 +2731,48 @@ fn synthetic_measurement(input: &str) -> String {\n\
         controller.emit(SessionDetailMsg::Clear);
         pump_main_context(|| controller.state().get().model.session.is_none());
         assert!(controller.state().get().model.session_opened_at.is_none());
+    }
+
+    #[gtk::test]
+    fn clear_message_clears_rows_and_targets() {
+        let temp_db = tempfile::NamedTempFile::new().expect("temp db");
+        seed_message_transcript(temp_db.path(), "test-session-123", INITIAL_PAGE_SIZE);
+
+        let controller = SessionDetail::builder().launch(temp_db.path().to_path_buf());
+        controller.emit(SessionDetailMsg::SetSession {
+            session: Box::new(build_test_session(None, None, 0, 0, 0)),
+            search_query: None,
+        });
+
+        pump_main_context(|| {
+            let parts = controller.state().get();
+            parts.model.pending_render_batch.is_none()
+                && parts.model.messages.len() == INITIAL_PAGE_SIZE
+        });
+
+        controller.emit(SessionDetailMsg::Clear);
+        pump_main_context(|| {
+            let parts = controller.state().get();
+            parts.model.session.is_none()
+        });
+
+        let parts = controller.state().get();
+        assert_eq!(parts.model.messages.len(), 0);
+        assert!(parts.model.display_targets_by_item_index.is_empty());
+    }
+
+    #[test]
+    fn search_positions_loaded_debug_includes_load_duration() {
+        let cmd = SessionDetailCmd::SearchPositionsLoaded {
+            request_id: 7,
+            session_id: "session-1".to_string(),
+            load_duration_ms: 12,
+            result: Ok(vec![MatchPosition { item_index: 3 }]),
+        };
+
+        let debug = format!("{cmd:?}");
+        assert!(debug.contains("load_duration_ms"));
+        assert!(debug.contains("12"));
     }
 
     #[gtk::test]

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -42,6 +42,7 @@ const DEFERRED_CLEAR_DELAY_MS: u64 = 250;
 pub struct SessionDetail {
     db_path: Arc<PathBuf>,
     session: Option<Session>,
+    session_opened_at: Option<Instant>,
     messages: FactoryVecDeque<TranscriptRow>,
     initial_page_size: usize,
     page_size: usize,
@@ -122,6 +123,7 @@ struct RenderMetrics {
     total_push_duration_ms: u128,
     max_push_duration_ms: u128,
     max_schedule_gap_ms: u128,
+    open_to_factory_push_ms: Option<u128>,
     message_count: usize,
     tool_call_count: usize,
     tool_burst_count: usize,
@@ -758,6 +760,7 @@ impl Component for SessionDetail {
         let model = Self {
             db_path,
             session: None,
+            session_opened_at: None,
             messages,
             initial_page_size: INITIAL_PAGE_SIZE,
             page_size: NEXT_PAGE_SIZE,
@@ -824,8 +827,20 @@ impl Component for SessionDetail {
                 self.reset_search_matches();
                 let session = *session;
                 let session_id = session.id.clone();
+                let message_count = session.message_count;
+                let has_search_query = normalized.is_some();
+                let query_len = normalized.as_ref().map(|query| query.len()).unwrap_or(0);
+                self.session_opened_at = Some(Instant::now());
                 self.session = Some(session);
                 self.start_first_page_load(&sender, &session_id, true);
+                tracing::info!(
+                    request_id = self.transcript_request_id,
+                    session_id = session_id.as_str(),
+                    message_count,
+                    has_search_query,
+                    query_len,
+                    "Session detail open started"
+                );
                 if let Some(query) = normalized {
                     let request_id = self.search_request_id;
                     self.spawn_match_positions_load(&sender, request_id, session_id.clone(), query);
@@ -906,6 +921,12 @@ impl Component for SessionDetail {
                     .as_ref()
                     .is_some_and(|session| session.id == session_id);
                 if request_id == self.transcript_request_id && active_session_matches {
+                    tracing::info!(
+                        request_id,
+                        session_id = session_id.as_str(),
+                        configured_delay_ms = DEFERRED_FIRST_PAGE_LOAD_DELAY_MS,
+                        "Session detail deferred first page load started"
+                    );
                     self.spawn_transcript_page_load(
                         &sender,
                         request_id,
@@ -937,6 +958,7 @@ impl Component for SessionDetail {
                 self.invalidate_transcript_requests();
                 self.invalidate_search_requests();
                 self.session = None;
+                self.session_opened_at = None;
                 self.clear_messages_safely();
                 self.loaded_count = 0;
                 self.has_more_messages = false;
@@ -1524,6 +1546,7 @@ impl SessionDetail {
     fn clear_for_navigation_back(&mut self) {
         self.invalidate_search_requests();
         self.session = None;
+        self.session_opened_at = None;
         self.clear_messages_safely();
         self.loaded_count = 0;
         self.has_more_messages = false;
@@ -1589,6 +1612,8 @@ impl SessionDetail {
             return;
         }
 
+        let session_opened_at = self.session_opened_at;
+
         let Some(batch) = &mut self.pending_render_batch else {
             return;
         };
@@ -1647,6 +1672,26 @@ impl SessionDetail {
             );
             self.schedule_transcript_render_batch(sender, request_id);
         } else {
+            let open_to_factory_push_ms = if offset == 0 {
+                session_opened_at.map(|opened_at| opened_at.elapsed().as_millis())
+            } else {
+                None
+            };
+            if offset == 0 {
+                tracing::info!(
+                    request_id,
+                    offset,
+                    source_row_count,
+                    display_item_count = total_items,
+                    batch_count,
+                    total_push_duration_ms,
+                    max_push_duration_ms,
+                    total_duration_ms,
+                    max_schedule_gap_ms,
+                    open_to_factory_push_ms,
+                    "First transcript page factory push complete"
+                );
+            }
             tracing::info!(
                 request_id,
                 offset,
@@ -1673,6 +1718,7 @@ impl SessionDetail {
                 total_push_duration_ms,
                 max_push_duration_ms,
                 max_schedule_gap_ms,
+                open_to_factory_push_ms,
                 message_count: row_kind_counts.message_count,
                 tool_call_count: row_kind_counts.tool_call_count,
                 tool_burst_count: row_kind_counts.tool_burst_count,
@@ -2557,6 +2603,25 @@ fn synthetic_measurement(input: &str) -> String {\n\
     }
 
     #[gtk::test]
+    fn session_open_timestamp_tracks_active_session_lifecycle() {
+        let temp_db = tempfile::NamedTempFile::new().expect("temp db");
+        seed_message_transcript(temp_db.path(), "test-session-123", INITIAL_PAGE_SIZE);
+
+        let controller = SessionDetail::builder().launch(temp_db.path().to_path_buf());
+        controller.emit(SessionDetailMsg::SetSession {
+            session: Box::new(build_test_session(None, None, 0, 0, 0)),
+            search_query: None,
+        });
+
+        pump_main_context(|| controller.state().get().model.session_opened_at.is_some());
+        assert!(controller.state().get().model.session_opened_at.is_some());
+
+        controller.emit(SessionDetailMsg::Clear);
+        pump_main_context(|| controller.state().get().model.session.is_none());
+        assert!(controller.state().get().model.session_opened_at.is_none());
+    }
+
+    #[gtk::test]
     fn session_detail_loads_transcript_pages_incrementally() {
         let temp_db = tempfile::NamedTempFile::new().expect("temp db");
         seed_message_transcript(temp_db.path(), "test-session-123", INITIAL_PAGE_SIZE + 5);
@@ -2643,6 +2708,7 @@ fn synthetic_measurement(input: &str) -> String {\n\
         assert_eq!(metrics.tool_call_count, 0);
         assert_eq!(metrics.tool_burst_count, 0);
         assert_eq!(metrics.subagent_count, 0);
+        assert!(metrics.open_to_factory_push_ms.is_some());
     }
 
     #[test]

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -840,7 +840,6 @@ impl Component for SessionDetail {
                 let message_count = session.message_count;
                 let has_search_query = normalized.is_some();
                 let query_len = normalized.as_ref().map(|query| query.len()).unwrap_or(0);
-                self.session_opened_at = Some(Instant::now());
                 self.session = Some(session);
                 self.start_first_page_load(&sender, &session_id, true, "open");
                 tracing::info!(
@@ -1551,6 +1550,7 @@ impl SessionDetail {
         self.has_more_messages = false;
         self.clear_pending_boundary_tool_rows();
         self.clear_messages_safely_with_metrics(clear_reason);
+        self.session_opened_at = Some(Instant::now());
 
         let request_id = self.transcript_request_id;
         let session_id = session_id.to_string();

--- a/src/ui/tool_inspector_pane.rs
+++ b/src/ui/tool_inspector_pane.rs
@@ -1,6 +1,7 @@
 use std::cell::Cell;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Instant;
 
 use adw::prelude::*;
 use chrono::TimeZone;
@@ -209,22 +210,26 @@ pub enum ToolInspectorPaneCmd {
         request_id: u64,
         session_id: String,
         tool_call_id: String,
+        load_duration_ms: u128,
         result: Result<Option<ToolCall>, String>,
     },
     Subagent {
         request_id: u64,
         session_id: String,
         subagent_id: String,
+        load_duration_ms: u128,
         subagent_result: Result<Option<Subagent>, String>,
         tools_result: Result<Vec<ToolCall>, String>,
     },
     Reasoning {
         request_id: u64,
+        load_duration_ms: u128,
         result: Result<Option<ReasoningAttachment>, String>,
     },
     DrillTool {
         session_id: String,
         tool_call_id: String,
+        load_duration_ms: u128,
         result: Result<Option<ToolCall>, String>,
     },
 }
@@ -319,39 +324,56 @@ impl Component for ToolInspectorPane {
                 request_id,
                 session_id,
                 tool_call_id,
+                load_duration_ms,
                 result,
-            } => self.apply_tool_call_cmd(request_id, &session_id, &tool_call_id, result),
+            } => self.apply_tool_call_cmd(
+                request_id,
+                &session_id,
+                &tool_call_id,
+                load_duration_ms,
+                result,
+            ),
             ToolInspectorPaneCmd::Subagent {
                 request_id,
                 session_id,
                 subagent_id,
+                load_duration_ms,
                 subagent_result,
                 tools_result,
             } => self.apply_subagent_cmd(
                 request_id,
                 &session_id,
                 &subagent_id,
+                load_duration_ms,
                 subagent_result,
                 tools_result,
             ),
-            ToolInspectorPaneCmd::Reasoning { request_id, result } => {
-                self.apply_reasoning_cmd(request_id, result)
-            }
+            ToolInspectorPaneCmd::Reasoning {
+                request_id,
+                load_duration_ms,
+                result,
+            } => self.apply_reasoning_cmd(request_id, load_duration_ms, result),
             ToolInspectorPaneCmd::DrillTool {
                 session_id,
                 tool_call_id,
+                load_duration_ms,
                 result,
-            } => self.apply_drill_tool_cmd(&session_id, &tool_call_id, result),
+            } => self.apply_drill_tool_cmd(&session_id, &tool_call_id, load_duration_ms, result),
         }
     }
 
     fn post_view(&self, _widgets: &mut Self::Widgets) {
+        let started_at = Instant::now();
         self.content_stack
             .set_visible_child_name(self.visible_page_name());
         self.render_tool_call_section();
         self.render_subagent_section();
         self.render_reasoning_section();
         self.sync_drilldown_page();
+        tracing::debug!(
+            duration_ms = started_at.elapsed().as_millis(),
+            "Updated tool inspector pane view"
+        );
     }
 }
 
@@ -381,13 +403,25 @@ impl ToolInspectorPane {
             tool_call_id: tool_call_id.clone(),
         };
         let request_id = self.begin_selection_load();
-        let db_path = self.db_path.clone();
-        sender.spawn_oneshot_command(move || ToolInspectorPaneCmd::ToolCall {
+        tracing::info!(
             request_id,
-            session_id: session_id.clone(),
-            tool_call_id: tool_call_id.clone(),
-            result: load_tool_call(db_path.as_path(), &session_id, &tool_call_id)
-                .map_err(|err| err.to_string()),
+            session_id = session_id.as_str(),
+            tool_call_id = tool_call_id.as_str(),
+            "Inspector tool call selection started"
+        );
+        let db_path = self.db_path.clone();
+        sender.spawn_oneshot_command(move || {
+            let started_at = Instant::now();
+            let result = load_tool_call(db_path.as_path(), &session_id, &tool_call_id)
+                .map_err(|err| err.to_string());
+            let load_duration_ms = started_at.elapsed().as_millis();
+            ToolInspectorPaneCmd::ToolCall {
+                request_id,
+                session_id: session_id.clone(),
+                tool_call_id: tool_call_id.clone(),
+                load_duration_ms,
+                result,
+            }
         });
     }
 
@@ -402,19 +436,29 @@ impl ToolInspectorPane {
             subagent_id: subagent_id.clone(),
         };
         let request_id = self.begin_selection_load();
-        let db_path = self.db_path.clone();
-        sender.spawn_oneshot_command(move || ToolInspectorPaneCmd::Subagent {
+        tracing::info!(
             request_id,
-            session_id: session_id.clone(),
-            subagent_id: subagent_id.clone(),
-            subagent_result: load_subagent(db_path.as_path(), &session_id, &subagent_id)
-                .map_err(|err| err.to_string()),
-            tools_result: load_tool_calls_for_subagent(
-                db_path.as_path(),
-                &session_id,
-                &subagent_id,
-            )
-            .map_err(|err| err.to_string()),
+            session_id = session_id.as_str(),
+            subagent_id = subagent_id.as_str(),
+            "Inspector subagent selection started"
+        );
+        let db_path = self.db_path.clone();
+        sender.spawn_oneshot_command(move || {
+            let started_at = Instant::now();
+            let subagent_result = load_subagent(db_path.as_path(), &session_id, &subagent_id)
+                .map_err(|err| err.to_string());
+            let tools_result =
+                load_tool_calls_for_subagent(db_path.as_path(), &session_id, &subagent_id)
+                    .map_err(|err| err.to_string());
+            let load_duration_ms = started_at.elapsed().as_millis();
+            ToolInspectorPaneCmd::Subagent {
+                request_id,
+                session_id: session_id.clone(),
+                subagent_id: subagent_id.clone(),
+                load_duration_ms,
+                subagent_result,
+                tools_result,
+            }
         });
     }
 
@@ -429,15 +473,24 @@ impl ToolInspectorPane {
             transcript_item_index,
         };
         let request_id = self.begin_selection_load();
-        let db_path = self.db_path.clone();
-        sender.spawn_oneshot_command(move || ToolInspectorPaneCmd::Reasoning {
+        tracing::info!(
             request_id,
-            result: load_reasoning_attachment(
-                db_path.as_path(),
-                &session_id,
-                transcript_item_index,
-            )
-            .map_err(|err| err.to_string()),
+            session_id = session_id.as_str(),
+            transcript_item_index,
+            "Inspector reasoning selection started"
+        );
+        let db_path = self.db_path.clone();
+        sender.spawn_oneshot_command(move || {
+            let started_at = Instant::now();
+            let result =
+                load_reasoning_attachment(db_path.as_path(), &session_id, transcript_item_index)
+                    .map_err(|err| err.to_string());
+            let load_duration_ms = started_at.elapsed().as_millis();
+            ToolInspectorPaneCmd::Reasoning {
+                request_id,
+                load_duration_ms,
+                result,
+            }
         });
     }
 
@@ -465,12 +518,23 @@ impl ToolInspectorPane {
 
         self.pending_drill_tool_id = Some(tool_call_id.clone());
         let selection_session_id = session_id.clone();
+        tracing::info!(
+            session_id = selection_session_id.as_str(),
+            tool_call_id = tool_call_id.as_str(),
+            "Inspector drill-down tool selection started"
+        );
         let db_path = self.db_path.clone();
-        sender.spawn_oneshot_command(move || ToolInspectorPaneCmd::DrillTool {
-            session_id: selection_session_id.clone(),
-            tool_call_id: tool_call_id.clone(),
-            result: load_tool_call(db_path.as_path(), &selection_session_id, &tool_call_id)
-                .map_err(|err| err.to_string()),
+        sender.spawn_oneshot_command(move || {
+            let started_at = Instant::now();
+            let result = load_tool_call(db_path.as_path(), &selection_session_id, &tool_call_id)
+                .map_err(|err| err.to_string());
+            let load_duration_ms = started_at.elapsed().as_millis();
+            ToolInspectorPaneCmd::DrillTool {
+                session_id: selection_session_id.clone(),
+                tool_call_id: tool_call_id.clone(),
+                load_duration_ms,
+                result,
+            }
         });
     }
 
@@ -501,11 +565,24 @@ impl ToolInspectorPane {
         request_id: u64,
         session_id: &str,
         tool_call_id: &str,
+        load_duration_ms: u128,
         result: Result<Option<ToolCall>, String>,
     ) {
         if !self.accept_request_result(request_id, &result) {
             return;
         }
+
+        let success = result.is_ok();
+        let found = result.as_ref().map(|tool| tool.is_some()).unwrap_or(false);
+        tracing::info!(
+            request_id,
+            session_id,
+            tool_call_id,
+            success,
+            found,
+            load_duration_ms,
+            "Inspector tool call load completed"
+        );
 
         match result {
             Ok(tool_call) => {
@@ -530,6 +607,7 @@ impl ToolInspectorPane {
         request_id: u64,
         session_id: &str,
         subagent_id: &str,
+        load_duration_ms: u128,
         subagent_result: Result<Option<Subagent>, String>,
         tools_result: Result<Vec<ToolCall>, String>,
     ) {
@@ -544,6 +622,23 @@ impl ToolInspectorPane {
         {
             return;
         }
+
+        let success = subagent_result.is_ok();
+        let found = subagent_result
+            .as_ref()
+            .map(|subagent| subagent.is_some())
+            .unwrap_or(false);
+        let subagent_tools_count = tools_result.as_ref().map(|tools| tools.len()).unwrap_or(0);
+        tracing::info!(
+            request_id,
+            session_id,
+            subagent_id,
+            success,
+            found,
+            subagent_tools_count,
+            load_duration_ms,
+            "Inspector subagent load completed"
+        );
 
         match subagent_result {
             Ok(subagent) => {
@@ -574,11 +669,25 @@ impl ToolInspectorPane {
     fn apply_reasoning_cmd(
         &mut self,
         request_id: u64,
+        load_duration_ms: u128,
         result: Result<Option<ReasoningAttachment>, String>,
     ) {
         if !self.accept_request_result(request_id, &result) {
             return;
         }
+
+        let success = result.is_ok();
+        let found = result
+            .as_ref()
+            .map(|reasoning| reasoning.is_some())
+            .unwrap_or(false);
+        tracing::info!(
+            request_id,
+            success,
+            found,
+            load_duration_ms,
+            "Inspector reasoning load completed"
+        );
 
         match result {
             Ok(attachment) => {
@@ -595,6 +704,7 @@ impl ToolInspectorPane {
         &mut self,
         session_id: &str,
         tool_call_id: &str,
+        load_duration_ms: u128,
         result: Result<Option<ToolCall>, String>,
     ) {
         if !matches!(
@@ -610,6 +720,17 @@ impl ToolInspectorPane {
         if self.pending_drill_tool_id.as_deref() != Some(tool_call_id) {
             return;
         }
+
+        let success = result.is_ok();
+        let found = result.as_ref().map(|tool| tool.is_some()).unwrap_or(false);
+        tracing::info!(
+            session_id,
+            tool_call_id,
+            success,
+            found,
+            load_duration_ms,
+            "Inspector drill-down tool load completed"
+        );
 
         self.pending_drill_tool_id = None;
         match result {
@@ -668,6 +789,7 @@ impl ToolInspectorPane {
     }
 
     fn rebuild_subagent_tool_rows(&self) {
+        let started_at = Instant::now();
         while let Some(child) = self.subagent_tools_list.first_child() {
             self.subagent_tools_list.remove(&child);
         }
@@ -676,6 +798,11 @@ impl ToolInspectorPane {
             self.subagent_tools_list
                 .append(&build_subagent_tool_row(tool, &self.sender));
         }
+        tracing::debug!(
+            subagent_tools_count = self.subagent_tools.len(),
+            duration_ms = started_at.elapsed().as_millis(),
+            "Rebuilt inspector subagent tool rows"
+        );
     }
 
     fn render_reasoning_section(&self) {
@@ -1295,6 +1422,7 @@ fn build_subagent_tool_row(
 }
 
 fn apply_renderer_stack(views: &RendererStackViews, tool_call: &ToolCall) {
+    let started_at = Instant::now();
     let init = renderer_init_from_tool_call(tool_call);
     let renderer_kind = resolve_renderer(&init.tool_name);
     views.stack.set_visible_child_name(renderer_kind.as_str());
@@ -1337,6 +1465,12 @@ fn apply_renderer_stack(views: &RendererStackViews, tool_call: &ToolCall) {
             views.generic_container.append(&widget);
         }
     }
+
+    tracing::debug!(
+        renderer_kind = renderer_kind.as_str(),
+        duration_ms = started_at.elapsed().as_millis(),
+        "Rendered inspector tool renderer"
+    );
 }
 
 fn clear_container(container: &gtk::Box) {
@@ -1848,6 +1982,21 @@ mod tests {
 
         assert!(apply_load_result(request_id, &mut state, in_flight, Ok(())).is_none());
         assert_eq!(state, LoadState::Idle);
+    }
+
+    #[test]
+    fn inspector_tool_call_command_debug_includes_load_duration() {
+        let cmd = ToolInspectorPaneCmd::ToolCall {
+            request_id: 1,
+            session_id: "session-1".to_string(),
+            tool_call_id: "call-1".to_string(),
+            load_duration_ms: 9,
+            result: Ok(None),
+        };
+
+        let debug = format!("{cmd:?}");
+        assert!(debug.contains("load_duration_ms"));
+        assert!(debug.contains("9"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #127 

- add targeted issue 127 tracing for `SessionDetail` and `ToolInspectorPane`, including open-to-first-factory-push timing and inspector load durations
- keep milestone logs at `info` and move noisier internal detail to `debug` so large-session investigations stay readable
- add two manual log reports under `docs/reports/` for the Codex session `019dc51a-f0cd-79c1-ba79-45fedac889c2`, including a clean direct-open capture showing the remaining delay is render-pipeline bound rather than database bound

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --all -- -D warnings`
- `cargo test --all --no-fail-fast`
- manual logging run with `RUST_LOG=info,sessions_chronicle=debug sessions-chronicle`