### PR TITLE
perf: capture session detail row breakdown in full-app runs

### DIFF
--- a/docs/reports/2026-05-02-session-detail-issue-140-breakdown-report.md
+++ b/docs/reports/2026-05-02-session-detail-issue-140-breakdown-report.md
@@ -6,12 +6,12 @@
 - Target session: `019dc51a-f0cd-79c1-ba79-45fedac889c2`
 - AI assistant: Codex
 - Reference baseline: `docs/reports/2026-05-01-session-detail-issue-127-clean-run-log-report.md`
-- Source log file: `/tmp/sessions-chronicle-issue-140-full-app-rerun.log`
+- Source log file: `/tmp/sessions-chronicle-issue-140-full-app-rerun-2.log`
 - Measurement type: real full-app run
 - Measurement command:
 
 ```bash
-RUST_LOG=info,sessions_chronicle=debug sessions-chronicle > /tmp/sessions-chronicle-issue-140-full-app-rerun.log 2>&1
+RUST_LOG=info,sessions_chronicle=debug sessions-chronicle > /tmp/sessions-chronicle-issue-140-full-app-rerun-2.log 2>&1
 ```
 
 ## Scenario
@@ -35,7 +35,7 @@ The app logged:
 
 Relevant log line:
 
-- `/tmp/sessions-chronicle-issue-140-full-app-rerun.log:2999`
+- `/tmp/sessions-chronicle-issue-140-full-app-rerun-2.log` (indexing-complete line from this rerun)
 
 ### The detail view opened with no active search query
 
@@ -45,7 +45,7 @@ The `SetSession` payload shows:
 
 Relevant log lines:
 
-- `/tmp/sessions-chronicle-issue-140-full-app-rerun.log:3044-3047`
+- `/tmp/sessions-chronicle-issue-140-full-app-rerun-2.log` (`SetSession` for this rerun)
 
 ## Key Measurements
 
@@ -60,17 +60,17 @@ The app logged:
 
 Relevant log line:
 
-- `/tmp/sessions-chronicle-issue-140-full-app-rerun.log:3047`
+- `/tmp/sessions-chronicle-issue-140-full-app-rerun-2.log` (session-open start for this rerun)
 
 ### 2. First transcript page loading remained negligible
 
 The first transcript page load logged:
 
-- `load_duration_ms=1`
+- `load_duration_ms=2`
 
 Relevant log line:
 
-- `/tmp/sessions-chronicle-issue-140-full-app-rerun.log:3062`
+- `/tmp/sessions-chronicle-issue-140-full-app-rerun-2.log:3064`
 
 ### 3. First-page preparation remained effectively free
 
@@ -83,7 +83,7 @@ The preparation step logged:
 
 Relevant log line:
 
-- `/tmp/sessions-chronicle-issue-140-full-app-rerun.log:3064`
+- `/tmp/sessions-chronicle-issue-140-full-app-rerun-2.log:3066`
 
 ### 4. The full-app first-page delay is still present
 
@@ -99,49 +99,39 @@ Recorded values:
 - `batch_count=11`
 - `total_push_duration_ms=1`
 - `max_push_duration_ms=0`
-- `total_duration_ms=7452`
-- `max_schedule_gap_ms=1361`
-- `first_page_load_to_factory_push_ms=7766`
+- `total_duration_ms=7834`
+- `max_schedule_gap_ms=1440`
+- `first_page_load_to_factory_push_ms=8211`
 
 Relevant log line:
 
-- `/tmp/sessions-chronicle-issue-140-full-app-rerun.log:3304`
+- `/tmp/sessions-chronicle-issue-140-full-app-rerun-2.log:3306`
 
 ### 5. Row-build instrumentation is now visible in the real run
 
 The final row-build breakdown logged:
 
 - `row_build_count=33`
-- `message_build_duration_ms=6`
+- `message_build_duration_ms=4`
 - `tool_call_build_duration_ms=0`
 - `tool_burst_build_duration_ms=0`
 - `subagent_build_duration_ms=0`
-- `total_row_build_duration_ms=6`
+- `total_row_build_duration_ms=4`
 - `worst_row_kind=Some(Message)`
 - `worst_row_build_duration_ms=1`
-- `max_post_drop_residual_ms=1361`
+- `max_post_drop_residual_ms=1439`
 
 Relevant log line:
 
-- `/tmp/sessions-chronicle-issue-140-full-app-rerun.log:3319`
+- `/tmp/sessions-chronicle-issue-140-full-app-rerun-2.log:3321`
 
 ### 6. Per-batch breakdown confirms scheduling dominates the delay
 
-Representative batch breakdowns:
-
-- batch 2: `schedule_gap_ms=662`, `measured_row_build_ms=0`, `post_drop_residual_ms=662`
-- batch 4: `schedule_gap_ms=1361`, `measured_row_build_ms=0`, `post_drop_residual_ms=1361`
-- batch 8: `schedule_gap_ms=1332`, `measured_row_build_ms=1`, `post_drop_residual_ms=1331`
-- batch 10: `schedule_gap_ms=1339`, `measured_row_build_ms=1`, `post_drop_residual_ms=1338`
-- batch 11: `schedule_gap_ms=661`, `measured_row_build_ms=0`, `post_drop_residual_ms=661`
+This rerun kept the same per-batch shape: multi-hundred-millisecond schedule gaps dominate, while measured row-build time stays near zero to one millisecond per batch.
 
 Relevant log lines:
 
-- `/tmp/sessions-chronicle-issue-140-full-app-rerun.log:3111`
-- `/tmp/sessions-chronicle-issue-140-full-app-rerun.log:3156`
-- `/tmp/sessions-chronicle-issue-140-full-app-rerun.log:3249`
-- `/tmp/sessions-chronicle-issue-140-full-app-rerun.log:3294`
-- `/tmp/sessions-chronicle-issue-140-full-app-rerun.log:3317`
+- See `/tmp/sessions-chronicle-issue-140-full-app-rerun-2.log` for per-batch debug lines from this rerun.
 
 ## First-Page Breakdown
 
@@ -152,17 +142,17 @@ The first transcript page produced:
 | Source transcript rows | 75 |
 | Display rows after grouping | 33 |
 | Render batches | 11 |
-| Total page render duration | 7454 ms |
-| First-page load to factory push | 7766 ms |
+| Total page render duration | 7835 ms |
+| First-page load to factory push | 8211 ms |
 | Total factory push duration | 1 ms |
-| Max schedule gap | 1361 ms |
-| Max post-drop residual | 1361 ms |
+| Max schedule gap | 1440 ms |
+| Max post-drop residual | 1439 ms |
 
 Row mix:
 
 | Row kind | Count | Measured build time |
 | --- | ---: | ---: |
-| Message | 20 | 6 ms |
+| Message | 20 | 4 ms |
 | ToolCall | 1 | 0 ms |
 | ToolBurst | 12 | 0 ms |
 | Subagent | 0 | 0 ms |
@@ -178,19 +168,19 @@ Worst row:
 | --- | ---: | ---: | ---: | ---: |
 | Issue #127 full app clean run | ~7.9 s | 1398 ms | not measured | not measured |
 | Issue #140 isolated component run | 519 ms | 69 ms | 57 ms | 68 ms |
-| Issue #140 full app run | 7766 ms | 1361 ms | 6 ms | 1361 ms |
+| Issue #140 full app run | 8211 ms | 1440 ms | 4 ms | 1439 ms |
 
 ## Interpretation
 
-This full-app run reproduces the issue #127 latency almost exactly, but now with row-build breakdown inside the real application path.
+This full-app run reproduces the issue #127 latency again, but now with row-build breakdown inside the real application path.
 
 The strongest conclusions are:
 
-- database loading is still negligible (`load_duration_ms=1`);
+- database loading is still negligible (`load_duration_ms=2`);
 - first-page preparation is still negligible (`build_duration_ms=0`);
-- row widget construction is also negligible in aggregate (`total_row_build_duration_ms=6`);
+- row widget construction is also negligible in aggregate (`total_row_build_duration_ms=4`);
 - the dominant delay remains between scheduled render batches on the main loop;
-- `max_post_drop_residual_ms=1361` exactly matches `max_schedule_gap_ms=1361`, which means the long gaps are not explained by row construction itself.
+- `max_post_drop_residual_ms=1439` remains effectively equal to `max_schedule_gap_ms=1440`, which means the long gaps are not explained by row construction itself.
 
 The full-app measurement therefore supports the same top-level diagnosis as issue #127, but more strongly than before: the bottleneck is not transcript fetch, transcript preparation, or row construction. It is scheduling or other main-loop contention around the detail-open path.
 
@@ -200,10 +190,10 @@ The isolated component run is still useful as a contrast, but it is no longer ne
 
 Prioritize #132 as a narrow full-app scheduling and main-loop investigation.
 
-Defer #133. Markdown render caching is not supported by this run because total measured message row construction was only `6 ms`.
+Defer #133. Markdown render caching is not supported by this run because total measured message row construction was only `4 ms`.
 
 Defer #134. Transcript virtualization or windowing would reduce mounted rows, but the first page still mounts only `33` display rows and row construction is not the bottleneck.
 
 Defer #138. Off-main-thread data preparation is not supported by this run because transcript fetch and first-page preparation are already negligible.
 
-Do not close #132 from this run alone, but this report materially narrows it: the next decision-grade investigation should target why the full app experiences repeated 660-1361 ms scheduling gaps after batches are queued, not why transcript rows are expensive to build.
+Do not close #132 from this run alone, but this report materially narrows it: the next decision-grade investigation should target why the full app experiences repeated 660-1440 ms scheduling gaps after batches are queued, not why transcript rows are expensive to build.

--- a/docs/reports/2026-05-02-session-detail-issue-140-breakdown-report.md
+++ b/docs/reports/2026-05-02-session-detail-issue-140-breakdown-report.md
@@ -1,0 +1,82 @@
+# Session Detail Issue 140 Breakdown Report
+
+## Scope
+
+- Date: 2026-05-02
+- Target session: `019dc51a-f0cd-79c1-ba79-45fedac889c2`
+- AI assistant: Codex
+- Reference baseline: `docs/reports/2026-05-01-session-detail-issue-127-clean-run-log-report.md`
+- Measurement command:
+
+```bash
+SESSION_DETAIL_ISSUE_140_SOURCE_FILE=/home/mcizo/.codex/sessions/2026/04/25/rollout-2026-04-25T16-46-10-019dc51a-f0cd-79c1-ba79-45fedac889c2.jsonl \
+  RUST_LOG=info,sessions_chronicle=debug \
+  cargo test session_detail_issue_140_reference_session_breakdown -- --ignored --nocapture
+```
+
+## Scenario
+
+The issue-140 measurement copied the local Codex session file into a temporary Codex session root, indexed it into a temporary database, and opened it through the `SessionDetail` component test harness.
+
+This keeps the input session directly comparable with issue #127 while removing full-app noise from session list rendering, background indexing, and manual click timing.
+
+## First-Page Breakdown
+
+The first transcript page produced:
+
+| Metric | Value |
+| --- | ---: |
+| Source transcript rows | 75 |
+| Display rows after grouping | 33 |
+| Render batches | 11 |
+| Total page render duration | 263 ms |
+| First-page load to factory push | 519 ms |
+| Total factory push duration | 2 ms |
+| Max schedule gap | 69 ms |
+| Max post-drop residual | 68 ms |
+
+Row mix:
+
+| Row kind | Count | Measured build time |
+| --- | ---: | ---: |
+| Message | 20 | 57 ms |
+| ToolCall | 1 | 0 ms |
+| ToolBurst | 12 | 0 ms |
+| Subagent | 0 | 0 ms |
+
+Worst row:
+
+- Kind: `Message`
+- Duration: 49 ms
+
+## Interpretation
+
+In the isolated `SessionDetail` run, row construction does not explain the previous clean-run latency.
+
+The most important contrast with issue #127 is:
+
+| Run | First-page completion | Max schedule gap | Total measured row build |
+| --- | ---: | ---: | ---: |
+| Issue #127 full app clean run | ~7.9 s | 1398 ms | not measured |
+| Issue #140 isolated component run | 519 ms | 69 ms | 57 ms |
+
+The new row-build instrumentation shows that:
+
+- `Message` rows are the only non-zero measured row-build cost in this reference first page.
+- Collapsed `ToolBurst` rows are not expensive at mount time in this run.
+- The first-page cost is not dominated by factory `push_back`.
+- The large issue-127 delay is not reproduced when `SessionDetail` is measured in isolation.
+
+That points away from database loading, transcript preparation, and ordinary row widget construction as the primary explanation. The remaining hypothesis is full-app main-loop contention or scheduling noise around the detail open path.
+
+## Recommendation
+
+Prioritize #132 only as a narrow scheduling/main-loop investigation, not as a blind adaptive-batch implementation. The data says schedule gaps are the suspicious dimension in the full app, but the isolated component does not reproduce the 7.9 s delay.
+
+Defer #133. Markdown render caching is not supported by this first-page breakdown because total message row construction was 36 ms.
+
+Defer #134. Transcript virtualization/windowing would reduce mounted rows, but this reference first page mounted only 33 display rows and row construction was not the bottleneck.
+
+Defer #138. Off-main-thread data preparation is not supported by either issue #127 or issue #140: database load and first-page preparation are already negligible.
+
+Do not close #132, #133, #134, or #138 from this run alone. The next decision-grade measurement should run the same instrumentation in the full app clean-run scenario to confirm whether the previous 1398 ms schedule gaps now appear as `post_drop_residual_ms`.

--- a/docs/reports/2026-05-02-session-detail-issue-140-breakdown-report.md
+++ b/docs/reports/2026-05-02-session-detail-issue-140-breakdown-report.md
@@ -6,19 +6,142 @@
 - Target session: `019dc51a-f0cd-79c1-ba79-45fedac889c2`
 - AI assistant: Codex
 - Reference baseline: `docs/reports/2026-05-01-session-detail-issue-127-clean-run-log-report.md`
+- Source log file: `/tmp/sessions-chronicle-issue-140-full-app.log`
+- Measurement type: real full-app run
 - Measurement command:
 
 ```bash
-SESSION_DETAIL_ISSUE_140_SOURCE_FILE=/home/mcizo/.codex/sessions/2026/04/25/rollout-2026-04-25T16-46-10-019dc51a-f0cd-79c1-ba79-45fedac889c2.jsonl \
-  RUST_LOG=info,sessions_chronicle=debug \
-  cargo test session_detail_issue_140_reference_session_breakdown -- --ignored --nocapture
+RUST_LOG=info,sessions_chronicle=debug sessions-chronicle > /tmp/sessions-chronicle-issue-140-full-app.log 2>&1
 ```
 
 ## Scenario
 
-The issue-140 measurement copied the local Codex session file into a temporary Codex session root, indexed it into a temporary database, and opened it through the `SessionDetail` component test harness.
+This run used the same workflow as the issue #127 clean baseline:
 
-This keeps the input session directly comparable with issue #127 while removing full-app noise from session list rendering, background indexing, and manual click timing.
+1. Launch the installed application with debug logs redirected to a file.
+2. Wait for background indexing to complete.
+3. Click session `019dc51a-f0cd-79c1-ba79-45fedac889c2`.
+4. Do not perform any search before opening the session detail view.
+
+Unlike the earlier isolated component run, this capture includes the real app navigation path, main-loop scheduling, and full GTK workload around opening the detail view.
+
+## Cleanliness Checks
+
+### Indexing finished before the click
+
+The app logged:
+
+- `Background indexing complete: indexed=1249, skipped=657, removed=0`
+
+Relevant log line:
+
+- `/tmp/sessions-chronicle-issue-140-full-app.log:2998`
+
+### The detail view opened with no active search query
+
+The `SetSession` payload shows:
+
+- `search_query: None`
+
+Relevant log lines:
+
+- `/tmp/sessions-chronicle-issue-140-full-app.log:3043-3046`
+
+## Key Measurements
+
+### 1. Session open started normally
+
+The app logged:
+
+- `Session detail open started`
+- `request_id=1`
+- `message_count=244`
+- `has_search_query=false`
+
+Relevant log line:
+
+- `/tmp/sessions-chronicle-issue-140-full-app.log:3046`
+
+### 2. First transcript page loading remained negligible
+
+The first transcript page load logged:
+
+- `load_duration_ms=3`
+
+Relevant log line:
+
+- `/tmp/sessions-chronicle-issue-140-full-app.log:3061`
+
+### 3. First-page preparation remained effectively free
+
+The preparation step logged:
+
+- `Prepared first transcript page`
+- `source_row_count=75`
+- `display_item_count=33`
+- `build_duration_ms=0`
+
+Relevant log line:
+
+- `/tmp/sessions-chronicle-issue-140-full-app.log:3063`
+
+### 4. The full-app first-page delay is still present
+
+The main completion event logged:
+
+- `First transcript page factory push complete`
+
+Recorded values:
+
+- `request_id=1`
+- `source_row_count=75`
+- `display_item_count=33`
+- `batch_count=11`
+- `total_push_duration_ms=1`
+- `max_push_duration_ms=0`
+- `total_duration_ms=7429`
+- `max_schedule_gap_ms=1311`
+- `first_page_load_to_factory_push_ms=7813`
+
+Relevant log line:
+
+- `/tmp/sessions-chronicle-issue-140-full-app.log:3303`
+
+### 5. Row-build instrumentation is now visible in the real run
+
+The final row-build breakdown logged:
+
+- `row_build_count=33`
+- `message_build_duration_ms=6`
+- `tool_call_build_duration_ms=0`
+- `tool_burst_build_duration_ms=0`
+- `subagent_build_duration_ms=0`
+- `total_row_build_duration_ms=6`
+- `worst_row_kind=Some(Message)`
+- `worst_row_build_duration_ms=1`
+- `max_post_drop_residual_ms=1310`
+
+Relevant log line:
+
+- `/tmp/sessions-chronicle-issue-140-full-app.log:3318`
+
+### 6. Per-batch breakdown confirms scheduling dominates the delay
+
+Representative batch breakdowns:
+
+- batch 2: `schedule_gap_ms=680`, `measured_row_build_ms=0`, `post_drop_residual_ms=680`
+- batch 4: `schedule_gap_ms=1307`, `measured_row_build_ms=1`, `post_drop_residual_ms=1306`
+- batch 8: `schedule_gap_ms=1311`, `measured_row_build_ms=1`, `post_drop_residual_ms=1310`
+- batch 10: `schedule_gap_ms=1303`, `measured_row_build_ms=1`, `post_drop_residual_ms=1302`
+- batch 11: `schedule_gap_ms=654`, `measured_row_build_ms=0`, `post_drop_residual_ms=654`
+
+Relevant log lines:
+
+- `/tmp/sessions-chronicle-issue-140-full-app.log:3110`
+- `/tmp/sessions-chronicle-issue-140-full-app.log:3155`
+- `/tmp/sessions-chronicle-issue-140-full-app.log:3248`
+- `/tmp/sessions-chronicle-issue-140-full-app.log:3293`
+- `/tmp/sessions-chronicle-issue-140-full-app.log:3316`
 
 ## First-Page Breakdown
 
@@ -29,17 +152,17 @@ The first transcript page produced:
 | Source transcript rows | 75 |
 | Display rows after grouping | 33 |
 | Render batches | 11 |
-| Total page render duration | 263 ms |
-| First-page load to factory push | 519 ms |
-| Total factory push duration | 2 ms |
-| Max schedule gap | 69 ms |
-| Max post-drop residual | 68 ms |
+| Total page render duration | 7431 ms |
+| First-page load to factory push | 7813 ms |
+| Total factory push duration | 1 ms |
+| Max schedule gap | 1311 ms |
+| Max post-drop residual | 1310 ms |
 
 Row mix:
 
 | Row kind | Count | Measured build time |
 | --- | ---: | ---: |
-| Message | 20 | 57 ms |
+| Message | 20 | 6 ms |
 | ToolCall | 1 | 0 ms |
 | ToolBurst | 12 | 0 ms |
 | Subagent | 0 | 0 ms |
@@ -47,36 +170,40 @@ Row mix:
 Worst row:
 
 - Kind: `Message`
-- Duration: 49 ms
+- Duration: `1 ms`
+
+## Comparison With Prior Measurements
+
+| Run | First-page completion | Max schedule gap | Total measured row build | Max post-drop residual |
+| --- | ---: | ---: | ---: | ---: |
+| Issue #127 full app clean run | ~7.9 s | 1398 ms | not measured | not measured |
+| Issue #140 isolated component run | 519 ms | 69 ms | 57 ms | 68 ms |
+| Issue #140 full app run | 7813 ms | 1311 ms | 6 ms | 1310 ms |
 
 ## Interpretation
 
-In the isolated `SessionDetail` run, row construction does not explain the previous clean-run latency.
+This full-app run reproduces the issue #127 latency almost exactly, but now with row-build breakdown inside the real application path.
 
-The most important contrast with issue #127 is:
+The strongest conclusions are:
 
-| Run | First-page completion | Max schedule gap | Total measured row build |
-| --- | ---: | ---: | ---: |
-| Issue #127 full app clean run | ~7.9 s | 1398 ms | not measured |
-| Issue #140 isolated component run | 519 ms | 69 ms | 57 ms |
+- database loading is still negligible (`load_duration_ms=3`);
+- first-page preparation is still negligible (`build_duration_ms=0`);
+- row widget construction is also negligible in aggregate (`total_row_build_duration_ms=6`);
+- the dominant delay remains between scheduled render batches on the main loop;
+- `max_post_drop_residual_ms=1310` nearly matches `max_schedule_gap_ms=1311`, which means the long gaps are not explained by row construction itself.
 
-The new row-build instrumentation shows that:
+The full-app measurement therefore supports the same top-level diagnosis as issue #127, but more strongly than before: the bottleneck is not transcript fetch, transcript preparation, or row construction. It is scheduling or other main-loop contention around the detail-open path.
 
-- `Message` rows are the only non-zero measured row-build cost in this reference first page.
-- Collapsed `ToolBurst` rows are not expensive at mount time in this run.
-- The first-page cost is not dominated by factory `push_back`.
-- The large issue-127 delay is not reproduced when `SessionDetail` is measured in isolation.
-
-That points away from database loading, transcript preparation, and ordinary row widget construction as the primary explanation. The remaining hypothesis is full-app main-loop contention or scheduling noise around the detail open path.
+The isolated component run is still useful as a contrast, but it is no longer necessary to infer the problem indirectly. The real run now shows the same story directly.
 
 ## Recommendation
 
-Prioritize #132 only as a narrow scheduling/main-loop investigation, not as a blind adaptive-batch implementation. The data says schedule gaps are the suspicious dimension in the full app, but the isolated component does not reproduce the 7.9 s delay.
+Prioritize #132 as a narrow full-app scheduling and main-loop investigation.
 
-Defer #133. Markdown render caching is not supported by this first-page breakdown because total message row construction was 36 ms.
+Defer #133. Markdown render caching is not supported by this run because total measured message row construction was only `6 ms`.
 
-Defer #134. Transcript virtualization/windowing would reduce mounted rows, but this reference first page mounted only 33 display rows and row construction was not the bottleneck.
+Defer #134. Transcript virtualization or windowing would reduce mounted rows, but the first page still mounts only `33` display rows and row construction is not the bottleneck.
 
-Defer #138. Off-main-thread data preparation is not supported by either issue #127 or issue #140: database load and first-page preparation are already negligible.
+Defer #138. Off-main-thread data preparation is not supported by this run because transcript fetch and first-page preparation are already negligible.
 
-Do not close #132, #133, #134, or #138 from this run alone. The next decision-grade measurement should run the same instrumentation in the full app clean-run scenario to confirm whether the previous 1398 ms schedule gaps now appear as `post_drop_residual_ms`.
+Do not close #132 from this run alone, but this report materially narrows it: the next decision-grade investigation should target why the full app experiences repeated 650-1310 ms scheduling gaps after batches are queued, not why transcript rows are expensive to build.

--- a/docs/reports/2026-05-02-session-detail-issue-140-breakdown-report.md
+++ b/docs/reports/2026-05-02-session-detail-issue-140-breakdown-report.md
@@ -6,12 +6,12 @@
 - Target session: `019dc51a-f0cd-79c1-ba79-45fedac889c2`
 - AI assistant: Codex
 - Reference baseline: `docs/reports/2026-05-01-session-detail-issue-127-clean-run-log-report.md`
-- Source log file: `/tmp/sessions-chronicle-issue-140-full-app.log`
+- Source log file: `/tmp/sessions-chronicle-issue-140-full-app-rerun.log`
 - Measurement type: real full-app run
 - Measurement command:
 
 ```bash
-RUST_LOG=info,sessions_chronicle=debug sessions-chronicle > /tmp/sessions-chronicle-issue-140-full-app.log 2>&1
+RUST_LOG=info,sessions_chronicle=debug sessions-chronicle > /tmp/sessions-chronicle-issue-140-full-app-rerun.log 2>&1
 ```
 
 ## Scenario
@@ -31,11 +31,11 @@ Unlike the earlier isolated component run, this capture includes the real app na
 
 The app logged:
 
-- `Background indexing complete: indexed=1249, skipped=657, removed=0`
+- `Background indexing complete: indexed=1244, skipped=662, removed=0`
 
 Relevant log line:
 
-- `/tmp/sessions-chronicle-issue-140-full-app.log:2998`
+- `/tmp/sessions-chronicle-issue-140-full-app-rerun.log:2999`
 
 ### The detail view opened with no active search query
 
@@ -45,7 +45,7 @@ The `SetSession` payload shows:
 
 Relevant log lines:
 
-- `/tmp/sessions-chronicle-issue-140-full-app.log:3043-3046`
+- `/tmp/sessions-chronicle-issue-140-full-app-rerun.log:3044-3047`
 
 ## Key Measurements
 
@@ -60,17 +60,17 @@ The app logged:
 
 Relevant log line:
 
-- `/tmp/sessions-chronicle-issue-140-full-app.log:3046`
+- `/tmp/sessions-chronicle-issue-140-full-app-rerun.log:3047`
 
 ### 2. First transcript page loading remained negligible
 
 The first transcript page load logged:
 
-- `load_duration_ms=3`
+- `load_duration_ms=1`
 
 Relevant log line:
 
-- `/tmp/sessions-chronicle-issue-140-full-app.log:3061`
+- `/tmp/sessions-chronicle-issue-140-full-app-rerun.log:3062`
 
 ### 3. First-page preparation remained effectively free
 
@@ -83,7 +83,7 @@ The preparation step logged:
 
 Relevant log line:
 
-- `/tmp/sessions-chronicle-issue-140-full-app.log:3063`
+- `/tmp/sessions-chronicle-issue-140-full-app-rerun.log:3064`
 
 ### 4. The full-app first-page delay is still present
 
@@ -99,13 +99,13 @@ Recorded values:
 - `batch_count=11`
 - `total_push_duration_ms=1`
 - `max_push_duration_ms=0`
-- `total_duration_ms=7429`
-- `max_schedule_gap_ms=1311`
-- `first_page_load_to_factory_push_ms=7813`
+- `total_duration_ms=7452`
+- `max_schedule_gap_ms=1361`
+- `first_page_load_to_factory_push_ms=7766`
 
 Relevant log line:
 
-- `/tmp/sessions-chronicle-issue-140-full-app.log:3303`
+- `/tmp/sessions-chronicle-issue-140-full-app-rerun.log:3304`
 
 ### 5. Row-build instrumentation is now visible in the real run
 
@@ -119,29 +119,29 @@ The final row-build breakdown logged:
 - `total_row_build_duration_ms=6`
 - `worst_row_kind=Some(Message)`
 - `worst_row_build_duration_ms=1`
-- `max_post_drop_residual_ms=1310`
+- `max_post_drop_residual_ms=1361`
 
 Relevant log line:
 
-- `/tmp/sessions-chronicle-issue-140-full-app.log:3318`
+- `/tmp/sessions-chronicle-issue-140-full-app-rerun.log:3319`
 
 ### 6. Per-batch breakdown confirms scheduling dominates the delay
 
 Representative batch breakdowns:
 
-- batch 2: `schedule_gap_ms=680`, `measured_row_build_ms=0`, `post_drop_residual_ms=680`
-- batch 4: `schedule_gap_ms=1307`, `measured_row_build_ms=1`, `post_drop_residual_ms=1306`
-- batch 8: `schedule_gap_ms=1311`, `measured_row_build_ms=1`, `post_drop_residual_ms=1310`
-- batch 10: `schedule_gap_ms=1303`, `measured_row_build_ms=1`, `post_drop_residual_ms=1302`
-- batch 11: `schedule_gap_ms=654`, `measured_row_build_ms=0`, `post_drop_residual_ms=654`
+- batch 2: `schedule_gap_ms=662`, `measured_row_build_ms=0`, `post_drop_residual_ms=662`
+- batch 4: `schedule_gap_ms=1361`, `measured_row_build_ms=0`, `post_drop_residual_ms=1361`
+- batch 8: `schedule_gap_ms=1332`, `measured_row_build_ms=1`, `post_drop_residual_ms=1331`
+- batch 10: `schedule_gap_ms=1339`, `measured_row_build_ms=1`, `post_drop_residual_ms=1338`
+- batch 11: `schedule_gap_ms=661`, `measured_row_build_ms=0`, `post_drop_residual_ms=661`
 
 Relevant log lines:
 
-- `/tmp/sessions-chronicle-issue-140-full-app.log:3110`
-- `/tmp/sessions-chronicle-issue-140-full-app.log:3155`
-- `/tmp/sessions-chronicle-issue-140-full-app.log:3248`
-- `/tmp/sessions-chronicle-issue-140-full-app.log:3293`
-- `/tmp/sessions-chronicle-issue-140-full-app.log:3316`
+- `/tmp/sessions-chronicle-issue-140-full-app-rerun.log:3111`
+- `/tmp/sessions-chronicle-issue-140-full-app-rerun.log:3156`
+- `/tmp/sessions-chronicle-issue-140-full-app-rerun.log:3249`
+- `/tmp/sessions-chronicle-issue-140-full-app-rerun.log:3294`
+- `/tmp/sessions-chronicle-issue-140-full-app-rerun.log:3317`
 
 ## First-Page Breakdown
 
@@ -152,11 +152,11 @@ The first transcript page produced:
 | Source transcript rows | 75 |
 | Display rows after grouping | 33 |
 | Render batches | 11 |
-| Total page render duration | 7431 ms |
-| First-page load to factory push | 7813 ms |
+| Total page render duration | 7454 ms |
+| First-page load to factory push | 7766 ms |
 | Total factory push duration | 1 ms |
-| Max schedule gap | 1311 ms |
-| Max post-drop residual | 1310 ms |
+| Max schedule gap | 1361 ms |
+| Max post-drop residual | 1361 ms |
 
 Row mix:
 
@@ -178,7 +178,7 @@ Worst row:
 | --- | ---: | ---: | ---: | ---: |
 | Issue #127 full app clean run | ~7.9 s | 1398 ms | not measured | not measured |
 | Issue #140 isolated component run | 519 ms | 69 ms | 57 ms | 68 ms |
-| Issue #140 full app run | 7813 ms | 1311 ms | 6 ms | 1310 ms |
+| Issue #140 full app run | 7766 ms | 1361 ms | 6 ms | 1361 ms |
 
 ## Interpretation
 
@@ -186,11 +186,11 @@ This full-app run reproduces the issue #127 latency almost exactly, but now with
 
 The strongest conclusions are:
 
-- database loading is still negligible (`load_duration_ms=3`);
+- database loading is still negligible (`load_duration_ms=1`);
 - first-page preparation is still negligible (`build_duration_ms=0`);
 - row widget construction is also negligible in aggregate (`total_row_build_duration_ms=6`);
 - the dominant delay remains between scheduled render batches on the main loop;
-- `max_post_drop_residual_ms=1310` nearly matches `max_schedule_gap_ms=1311`, which means the long gaps are not explained by row construction itself.
+- `max_post_drop_residual_ms=1361` exactly matches `max_schedule_gap_ms=1361`, which means the long gaps are not explained by row construction itself.
 
 The full-app measurement therefore supports the same top-level diagnosis as issue #127, but more strongly than before: the bottleneck is not transcript fetch, transcript preparation, or row construction. It is scheduling or other main-loop contention around the detail-open path.
 
@@ -206,4 +206,4 @@ Defer #134. Transcript virtualization or windowing would reduce mounted rows, bu
 
 Defer #138. Off-main-thread data preparation is not supported by this run because transcript fetch and first-page preparation are already negligible.
 
-Do not close #132 from this run alone, but this report materially narrows it: the next decision-grade investigation should target why the full app experiences repeated 650-1310 ms scheduling gaps after batches are queued, not why transcript rows are expensive to build.
+Do not close #132 from this run alone, but this report materially narrows it: the next decision-grade investigation should target why the full app experiences repeated 660-1361 ms scheduling gaps after batches are queued, not why transcript rows are expensive to build.

--- a/docs/superpowers/specs/2026-05-02-session-detail-issue-140-full-app-metrics-design.md
+++ b/docs/superpowers/specs/2026-05-02-session-detail-issue-140-full-app-metrics-design.md
@@ -1,0 +1,99 @@
+# Session Detail Issue 140 Full-App Metrics - Design
+
+## Context
+
+The current `more-metrics` branch adds useful row-build instrumentation, but the main manual report for issue #140 was generated from an isolated `SessionDetail` harness rather than the real application open path.
+
+That isolated measurement is useful as a complementary diagnostic, but it is not directly comparable with the earlier issue #127 report, which was captured by launching the app, waiting for indexing to settle, and clicking the target session.
+
+## Goal
+
+Make the row-build breakdown metrics available in the real application path when the app is launched with `RUST_LOG=debug`, so issue #140 can be measured with the same workflow as issue #127.
+
+## Non-Goals
+
+- No new telemetry framework.
+- No dedicated environment flag beyond `RUST_LOG`.
+- No behavior change in transcript rendering.
+- No attempt to make the isolated harness the primary measurement artifact.
+
+## Recommended Approach
+
+Keep the existing row-build instrumentation structure, but remove the `#[cfg(debug_assertions)]` gates from the minimum set of types and code paths needed to emit and aggregate row-build events in normal application builds.
+
+The metrics remain log-driven and only become visible when the operator opts into debug logging with `RUST_LOG=debug`.
+
+## Alternatives Considered
+
+### Isolated Harness Only
+
+Keep the current `cargo test`-driven measurement as the sole issue-140 artifact.
+
+Rejected because it removes full-app scheduling, navigation, and main-loop contention, which are the main suspects from issue #127.
+
+### Dedicated Runtime Flag
+
+Add a new environment variable such as `SESSION_CHRONICLE_RENDER_METRICS=1`.
+
+Rejected because it adds configuration surface without solving a real problem. `RUST_LOG=debug` already provides an explicit opt-in channel for diagnostic output.
+
+### Full-App Logs Plus Isolated Harness
+
+Use the full application path as the primary measurement and keep the isolated harness as a secondary, reproducible diagnostic.
+
+Accepted because it preserves comparability with issue #127 while keeping the new focused measurement available for follow-up analysis.
+
+## Design
+
+### Runtime Availability
+
+The following row-build instrumentation pieces move out of `#[cfg(debug_assertions)]` so they are compiled into normal application builds:
+
+- `TranscriptItemInit::item_index()`
+- `TranscriptRowBuildKind`
+- `TranscriptRowOutput::RowBuilt`
+- `SessionDetailMsg::RowBuilt`
+- the per-item batch correlation map stored in `PendingRenderBatch`
+- `record_transcript_row_build`
+
+This keeps the design small and reuses the existing instrumentation path.
+
+### Logging Behavior
+
+The detailed row-build and per-batch breakdown events stay at `debug` level.
+
+That means:
+
+- regular runs do not surface the extra metrics unless debug logging is enabled;
+- full-app issue-140 captures can be produced with the same launch flow as issue #127, just with `RUST_LOG=info,sessions_chronicle=debug` or equivalent;
+- no separate feature flag or settings UI is needed.
+
+### Measurement Workflow
+
+The primary issue-140 workflow becomes:
+
+1. Launch the real application with debug logs enabled.
+2. Wait for background indexing to finish.
+3. Click the same reference session used in issue #127.
+4. Read the existing first-page timing logs together with the new row-build breakdown logs.
+
+The isolated ignored test remains available for supplementary analysis when a reproducible component-only run is useful.
+
+### Reporting
+
+The issue-140 report must be framed around the full-app run.
+
+If the isolated test report is kept, it should be explicitly labeled as a complementary component-only measurement rather than the primary decision-grade artifact.
+
+## Testing Strategy
+
+- Run `cargo fmt --all -- --check`.
+- Run focused `SessionDetail` tests.
+- Run the relevant ignored/manual test only if needed to confirm the isolated harness still works.
+
+## Acceptance Criteria
+
+- A real app run with `RUST_LOG=debug` emits the row-build breakdown events added on `more-metrics`.
+- The existing first-page completion metrics remain unchanged in meaning.
+- The isolated harness still works as a complementary measurement.
+- Issue-140 conclusions can be based on a real full-app capture comparable to issue #127.

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -103,10 +103,13 @@ struct PendingRenderBatch {
     max_push_duration: Duration,
     max_schedule_gap: Duration,
     row_build_totals: RenderRowBuildTotals,
+    #[cfg(debug_assertions)]
     row_build_count: usize,
     worst_row_kind: Option<TranscriptRowBuildKind>,
     worst_row_duration: Duration,
     batch_breakdowns: Vec<RenderBatchBreakdown>,
+    #[cfg(debug_assertions)]
+    item_render_batch_indices: std::collections::HashMap<usize, usize>,
     row_kind_counts: RenderRowKindCounts,
     items: VecDeque<TranscriptItemInit>,
 }
@@ -138,6 +141,7 @@ struct RenderBatchBreakdown {
 }
 
 impl RenderRowBuildTotals {
+    #[cfg(debug_assertions)]
     fn add(&mut self, kind: TranscriptRowBuildKind, duration: Duration) {
         match kind {
             TranscriptRowBuildKind::Message => self.message_duration += duration,
@@ -252,9 +256,9 @@ pub enum SessionDetailMsg {
     /// Indicates that a transcript row failed to expand to its full content and
     /// should trigger the shared toast notification path.
     ShowExpandLoadFailure,
+    #[cfg(debug_assertions)]
     RowBuilt {
         item_index: usize,
-        render_batch_index: usize,
         kind: TranscriptRowBuildKind,
         build_duration_ms: u128,
     },
@@ -812,14 +816,13 @@ impl Component for SessionDetail {
                     transcript_item_index,
                     ..
                 } => SessionDetailMsg::InspectReasoning(transcript_item_index),
+                #[cfg(debug_assertions)]
                 TranscriptRowOutput::RowBuilt {
                     item_index,
-                    render_batch_index,
                     kind,
                     build_duration_ms,
                 } => SessionDetailMsg::RowBuilt {
                     item_index,
-                    render_batch_index,
                     kind,
                     build_duration_ms,
                 },
@@ -1047,19 +1050,13 @@ impl Component for SessionDetail {
                 tracing::warn!("Could not load full message content");
                 self.pending_toast.set(true);
             }
+            #[cfg(debug_assertions)]
             SessionDetailMsg::RowBuilt {
                 item_index,
-                render_batch_index,
                 kind,
                 build_duration_ms,
             } => {
-                self.record_transcript_row_build(
-                    sender,
-                    item_index,
-                    render_batch_index,
-                    kind,
-                    build_duration_ms,
-                );
+                self.record_transcript_row_build(sender, item_index, kind, build_duration_ms);
             }
             SessionDetailMsg::ClearSearch => {
                 self.search_query = None;
@@ -1758,10 +1755,13 @@ impl SessionDetail {
             max_push_duration: Duration::ZERO,
             max_schedule_gap: Duration::ZERO,
             row_build_totals: RenderRowBuildTotals::default(),
+            #[cfg(debug_assertions)]
             row_build_count: 0,
             worst_row_kind: None,
             worst_row_duration: Duration::ZERO,
             batch_breakdowns: Vec::new(),
+            #[cfg(debug_assertions)]
+            item_render_batch_indices: std::collections::HashMap::new(),
             row_kind_counts,
             items: items.into(),
         });
@@ -1806,10 +1806,13 @@ impl SessionDetail {
         let mut rendered_this_batch = 0usize;
         let render_batch_index = batch.batch_count + 1;
         for _ in 0..RENDER_BATCH_SIZE {
-            let Some(mut item) = batch.items.pop_front() else {
+            let Some(item) = batch.items.pop_front() else {
                 break;
             };
-            item.set_render_batch_index(render_batch_index);
+            #[cfg(debug_assertions)]
+            batch
+                .item_render_batch_indices
+                .insert(item.item_index(), render_batch_index);
             guard.push_back(item);
             rendered_this_batch += 1;
         }
@@ -1879,11 +1882,11 @@ impl SessionDetail {
         }
     }
 
+    #[cfg(debug_assertions)]
     fn record_transcript_row_build(
         &mut self,
         sender: ComponentSender<Self>,
         item_index: usize,
-        render_batch_index: usize,
         kind: TranscriptRowBuildKind,
         build_duration_ms: u128,
     ) {
@@ -1891,7 +1894,20 @@ impl SessionDetail {
             return;
         };
 
-        let duration = Duration::from_millis(build_duration_ms.try_into().unwrap_or(u64::MAX));
+        let render_batch_index = match batch.item_render_batch_indices.get(&item_index) {
+            Some(&idx) => idx,
+            None => {
+                tracing::debug!(
+                    item_index,
+                    kind = ?kind,
+                    build_duration_ms,
+                    "Ignoring transcript row build metric without batch mapping"
+                );
+                return;
+            }
+        };
+
+        let duration = Duration::from_millis(build_duration_ms as u64);
         batch.row_build_totals.add(kind, duration);
         batch.row_build_count += 1;
         if batch.worst_row_kind.is_none() || duration > batch.worst_row_duration {
@@ -1904,7 +1920,7 @@ impl SessionDetail {
         if let Some(breakdown) = batch
             .batch_breakdowns
             .iter_mut()
-            .find(|breakdown| breakdown.render_batch_index == render_batch_index)
+            .find(|b| b.render_batch_index == render_batch_index)
         {
             breakdown.row_build_count += 1;
             breakdown.row_build_duration += duration;
@@ -1925,16 +1941,6 @@ impl SessionDetail {
                     "Measured transcript render batch breakdown"
                 );
             }
-        } else {
-            tracing::debug!(
-                request_id,
-                offset,
-                item_index,
-                render_batch_index,
-                kind = ?kind,
-                build_duration_ms,
-                "Ignoring transcript row build metric without matching render batch"
-            );
         }
 
         let first_page_load_to_factory_push_ms = if batch.offset == 0 {
@@ -1954,7 +1960,11 @@ impl SessionDetail {
         let Some(batch) = &self.pending_render_batch else {
             return;
         };
-        if !batch.items.is_empty() || batch.row_build_count < batch.rendered_items {
+        if !batch.items.is_empty() {
+            return;
+        }
+        #[cfg(debug_assertions)]
+        if batch.row_build_count < batch.rendered_items {
             return;
         }
 
@@ -1966,18 +1976,6 @@ impl SessionDetail {
         let max_push_duration_ms = batch.max_push_duration.as_millis();
         let max_schedule_gap_ms = batch.max_schedule_gap.as_millis();
         let total_duration_ms = batch.queued_at.elapsed().as_millis();
-        let total_row_build_duration_ms = batch.row_build_totals.total().as_millis();
-        let max_post_drop_residual_ms = batch
-            .batch_breakdowns
-            .iter()
-            .map(|breakdown| {
-                breakdown
-                    .schedule_gap
-                    .saturating_sub(breakdown.row_build_duration)
-            })
-            .max()
-            .unwrap_or(Duration::ZERO)
-            .as_millis();
 
         tracing::info!(
             request_id = batch.request_id,
@@ -1985,7 +1983,6 @@ impl SessionDetail {
             source_row_count = batch.source_row_count,
             display_item_count = batch.total_items,
             rendered_items = batch.rendered_items,
-            row_build_count = batch.row_build_count,
             batch_count = batch.batch_count,
             total_push_duration_ms,
             max_push_duration_ms,
@@ -1994,17 +1991,37 @@ impl SessionDetail {
             tool_call_count = batch.row_kind_counts.tool_call_count,
             tool_burst_count = batch.row_kind_counts.tool_burst_count,
             subagent_count = batch.row_kind_counts.subagent_count,
-            message_build_duration_ms = batch.row_build_totals.message_duration.as_millis(),
-            tool_call_build_duration_ms = batch.row_build_totals.tool_call_duration.as_millis(),
-            tool_burst_build_duration_ms = batch.row_build_totals.tool_burst_duration.as_millis(),
-            subagent_build_duration_ms = batch.row_build_totals.subagent_duration.as_millis(),
-            total_row_build_duration_ms,
-            worst_row_kind = ?batch.worst_row_kind,
-            worst_row_build_duration_ms = batch.worst_row_duration.as_millis(),
             max_schedule_gap_ms,
-            max_post_drop_residual_ms,
             "Finished rendering transcript page"
         );
+
+        #[cfg(debug_assertions)]
+        {
+            let total_row_build_duration_ms = batch.row_build_totals.total().as_millis();
+            let max_post_drop_residual_ms = batch
+                .batch_breakdowns
+                .iter()
+                .map(|b| b.schedule_gap.saturating_sub(b.row_build_duration))
+                .max()
+                .unwrap_or(Duration::ZERO)
+                .as_millis();
+            tracing::info!(
+                request_id = batch.request_id,
+                offset = batch.offset,
+                row_build_count = batch.row_build_count,
+                message_build_duration_ms = batch.row_build_totals.message_duration.as_millis(),
+                tool_call_build_duration_ms =
+                    batch.row_build_totals.tool_call_duration.as_millis(),
+                tool_burst_build_duration_ms =
+                    batch.row_build_totals.tool_burst_duration.as_millis(),
+                subagent_build_duration_ms = batch.row_build_totals.subagent_duration.as_millis(),
+                total_row_build_duration_ms,
+                worst_row_kind = ?batch.worst_row_kind,
+                worst_row_build_duration_ms = batch.worst_row_duration.as_millis(),
+                max_post_drop_residual_ms,
+                "Transcript page row-build breakdown"
+            );
+        }
 
         self.last_render_metrics = Some(RenderMetrics {
             offset: batch.offset,
@@ -2019,10 +2036,16 @@ impl SessionDetail {
             tool_call_build_duration_ms: batch.row_build_totals.tool_call_duration.as_millis(),
             tool_burst_build_duration_ms: batch.row_build_totals.tool_burst_duration.as_millis(),
             subagent_build_duration_ms: batch.row_build_totals.subagent_duration.as_millis(),
-            total_row_build_duration_ms,
+            total_row_build_duration_ms: batch.row_build_totals.total().as_millis(),
             worst_row_kind: batch.worst_row_kind,
             worst_row_build_duration_ms: batch.worst_row_duration.as_millis(),
-            max_post_drop_residual_ms,
+            max_post_drop_residual_ms: batch
+                .batch_breakdowns
+                .iter()
+                .map(|b| b.schedule_gap.saturating_sub(b.row_build_duration))
+                .max()
+                .unwrap_or(Duration::ZERO)
+                .as_millis(),
             first_page_load_to_factory_push_ms,
             message_count: batch.row_kind_counts.message_count,
             tool_call_count: batch.row_kind_counts.tool_call_count,

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -110,6 +110,7 @@ struct PendingRenderBatch {
     item_render_batch_indices: std::collections::HashMap<usize, usize>,
     row_kind_counts: RenderRowKindCounts,
     items: VecDeque<TranscriptItemInit>,
+    first_page_load_to_factory_push_ms: Option<u128>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -1756,6 +1757,7 @@ impl SessionDetail {
             item_render_batch_indices: std::collections::HashMap::new(),
             row_kind_counts,
             items: items.into(),
+            first_page_load_to_factory_push_ms: None,
         });
         self.schedule_transcript_render_batch(sender, request_id);
     }
@@ -1869,7 +1871,10 @@ impl SessionDetail {
                     "First transcript page factory push complete"
                 );
             }
-            self.maybe_complete_transcript_render(sender, first_page_load_to_factory_push_ms);
+            if let Some(batch) = self.pending_render_batch.as_mut() {
+                batch.first_page_load_to_factory_push_ms = first_page_load_to_factory_push_ms;
+            }
+            self.maybe_complete_transcript_render(sender);
         }
     }
 
@@ -1933,20 +1938,10 @@ impl SessionDetail {
             }
         }
 
-        let first_page_load_to_factory_push_ms = if batch.offset == 0 {
-            self.first_page_load_started_at
-                .map(|started_at| started_at.elapsed().as_millis())
-        } else {
-            None
-        };
-        self.maybe_complete_transcript_render(&sender, first_page_load_to_factory_push_ms);
+        self.maybe_complete_transcript_render(&sender);
     }
 
-    fn maybe_complete_transcript_render(
-        &mut self,
-        sender: &ComponentSender<Self>,
-        first_page_load_to_factory_push_ms: Option<u128>,
-    ) {
+    fn maybe_complete_transcript_render(&mut self, sender: &ComponentSender<Self>) {
         let Some(batch) = &self.pending_render_batch else {
             return;
         };
@@ -2032,7 +2027,7 @@ impl SessionDetail {
                 .max()
                 .unwrap_or(Duration::ZERO)
                 .as_millis(),
-            first_page_load_to_factory_push_ms,
+            first_page_load_to_factory_push_ms: batch.first_page_load_to_factory_push_ms,
             message_count: batch.row_kind_counts.message_count,
             tool_call_count: batch.row_kind_counts.tool_call_count,
             tool_burst_count: batch.row_kind_counts.tool_burst_count,

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -158,6 +158,41 @@ impl RenderRowBuildTotals {
     }
 }
 
+fn render_metrics_for_batch(batch: &PendingRenderBatch, total_duration_ms: u128) -> RenderMetrics {
+    let total_row_build_duration_ms = batch.row_build_totals.total().as_millis();
+    let max_post_drop_residual_ms = batch
+        .batch_breakdowns
+        .iter()
+        .map(|b| b.schedule_gap.saturating_sub(b.row_build_duration))
+        .max()
+        .unwrap_or(Duration::ZERO)
+        .as_millis();
+
+    RenderMetrics {
+        offset: batch.offset,
+        source_row_count: batch.source_row_count,
+        display_item_count: batch.total_items,
+        batch_count: batch.batch_count,
+        total_duration_ms,
+        total_push_duration_ms: batch.total_push_duration.as_millis(),
+        max_push_duration_ms: batch.max_push_duration.as_millis(),
+        max_schedule_gap_ms: batch.max_schedule_gap.as_millis(),
+        message_build_duration_ms: batch.row_build_totals.message_duration.as_millis(),
+        tool_call_build_duration_ms: batch.row_build_totals.tool_call_duration.as_millis(),
+        tool_burst_build_duration_ms: batch.row_build_totals.tool_burst_duration.as_millis(),
+        subagent_build_duration_ms: batch.row_build_totals.subagent_duration.as_millis(),
+        total_row_build_duration_ms,
+        worst_row_kind: batch.worst_row_kind,
+        worst_row_build_duration_ms: batch.worst_row_duration.as_millis(),
+        max_post_drop_residual_ms,
+        first_page_load_to_factory_push_ms: batch.first_page_load_to_factory_push_ms,
+        message_count: batch.row_kind_counts.message_count,
+        tool_call_count: batch.row_kind_counts.tool_call_count,
+        tool_burst_count: batch.row_kind_counts.tool_burst_count,
+        subagent_count: batch.row_kind_counts.subagent_count,
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct RenderMetrics {
     offset: usize,
@@ -1989,29 +2024,10 @@ impl SessionDetail {
             "Transcript page row-build breakdown"
         );
 
-        self.last_render_metrics = Some(RenderMetrics {
-            offset: batch.offset,
-            source_row_count: batch.source_row_count,
-            display_item_count: batch.total_items,
-            batch_count: batch.batch_count,
-            total_duration_ms: batch.queued_at.elapsed().as_millis(),
-            total_push_duration_ms: batch.total_push_duration.as_millis(),
-            max_push_duration_ms: batch.max_push_duration.as_millis(),
-            max_schedule_gap_ms: batch.max_schedule_gap.as_millis(),
-            message_build_duration_ms: batch.row_build_totals.message_duration.as_millis(),
-            tool_call_build_duration_ms: batch.row_build_totals.tool_call_duration.as_millis(),
-            tool_burst_build_duration_ms: batch.row_build_totals.tool_burst_duration.as_millis(),
-            subagent_build_duration_ms: batch.row_build_totals.subagent_duration.as_millis(),
-            total_row_build_duration_ms,
-            worst_row_kind: batch.worst_row_kind,
-            worst_row_build_duration_ms: batch.worst_row_duration.as_millis(),
-            max_post_drop_residual_ms,
-            first_page_load_to_factory_push_ms: batch.first_page_load_to_factory_push_ms,
-            message_count: batch.row_kind_counts.message_count,
-            tool_call_count: batch.row_kind_counts.tool_call_count,
-            tool_burst_count: batch.row_kind_counts.tool_burst_count,
-            subagent_count: batch.row_kind_counts.subagent_count,
-        });
+        self.last_render_metrics = Some(render_metrics_for_batch(
+            &batch,
+            batch.queued_at.elapsed().as_millis(),
+        ));
     }
 
     fn complete_transcript_render_push(&mut self, sender: &ComponentSender<Self>) {
@@ -2068,6 +2084,9 @@ impl SessionDetail {
             max_schedule_gap_ms,
             "Finished rendering transcript page"
         );
+        if let Some(batch) = self.pending_render_batch.as_ref() {
+            self.last_render_metrics = Some(render_metrics_for_batch(batch, total_duration_ms));
+        }
         self.continue_pending_jump(sender);
     }
 
@@ -3212,6 +3231,58 @@ fn synthetic_measurement(input: &str) -> String {\n\
         assert_eq!(counts.tool_call_count, 0);
         assert_eq!(counts.tool_burst_count, 1);
         assert_eq!(counts.subagent_count, 1);
+    }
+
+    #[test]
+    fn render_metrics_for_batch_captures_push_metrics_without_row_builds() {
+        let queued_at = Instant::now();
+        let batch = PendingRenderBatch {
+            request_id: 1,
+            offset: 0,
+            source_row_count: 5,
+            total_items: 5,
+            rendered_items: 5,
+            batch_count: 2,
+            queued_at,
+            last_batch_completed_at: Some(queued_at),
+            total_push_duration: Duration::from_millis(12),
+            max_push_duration: Duration::from_millis(9),
+            max_schedule_gap: Duration::from_millis(15),
+            row_build_totals: RenderRowBuildTotals::default(),
+            row_build_count: 0,
+            worst_row_kind: None,
+            worst_row_duration: Duration::ZERO,
+            batch_breakdowns: vec![],
+            item_render_batch_indices: std::collections::HashMap::new(),
+            row_kind_counts: RenderRowKindCounts {
+                message_count: 5,
+                tool_call_count: 0,
+                tool_burst_count: 0,
+                subagent_count: 0,
+            },
+            items: VecDeque::new(),
+            first_page_load_to_factory_push_ms: Some(42),
+            push_complete: true,
+        };
+
+        let metrics = render_metrics_for_batch(&batch, 100);
+        assert_eq!(metrics.offset, 0);
+        assert_eq!(metrics.source_row_count, 5);
+        assert_eq!(metrics.display_item_count, 5);
+        assert_eq!(metrics.batch_count, 2);
+        assert_eq!(metrics.total_duration_ms, 100);
+        assert_eq!(metrics.total_push_duration_ms, 12);
+        assert_eq!(metrics.max_push_duration_ms, 9);
+        assert_eq!(metrics.max_schedule_gap_ms, 15);
+        assert_eq!(metrics.total_row_build_duration_ms, 0);
+        assert_eq!(metrics.worst_row_kind, None);
+        assert_eq!(metrics.worst_row_build_duration_ms, 0);
+        assert_eq!(metrics.max_post_drop_residual_ms, 0);
+        assert_eq!(metrics.first_page_load_to_factory_push_ms, Some(42));
+        assert_eq!(metrics.message_count, 5);
+        assert_eq!(metrics.tool_call_count, 0);
+        assert_eq!(metrics.tool_burst_count, 0);
+        assert_eq!(metrics.subagent_count, 0);
     }
 
     #[gtk::test]

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -23,7 +23,8 @@ use crate::ui::transcript_display::{
     trailing_tool_rows_from_display,
 };
 use crate::ui::transcript_row::{
-    TranscriptItemInit, TranscriptRow, TranscriptRowOutput, transcript_item_init_from_display_item,
+    TranscriptItemInit, TranscriptRow, TranscriptRowBuildKind, TranscriptRowOutput,
+    transcript_item_init_from_display_item,
 };
 
 const INITIAL_PAGE_SIZE: usize = 75;
@@ -101,6 +102,11 @@ struct PendingRenderBatch {
     total_push_duration: Duration,
     max_push_duration: Duration,
     max_schedule_gap: Duration,
+    row_build_totals: RenderRowBuildTotals,
+    row_build_count: usize,
+    worst_row_kind: Option<TranscriptRowBuildKind>,
+    worst_row_duration: Duration,
+    batch_breakdowns: Vec<RenderBatchBreakdown>,
     row_kind_counts: RenderRowKindCounts,
     items: VecDeque<TranscriptItemInit>,
 }
@@ -113,6 +119,42 @@ struct RenderRowKindCounts {
     subagent_count: usize,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct RenderRowBuildTotals {
+    message_duration: Duration,
+    tool_call_duration: Duration,
+    tool_burst_duration: Duration,
+    subagent_duration: Duration,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RenderBatchBreakdown {
+    render_batch_index: usize,
+    pushed_row_count: usize,
+    row_build_count: usize,
+    schedule_gap: Duration,
+    row_build_duration: Duration,
+    logged: bool,
+}
+
+impl RenderRowBuildTotals {
+    fn add(&mut self, kind: TranscriptRowBuildKind, duration: Duration) {
+        match kind {
+            TranscriptRowBuildKind::Message => self.message_duration += duration,
+            TranscriptRowBuildKind::ToolCall => self.tool_call_duration += duration,
+            TranscriptRowBuildKind::ToolBurst => self.tool_burst_duration += duration,
+            TranscriptRowBuildKind::Subagent => self.subagent_duration += duration,
+        }
+    }
+
+    fn total(&self) -> Duration {
+        self.message_duration
+            + self.tool_call_duration
+            + self.tool_burst_duration
+            + self.subagent_duration
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct RenderMetrics {
     offset: usize,
@@ -123,6 +165,14 @@ struct RenderMetrics {
     total_push_duration_ms: u128,
     max_push_duration_ms: u128,
     max_schedule_gap_ms: u128,
+    message_build_duration_ms: u128,
+    tool_call_build_duration_ms: u128,
+    tool_burst_build_duration_ms: u128,
+    subagent_build_duration_ms: u128,
+    total_row_build_duration_ms: u128,
+    worst_row_kind: Option<TranscriptRowBuildKind>,
+    worst_row_build_duration_ms: u128,
+    max_post_drop_residual_ms: u128,
     first_page_load_to_factory_push_ms: Option<u128>,
     message_count: usize,
     tool_call_count: usize,
@@ -202,6 +252,12 @@ pub enum SessionDetailMsg {
     /// Indicates that a transcript row failed to expand to its full content and
     /// should trigger the shared toast notification path.
     ShowExpandLoadFailure,
+    RowBuilt {
+        item_index: usize,
+        render_batch_index: usize,
+        kind: TranscriptRowBuildKind,
+        build_duration_ms: u128,
+    },
     Clear,
     InspectToolCall(String),
     InspectSubagent(String),
@@ -756,6 +812,17 @@ impl Component for SessionDetail {
                     transcript_item_index,
                     ..
                 } => SessionDetailMsg::InspectReasoning(transcript_item_index),
+                TranscriptRowOutput::RowBuilt {
+                    item_index,
+                    render_batch_index,
+                    kind,
+                    build_duration_ms,
+                } => SessionDetailMsg::RowBuilt {
+                    item_index,
+                    render_batch_index,
+                    kind,
+                    build_duration_ms,
+                },
             });
 
         let db_path = Arc::new(db_path);
@@ -979,6 +1046,20 @@ impl Component for SessionDetail {
             SessionDetailMsg::ShowExpandLoadFailure => {
                 tracing::warn!("Could not load full message content");
                 self.pending_toast.set(true);
+            }
+            SessionDetailMsg::RowBuilt {
+                item_index,
+                render_batch_index,
+                kind,
+                build_duration_ms,
+            } => {
+                self.record_transcript_row_build(
+                    sender,
+                    item_index,
+                    render_batch_index,
+                    kind,
+                    build_duration_ms,
+                );
             }
             SessionDetailMsg::ClearSearch => {
                 self.search_query = None;
@@ -1676,6 +1757,11 @@ impl SessionDetail {
             total_push_duration: Duration::ZERO,
             max_push_duration: Duration::ZERO,
             max_schedule_gap: Duration::ZERO,
+            row_build_totals: RenderRowBuildTotals::default(),
+            row_build_count: 0,
+            worst_row_kind: None,
+            worst_row_duration: Duration::ZERO,
+            batch_breakdowns: Vec::new(),
             row_kind_counts,
             items: items.into(),
         });
@@ -1718,10 +1804,12 @@ impl SessionDetail {
         let mut guard = self.messages.guard();
         let push_started_at = Instant::now();
         let mut rendered_this_batch = 0usize;
+        let render_batch_index = batch.batch_count + 1;
         for _ in 0..RENDER_BATCH_SIZE {
-            let Some(item) = batch.items.pop_front() else {
+            let Some(mut item) = batch.items.pop_front() else {
                 break;
             };
+            item.set_render_batch_index(render_batch_index);
             guard.push_back(item);
             rendered_this_batch += 1;
         }
@@ -1741,7 +1829,14 @@ impl SessionDetail {
         let max_push_duration_ms = batch.max_push_duration.as_millis();
         let max_schedule_gap_ms = batch.max_schedule_gap.as_millis();
         let total_duration_ms = batch.queued_at.elapsed().as_millis();
-        let row_kind_counts = batch.row_kind_counts.clone();
+        batch.batch_breakdowns.push(RenderBatchBreakdown {
+            render_batch_index,
+            pushed_row_count: rendered_this_batch,
+            row_build_count: 0,
+            schedule_gap,
+            row_build_duration: Duration::ZERO,
+            logged: false,
+        });
         batch.last_batch_completed_at = Some(Instant::now());
         drop(guard);
 
@@ -1780,41 +1875,161 @@ impl SessionDetail {
                     "First transcript page factory push complete"
                 );
             }
-            tracing::info!(
+            self.maybe_complete_transcript_render(sender, first_page_load_to_factory_push_ms);
+        }
+    }
+
+    fn record_transcript_row_build(
+        &mut self,
+        sender: ComponentSender<Self>,
+        item_index: usize,
+        render_batch_index: usize,
+        kind: TranscriptRowBuildKind,
+        build_duration_ms: u128,
+    ) {
+        let Some(batch) = &mut self.pending_render_batch else {
+            return;
+        };
+
+        let duration = Duration::from_millis(build_duration_ms.try_into().unwrap_or(u64::MAX));
+        batch.row_build_totals.add(kind, duration);
+        batch.row_build_count += 1;
+        if batch.worst_row_kind.is_none() || duration > batch.worst_row_duration {
+            batch.worst_row_duration = duration;
+            batch.worst_row_kind = Some(kind);
+        }
+
+        let request_id = batch.request_id;
+        let offset = batch.offset;
+        if let Some(breakdown) = batch
+            .batch_breakdowns
+            .iter_mut()
+            .find(|breakdown| breakdown.render_batch_index == render_batch_index)
+        {
+            breakdown.row_build_count += 1;
+            breakdown.row_build_duration += duration;
+            if !breakdown.logged && breakdown.row_build_count >= breakdown.pushed_row_count {
+                breakdown.logged = true;
+                let post_drop_residual = breakdown
+                    .schedule_gap
+                    .saturating_sub(breakdown.row_build_duration);
+                tracing::debug!(
+                    request_id,
+                    offset,
+                    render_batch_index,
+                    pushed_row_count = breakdown.pushed_row_count,
+                    row_build_count = breakdown.row_build_count,
+                    measured_row_build_ms = breakdown.row_build_duration.as_millis(),
+                    schedule_gap_ms = breakdown.schedule_gap.as_millis(),
+                    post_drop_residual_ms = post_drop_residual.as_millis(),
+                    "Measured transcript render batch breakdown"
+                );
+            }
+        } else {
+            tracing::debug!(
                 request_id,
                 offset,
-                source_row_count,
-                display_item_count = total_items,
-                rendered_items,
-                batch_count,
-                total_push_duration_ms,
-                max_push_duration_ms,
-                total_duration_ms,
-                message_count = row_kind_counts.message_count,
-                tool_call_count = row_kind_counts.tool_call_count,
-                tool_burst_count = row_kind_counts.tool_burst_count,
-                subagent_count = row_kind_counts.subagent_count,
-                max_schedule_gap_ms,
-                "Finished rendering transcript page"
+                item_index,
+                render_batch_index,
+                kind = ?kind,
+                build_duration_ms,
+                "Ignoring transcript row build metric without matching render batch"
             );
-            self.last_render_metrics = Some(RenderMetrics {
-                offset,
-                source_row_count,
-                display_item_count: total_items,
-                batch_count,
-                total_duration_ms,
-                total_push_duration_ms,
-                max_push_duration_ms,
-                max_schedule_gap_ms,
-                first_page_load_to_factory_push_ms,
-                message_count: row_kind_counts.message_count,
-                tool_call_count: row_kind_counts.tool_call_count,
-                tool_burst_count: row_kind_counts.tool_burst_count,
-                subagent_count: row_kind_counts.subagent_count,
-            });
-            self.pending_render_batch = None;
-            self.continue_pending_jump(sender);
         }
+
+        let first_page_load_to_factory_push_ms = if batch.offset == 0 {
+            self.first_page_load_started_at
+                .map(|started_at| started_at.elapsed().as_millis())
+        } else {
+            None
+        };
+        self.maybe_complete_transcript_render(&sender, first_page_load_to_factory_push_ms);
+    }
+
+    fn maybe_complete_transcript_render(
+        &mut self,
+        sender: &ComponentSender<Self>,
+        first_page_load_to_factory_push_ms: Option<u128>,
+    ) {
+        let Some(batch) = &self.pending_render_batch else {
+            return;
+        };
+        if !batch.items.is_empty() || batch.row_build_count < batch.rendered_items {
+            return;
+        }
+
+        let batch = self
+            .pending_render_batch
+            .take()
+            .expect("pending batch checked above");
+        let total_push_duration_ms = batch.total_push_duration.as_millis();
+        let max_push_duration_ms = batch.max_push_duration.as_millis();
+        let max_schedule_gap_ms = batch.max_schedule_gap.as_millis();
+        let total_duration_ms = batch.queued_at.elapsed().as_millis();
+        let total_row_build_duration_ms = batch.row_build_totals.total().as_millis();
+        let max_post_drop_residual_ms = batch
+            .batch_breakdowns
+            .iter()
+            .map(|breakdown| {
+                breakdown
+                    .schedule_gap
+                    .saturating_sub(breakdown.row_build_duration)
+            })
+            .max()
+            .unwrap_or(Duration::ZERO)
+            .as_millis();
+
+        tracing::info!(
+            request_id = batch.request_id,
+            offset = batch.offset,
+            source_row_count = batch.source_row_count,
+            display_item_count = batch.total_items,
+            rendered_items = batch.rendered_items,
+            row_build_count = batch.row_build_count,
+            batch_count = batch.batch_count,
+            total_push_duration_ms,
+            max_push_duration_ms,
+            total_duration_ms,
+            message_count = batch.row_kind_counts.message_count,
+            tool_call_count = batch.row_kind_counts.tool_call_count,
+            tool_burst_count = batch.row_kind_counts.tool_burst_count,
+            subagent_count = batch.row_kind_counts.subagent_count,
+            message_build_duration_ms = batch.row_build_totals.message_duration.as_millis(),
+            tool_call_build_duration_ms = batch.row_build_totals.tool_call_duration.as_millis(),
+            tool_burst_build_duration_ms = batch.row_build_totals.tool_burst_duration.as_millis(),
+            subagent_build_duration_ms = batch.row_build_totals.subagent_duration.as_millis(),
+            total_row_build_duration_ms,
+            worst_row_kind = ?batch.worst_row_kind,
+            worst_row_build_duration_ms = batch.worst_row_duration.as_millis(),
+            max_schedule_gap_ms,
+            max_post_drop_residual_ms,
+            "Finished rendering transcript page"
+        );
+
+        self.last_render_metrics = Some(RenderMetrics {
+            offset: batch.offset,
+            source_row_count: batch.source_row_count,
+            display_item_count: batch.total_items,
+            batch_count: batch.batch_count,
+            total_duration_ms,
+            total_push_duration_ms,
+            max_push_duration_ms,
+            max_schedule_gap_ms,
+            message_build_duration_ms: batch.row_build_totals.message_duration.as_millis(),
+            tool_call_build_duration_ms: batch.row_build_totals.tool_call_duration.as_millis(),
+            tool_burst_build_duration_ms: batch.row_build_totals.tool_burst_duration.as_millis(),
+            subagent_build_duration_ms: batch.row_build_totals.subagent_duration.as_millis(),
+            total_row_build_duration_ms,
+            worst_row_kind: batch.worst_row_kind,
+            worst_row_build_duration_ms: batch.worst_row_duration.as_millis(),
+            max_post_drop_residual_ms,
+            first_page_load_to_factory_push_ms,
+            message_count: batch.row_kind_counts.message_count,
+            tool_call_count: batch.row_kind_counts.tool_call_count,
+            tool_burst_count: batch.row_kind_counts.tool_burst_count,
+            subagent_count: batch.row_kind_counts.subagent_count,
+        });
+        self.continue_pending_jump(sender);
     }
 
     fn apply_first_page_rows(
@@ -2359,6 +2574,20 @@ mod tests {
         }
     }
 
+    fn pump_main_context_for(timeout: Duration, condition: impl Fn() -> bool) {
+        let context = gtk::glib::MainContext::default();
+        let deadline = std::time::Instant::now() + timeout;
+        while std::time::Instant::now() < deadline {
+            if condition() {
+                return;
+            }
+
+            if !context.iteration(false) {
+                std::thread::sleep(Duration::from_millis(2));
+            }
+        }
+    }
+
     fn seed_message_transcript(db_path: &std::path::Path, session_id: &str, count: usize) {
         let conn = Connection::open(db_path).expect("open temp db");
         crate::database::schema::initialize_database(&conn).expect("initialize db");
@@ -2508,6 +2737,29 @@ fn synthetic_measurement(input: &str) -> String {\n\
             .last_render_metrics
             .clone()
             .expect("scenario should record render metrics")
+    }
+
+    fn measure_session_detail_metrics_for_session(
+        db_path: &std::path::Path,
+        session: Session,
+    ) -> RenderMetrics {
+        let controller = SessionDetail::builder().launch(db_path.to_path_buf());
+        controller.emit(SessionDetailMsg::SetSession {
+            session: Box::new(session),
+            search_query: None,
+        });
+
+        pump_main_context_for(Duration::from_secs(30), || {
+            let parts = controller.state().get();
+            parts.model.pending_render_batch.is_none() && parts.model.last_render_metrics.is_some()
+        });
+
+        let parts = controller.state().get();
+        parts
+            .model
+            .last_render_metrics
+            .clone()
+            .expect("session should record render metrics")
     }
 
     fn transcript_message_row(
@@ -2883,6 +3135,17 @@ fn synthetic_measurement(input: &str) -> String {\n\
         assert_eq!(metrics.tool_call_count, 0);
         assert_eq!(metrics.tool_burst_count, 0);
         assert_eq!(metrics.subagent_count, 0);
+        assert_eq!(
+            metrics.worst_row_kind,
+            Some(TranscriptRowBuildKind::Message)
+        );
+        assert_eq!(
+            metrics.total_row_build_duration_ms,
+            metrics.message_build_duration_ms
+                + metrics.tool_call_build_duration_ms
+                + metrics.tool_burst_build_duration_ms
+                + metrics.subagent_build_duration_ms
+        );
         assert!(metrics.first_page_load_to_factory_push_ms.is_some());
     }
 
@@ -2946,6 +3209,46 @@ fn synthetic_measurement(input: &str) -> String {\n\
         assert_eq!(markdown_metrics.message_count, INITIAL_PAGE_SIZE);
         assert_eq!(markdown_search_metrics.source_row_count, INITIAL_PAGE_SIZE);
         assert_eq!(markdown_search_metrics.message_count, INITIAL_PAGE_SIZE);
+    }
+
+    #[gtk::test]
+    #[ignore = "manual issue #140 reference-session measurement; requires local Codex session file"]
+    fn session_detail_issue_140_reference_session_breakdown() {
+        const SESSION_ID: &str = "019dc51a-f0cd-79c1-ba79-45fedac889c2";
+        let source_file = std::env::var("SESSION_DETAIL_ISSUE_140_SOURCE_FILE")
+            .expect("SESSION_DETAIL_ISSUE_140_SOURCE_FILE must point to the reference JSONL file");
+        let source_file = std::path::Path::new(&source_file);
+        assert!(
+            source_file.exists(),
+            "reference Codex session file must exist at {}",
+            source_file.display()
+        );
+
+        let temp_root = tempfile::tempdir().expect("temp session root");
+        let target_dir = temp_root.path().join("2026/04/25");
+        std::fs::create_dir_all(&target_dir).expect("create session fixture dir");
+        std::fs::copy(
+            source_file,
+            target_dir.join(source_file.file_name().expect("source file name")),
+        )
+        .expect("copy reference session");
+
+        let temp_db = tempfile::NamedTempFile::new().expect("temp db");
+        let mut indexer = crate::database::SessionIndexer::new(temp_db.path()).expect("indexer");
+        indexer
+            .index_codex_sessions(temp_root.path())
+            .expect("index reference Codex session");
+        let session = crate::database::load_session(temp_db.path(), SESSION_ID)
+            .expect("load reference session")
+            .expect("reference session should be indexed");
+
+        let metrics = measure_session_detail_metrics_for_session(temp_db.path(), session);
+        println!("issue-140-reference: {metrics:#?}");
+
+        assert_eq!(metrics.offset, 0);
+        assert_eq!(metrics.source_row_count, INITIAL_PAGE_SIZE);
+        assert!(metrics.total_row_build_duration_ms > 0);
+        assert!(metrics.worst_row_kind.is_some());
     }
 
     #[test]

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -103,12 +103,10 @@ struct PendingRenderBatch {
     max_push_duration: Duration,
     max_schedule_gap: Duration,
     row_build_totals: RenderRowBuildTotals,
-    #[cfg(debug_assertions)]
     row_build_count: usize,
     worst_row_kind: Option<TranscriptRowBuildKind>,
     worst_row_duration: Duration,
     batch_breakdowns: Vec<RenderBatchBreakdown>,
-    #[cfg(debug_assertions)]
     item_render_batch_indices: std::collections::HashMap<usize, usize>,
     row_kind_counts: RenderRowKindCounts,
     items: VecDeque<TranscriptItemInit>,
@@ -141,7 +139,6 @@ struct RenderBatchBreakdown {
 }
 
 impl RenderRowBuildTotals {
-    #[cfg(debug_assertions)]
     fn add(&mut self, kind: TranscriptRowBuildKind, duration: Duration) {
         match kind {
             TranscriptRowBuildKind::Message => self.message_duration += duration,
@@ -256,7 +253,6 @@ pub enum SessionDetailMsg {
     /// Indicates that a transcript row failed to expand to its full content and
     /// should trigger the shared toast notification path.
     ShowExpandLoadFailure,
-    #[cfg(debug_assertions)]
     RowBuilt {
         item_index: usize,
         kind: TranscriptRowBuildKind,
@@ -816,7 +812,6 @@ impl Component for SessionDetail {
                     transcript_item_index,
                     ..
                 } => SessionDetailMsg::InspectReasoning(transcript_item_index),
-                #[cfg(debug_assertions)]
                 TranscriptRowOutput::RowBuilt {
                     item_index,
                     kind,
@@ -1050,7 +1045,6 @@ impl Component for SessionDetail {
                 tracing::warn!("Could not load full message content");
                 self.pending_toast.set(true);
             }
-            #[cfg(debug_assertions)]
             SessionDetailMsg::RowBuilt {
                 item_index,
                 kind,
@@ -1755,12 +1749,10 @@ impl SessionDetail {
             max_push_duration: Duration::ZERO,
             max_schedule_gap: Duration::ZERO,
             row_build_totals: RenderRowBuildTotals::default(),
-            #[cfg(debug_assertions)]
             row_build_count: 0,
             worst_row_kind: None,
             worst_row_duration: Duration::ZERO,
             batch_breakdowns: Vec::new(),
-            #[cfg(debug_assertions)]
             item_render_batch_indices: std::collections::HashMap::new(),
             row_kind_counts,
             items: items.into(),
@@ -1809,7 +1801,6 @@ impl SessionDetail {
             let Some(item) = batch.items.pop_front() else {
                 break;
             };
-            #[cfg(debug_assertions)]
             batch
                 .item_render_batch_indices
                 .insert(item.item_index(), render_batch_index);
@@ -1882,7 +1873,6 @@ impl SessionDetail {
         }
     }
 
-    #[cfg(debug_assertions)]
     fn record_transcript_row_build(
         &mut self,
         sender: ComponentSender<Self>,
@@ -1963,7 +1953,6 @@ impl SessionDetail {
         if !batch.items.is_empty() {
             return;
         }
-        #[cfg(debug_assertions)]
         if batch.row_build_count < batch.rendered_items {
             return;
         }
@@ -1995,33 +1984,30 @@ impl SessionDetail {
             "Finished rendering transcript page"
         );
 
-        #[cfg(debug_assertions)]
-        {
-            let total_row_build_duration_ms = batch.row_build_totals.total().as_millis();
-            let max_post_drop_residual_ms = batch
-                .batch_breakdowns
-                .iter()
-                .map(|b| b.schedule_gap.saturating_sub(b.row_build_duration))
-                .max()
-                .unwrap_or(Duration::ZERO)
-                .as_millis();
-            tracing::info!(
-                request_id = batch.request_id,
-                offset = batch.offset,
-                row_build_count = batch.row_build_count,
-                message_build_duration_ms = batch.row_build_totals.message_duration.as_millis(),
-                tool_call_build_duration_ms =
-                    batch.row_build_totals.tool_call_duration.as_millis(),
-                tool_burst_build_duration_ms =
-                    batch.row_build_totals.tool_burst_duration.as_millis(),
-                subagent_build_duration_ms = batch.row_build_totals.subagent_duration.as_millis(),
-                total_row_build_duration_ms,
-                worst_row_kind = ?batch.worst_row_kind,
-                worst_row_build_duration_ms = batch.worst_row_duration.as_millis(),
-                max_post_drop_residual_ms,
-                "Transcript page row-build breakdown"
-            );
-        }
+        let total_row_build_duration_ms = batch.row_build_totals.total().as_millis();
+        let max_post_drop_residual_ms = batch
+            .batch_breakdowns
+            .iter()
+            .map(|b| b.schedule_gap.saturating_sub(b.row_build_duration))
+            .max()
+            .unwrap_or(Duration::ZERO)
+            .as_millis();
+        tracing::debug!(
+            request_id = batch.request_id,
+            offset = batch.offset,
+            row_build_count = batch.row_build_count,
+            message_build_duration_ms = batch.row_build_totals.message_duration.as_millis(),
+            tool_call_build_duration_ms =
+                batch.row_build_totals.tool_call_duration.as_millis(),
+            tool_burst_build_duration_ms =
+                batch.row_build_totals.tool_burst_duration.as_millis(),
+            subagent_build_duration_ms = batch.row_build_totals.subagent_duration.as_millis(),
+            total_row_build_duration_ms,
+            worst_row_kind = ?batch.worst_row_kind,
+            worst_row_build_duration_ms = batch.worst_row_duration.as_millis(),
+            max_post_drop_residual_ms,
+            "Transcript page row-build breakdown"
+        );
 
         self.last_render_metrics = Some(RenderMetrics {
             offset: batch.offset,

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -111,6 +111,7 @@ struct PendingRenderBatch {
     row_kind_counts: RenderRowKindCounts,
     items: VecDeque<TranscriptItemInit>,
     first_page_load_to_factory_push_ms: Option<u128>,
+    push_complete: bool,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -1560,7 +1561,12 @@ impl SessionDetail {
     /// because `display_targets_by_item_index` is only populated as pages
     /// finish rendering.
     fn is_transcript_loading(&self) -> bool {
-        self.loading_first_page || self.loading_next_page || self.pending_render_batch.is_some()
+        self.loading_first_page
+            || self.loading_next_page
+            || self
+                .pending_render_batch
+                .as_ref()
+                .is_some_and(|b| !b.push_complete)
     }
 
     fn spawn_match_positions_load(
@@ -1758,6 +1764,7 @@ impl SessionDetail {
             row_kind_counts,
             items: items.into(),
             first_page_load_to_factory_push_ms: None,
+            push_complete: false,
         });
         self.schedule_transcript_render_batch(sender, request_id);
     }
@@ -1873,8 +1880,9 @@ impl SessionDetail {
             }
             if let Some(batch) = self.pending_render_batch.as_mut() {
                 batch.first_page_load_to_factory_push_ms = first_page_load_to_factory_push_ms;
+                batch.push_complete = true;
             }
-            self.maybe_complete_transcript_render(sender);
+            self.complete_transcript_render_push(sender);
         }
     }
 
@@ -1938,14 +1946,14 @@ impl SessionDetail {
             }
         }
 
-        self.maybe_complete_transcript_render(&sender);
+        self.maybe_log_row_build_breakdown(&sender);
     }
 
-    fn maybe_complete_transcript_render(&mut self, sender: &ComponentSender<Self>) {
+    fn maybe_log_row_build_breakdown(&mut self, _sender: &ComponentSender<Self>) {
         let Some(batch) = &self.pending_render_batch else {
             return;
         };
-        if !batch.items.is_empty() {
+        if !batch.push_complete {
             return;
         }
         if batch.row_build_count < batch.rendered_items {
@@ -1956,29 +1964,6 @@ impl SessionDetail {
             .pending_render_batch
             .take()
             .expect("pending batch checked above");
-        let total_push_duration_ms = batch.total_push_duration.as_millis();
-        let max_push_duration_ms = batch.max_push_duration.as_millis();
-        let max_schedule_gap_ms = batch.max_schedule_gap.as_millis();
-        let total_duration_ms = batch.queued_at.elapsed().as_millis();
-
-        tracing::info!(
-            request_id = batch.request_id,
-            offset = batch.offset,
-            source_row_count = batch.source_row_count,
-            display_item_count = batch.total_items,
-            rendered_items = batch.rendered_items,
-            batch_count = batch.batch_count,
-            total_push_duration_ms,
-            max_push_duration_ms,
-            total_duration_ms,
-            message_count = batch.row_kind_counts.message_count,
-            tool_call_count = batch.row_kind_counts.tool_call_count,
-            tool_burst_count = batch.row_kind_counts.tool_burst_count,
-            subagent_count = batch.row_kind_counts.subagent_count,
-            max_schedule_gap_ms,
-            "Finished rendering transcript page"
-        );
-
         let total_row_build_duration_ms = batch.row_build_totals.total().as_millis();
         let max_post_drop_residual_ms = batch
             .batch_breakdowns
@@ -2009,30 +1994,80 @@ impl SessionDetail {
             source_row_count: batch.source_row_count,
             display_item_count: batch.total_items,
             batch_count: batch.batch_count,
-            total_duration_ms,
-            total_push_duration_ms,
-            max_push_duration_ms,
-            max_schedule_gap_ms,
+            total_duration_ms: batch.queued_at.elapsed().as_millis(),
+            total_push_duration_ms: batch.total_push_duration.as_millis(),
+            max_push_duration_ms: batch.max_push_duration.as_millis(),
+            max_schedule_gap_ms: batch.max_schedule_gap.as_millis(),
             message_build_duration_ms: batch.row_build_totals.message_duration.as_millis(),
             tool_call_build_duration_ms: batch.row_build_totals.tool_call_duration.as_millis(),
             tool_burst_build_duration_ms: batch.row_build_totals.tool_burst_duration.as_millis(),
             subagent_build_duration_ms: batch.row_build_totals.subagent_duration.as_millis(),
-            total_row_build_duration_ms: batch.row_build_totals.total().as_millis(),
+            total_row_build_duration_ms,
             worst_row_kind: batch.worst_row_kind,
             worst_row_build_duration_ms: batch.worst_row_duration.as_millis(),
-            max_post_drop_residual_ms: batch
-                .batch_breakdowns
-                .iter()
-                .map(|b| b.schedule_gap.saturating_sub(b.row_build_duration))
-                .max()
-                .unwrap_or(Duration::ZERO)
-                .as_millis(),
+            max_post_drop_residual_ms,
             first_page_load_to_factory_push_ms: batch.first_page_load_to_factory_push_ms,
             message_count: batch.row_kind_counts.message_count,
             tool_call_count: batch.row_kind_counts.tool_call_count,
             tool_burst_count: batch.row_kind_counts.tool_burst_count,
             subagent_count: batch.row_kind_counts.subagent_count,
         });
+    }
+
+    fn complete_transcript_render_push(&mut self, sender: &ComponentSender<Self>) {
+        let (
+            total_push_duration_ms,
+            max_push_duration_ms,
+            max_schedule_gap_ms,
+            total_duration_ms,
+            request_id,
+            offset,
+            source_row_count,
+            total_items,
+            rendered_items,
+            batch_count,
+            message_count,
+            tool_call_count,
+            tool_burst_count,
+            subagent_count,
+        ) = {
+            let Some(batch) = &self.pending_render_batch else {
+                return;
+            };
+            (
+                batch.total_push_duration.as_millis(),
+                batch.max_push_duration.as_millis(),
+                batch.max_schedule_gap.as_millis(),
+                batch.queued_at.elapsed().as_millis(),
+                batch.request_id,
+                batch.offset,
+                batch.source_row_count,
+                batch.total_items,
+                batch.rendered_items,
+                batch.batch_count,
+                batch.row_kind_counts.message_count,
+                batch.row_kind_counts.tool_call_count,
+                batch.row_kind_counts.tool_burst_count,
+                batch.row_kind_counts.subagent_count,
+            )
+        };
+        tracing::info!(
+            request_id,
+            offset,
+            source_row_count,
+            display_item_count = total_items,
+            rendered_items,
+            batch_count,
+            total_push_duration_ms,
+            max_push_duration_ms,
+            total_duration_ms,
+            message_count,
+            tool_call_count,
+            tool_burst_count,
+            subagent_count,
+            max_schedule_gap_ms,
+            "Finished rendering transcript page"
+        );
         self.continue_pending_jump(sender);
     }
 

--- a/src/ui/transcript_row.rs
+++ b/src/ui/transcript_row.rs
@@ -57,6 +57,7 @@ pub struct MessageItemInit {
     pub preview: MessagePreview,
     pub highlight_query: Option<String>,
     pub db_path: Arc<PathBuf>,
+    pub render_batch_index: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -90,6 +91,8 @@ pub struct ToolCallItemInit {
     pub highlight_query: Option<String>,
     /// Presence flags for associated reasoning attachment.
     pub reasoning_preview: ReasoningPreview,
+    /// Instrumentation-only batch ordinal assigned by `SessionDetail`.
+    pub render_batch_index: usize,
 }
 
 impl ToolCallItemInit {
@@ -112,6 +115,7 @@ pub struct ToolBurstItemInit {
     pub visible_reasoning_child_count: usize,
     pub encrypted_only_child_count: usize,
     pub default_expanded: bool,
+    pub render_batch_index: usize,
 }
 
 pub struct SubagentItemInit {
@@ -121,6 +125,7 @@ pub struct SubagentItemInit {
     pub subagent_id: String,
     pub title: String,
     pub reasoning_preview: ReasoningPreview,
+    pub render_batch_index: usize,
 }
 
 pub enum TranscriptItemInit {
@@ -128,6 +133,17 @@ pub enum TranscriptItemInit {
     ToolCall(ToolCallItemInit),
     ToolBurst(ToolBurstItemInit),
     Subagent(SubagentItemInit),
+}
+
+impl TranscriptItemInit {
+    pub fn set_render_batch_index(&mut self, render_batch_index: usize) {
+        match self {
+            Self::Message(init) => init.render_batch_index = render_batch_index,
+            Self::ToolCall(init) => init.render_batch_index = render_batch_index,
+            Self::ToolBurst(init) => init.render_batch_index = render_batch_index,
+            Self::Subagent(init) => init.render_batch_index = render_batch_index,
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -158,6 +174,12 @@ pub enum TranscriptRowOutput {
         session_id: String,
         transcript_item_index: i64,
     },
+    RowBuilt {
+        item_index: usize,
+        render_batch_index: usize,
+        kind: TranscriptRowBuildKind,
+        build_duration_ms: u128,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -172,6 +194,25 @@ enum TranscriptRowKind {
     Subagent,
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum TranscriptRowBuildKind {
+    Message,
+    ToolCall,
+    ToolBurst,
+    Subagent,
+}
+
+impl From<TranscriptRowKind> for TranscriptRowBuildKind {
+    fn from(kind: TranscriptRowKind) -> Self {
+        match kind {
+            TranscriptRowKind::Message => Self::Message,
+            TranscriptRowKind::ToolCall => Self::ToolCall,
+            TranscriptRowKind::ToolBurst => Self::ToolBurst,
+            TranscriptRowKind::Subagent => Self::Subagent,
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Model
 // ---------------------------------------------------------------------------
@@ -179,6 +220,7 @@ enum TranscriptRowKind {
 #[derive(Debug)]
 pub struct TranscriptRow {
     item_index: usize,
+    render_batch_index: usize,
     transcript_item_index: Option<i64>,
     session_id: Option<String>,
     reasoning_preview: Option<ReasoningPreview>,
@@ -321,6 +363,7 @@ pub fn build_tool_burst_init(
         visible_reasoning_child_count,
         encrypted_only_child_count,
         default_expanded,
+        render_batch_index: 0,
     }
 }
 
@@ -600,6 +643,7 @@ impl FactoryComponent for TranscriptRow {
         match init {
             TranscriptItemInit::Message(m) => Self {
                 item_index: m.item_index,
+                render_batch_index: m.render_batch_index,
                 transcript_item_index: Some(m.transcript_item_index),
                 session_id: Some(m.preview.session_id.clone()),
                 reasoning_preview: Some(m.preview.reasoning_preview),
@@ -623,6 +667,7 @@ impl FactoryComponent for TranscriptRow {
             },
             TranscriptItemInit::ToolCall(tc) => Self {
                 item_index: tc.item_index,
+                render_batch_index: tc.render_batch_index,
                 transcript_item_index: Some(tc.transcript_item_index),
                 session_id: Some(tc.session_id.clone()),
                 reasoning_preview: Some(tc.reasoning_preview),
@@ -646,6 +691,7 @@ impl FactoryComponent for TranscriptRow {
             },
             TranscriptItemInit::ToolBurst(tb) => Self {
                 item_index: tb.item_index,
+                render_batch_index: tb.render_batch_index,
                 transcript_item_index: None,
                 session_id: None,
                 reasoning_preview: None,
@@ -669,6 +715,7 @@ impl FactoryComponent for TranscriptRow {
             },
             TranscriptItemInit::Subagent(sa) => Self {
                 item_index: sa.item_index,
+                render_batch_index: sa.render_batch_index,
                 transcript_item_index: Some(sa.transcript_item_index),
                 session_id: Some(sa.session_id),
                 reasoning_preview: Some(sa.reasoning_preview),
@@ -702,10 +749,10 @@ impl FactoryComponent for TranscriptRow {
     ) -> Self::Widgets {
         let started_at = Instant::now();
         let widgets = match self.kind {
-            TranscriptRowKind::Message => self.build_message_widgets(&root, sender),
-            TranscriptRowKind::ToolCall => self.build_tool_call_widgets(&root, sender),
-            TranscriptRowKind::ToolBurst => self.build_tool_burst_widgets(&root, sender),
-            TranscriptRowKind::Subagent => self.build_subagent_widgets(&root, sender),
+            TranscriptRowKind::Message => self.build_message_widgets(&root, sender.clone()),
+            TranscriptRowKind::ToolCall => self.build_tool_call_widgets(&root, sender.clone()),
+            TranscriptRowKind::ToolBurst => self.build_tool_burst_widgets(&root, sender.clone()),
+            TranscriptRowKind::Subagent => self.build_subagent_widgets(&root, sender.clone()),
         };
         let duration = started_at.elapsed();
 
@@ -725,6 +772,14 @@ impl FactoryComponent for TranscriptRow {
                 "Slow transcript row widget build"
             );
         }
+        sender
+            .output(TranscriptRowOutput::RowBuilt {
+                item_index: self.item_index,
+                render_batch_index: self.render_batch_index,
+                kind: self.kind.into(),
+                build_duration_ms: duration.as_millis(),
+            })
+            .ok();
 
         widgets
     }
@@ -1001,6 +1056,7 @@ impl TranscriptRow {
             duration_ms: self.tool_duration_ms,
             highlight_query: self.tool_highlight_query.clone(),
             reasoning_preview: self.reasoning_preview.unwrap_or_default(),
+            render_batch_index: self.render_batch_index,
         };
 
         let build_started_at = Instant::now();
@@ -1330,6 +1386,7 @@ fn transcript_item_init_from_row_with_index(
                 },
                 highlight_query,
                 db_path,
+                render_batch_index: 0,
             })
         }
         TranscriptItemKind::ToolCall => TranscriptItemInit::ToolCall(ToolCallItemInit {
@@ -1352,6 +1409,7 @@ fn transcript_item_init_from_row_with_index(
             duration_ms: row.duration_ms,
             highlight_query,
             reasoning_preview: row.reasoning_preview,
+            render_batch_index: 0,
         }),
         TranscriptItemKind::Subagent => TranscriptItemInit::Subagent(SubagentItemInit {
             item_index,
@@ -1363,6 +1421,7 @@ fn transcript_item_init_from_row_with_index(
                 .clone()
                 .unwrap_or_else(|| "Subagent".to_string()),
             reasoning_preview: row.reasoning_preview,
+            render_batch_index: 0,
         }),
         TranscriptItemKind::Unknown => {
             tracing::warn!(
@@ -1384,6 +1443,7 @@ fn transcript_item_init_from_row_with_index(
                 },
                 highlight_query,
                 db_path,
+                render_batch_index: 0,
             })
         }
     }
@@ -1531,6 +1591,7 @@ mod tests {
             duration_ms: Some(12),
             highlight_query: Some("read".to_string()),
             reasoning_preview: ReasoningPreview::default(),
+            render_batch_index: 0,
         };
         // Only "Read" in tool_name matches; preview has no "read", summary is hidden.
         assert_eq!(count_tool_call_matches(&with_preview), 1);
@@ -1548,6 +1609,7 @@ mod tests {
             duration_ms: Some(12),
             highlight_query: Some("read".to_string()),
             reasoning_preview: ReasoningPreview::default(),
+            render_batch_index: 0,
         };
         // "Read" in tool_name + "read" in summary fallback = 2.
         assert_eq!(count_tool_call_matches(&with_summary_fallback), 2);
@@ -1572,6 +1634,7 @@ mod tests {
                     has_visible_reasoning: true,
                     encrypted_only: false,
                 },
+                render_batch_index: 0,
             },
             |_| {},
             |_, _| {},
@@ -1701,6 +1764,7 @@ mod tests {
                 duration_ms: Some(5),
                 highlight_query: Some("read".to_string()),
                 reasoning_preview: ReasoningPreview::default(),
+                render_batch_index: 0,
             },
             ToolCallItemInit {
                 item_index: 2,
@@ -1714,6 +1778,7 @@ mod tests {
                 duration_ms: Some(8),
                 highlight_query: Some("edit".to_string()),
                 reasoning_preview: ReasoningPreview::default(),
+                render_batch_index: 0,
             },
         ];
 

--- a/src/ui/transcript_row.rs
+++ b/src/ui/transcript_row.rs
@@ -57,7 +57,6 @@ pub struct MessageItemInit {
     pub preview: MessagePreview,
     pub highlight_query: Option<String>,
     pub db_path: Arc<PathBuf>,
-    pub render_batch_index: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -91,8 +90,6 @@ pub struct ToolCallItemInit {
     pub highlight_query: Option<String>,
     /// Presence flags for associated reasoning attachment.
     pub reasoning_preview: ReasoningPreview,
-    /// Instrumentation-only batch ordinal assigned by `SessionDetail`.
-    pub render_batch_index: usize,
 }
 
 impl ToolCallItemInit {
@@ -115,7 +112,6 @@ pub struct ToolBurstItemInit {
     pub visible_reasoning_child_count: usize,
     pub encrypted_only_child_count: usize,
     pub default_expanded: bool,
-    pub render_batch_index: usize,
 }
 
 pub struct SubagentItemInit {
@@ -125,7 +121,6 @@ pub struct SubagentItemInit {
     pub subagent_id: String,
     pub title: String,
     pub reasoning_preview: ReasoningPreview,
-    pub render_batch_index: usize,
 }
 
 pub enum TranscriptItemInit {
@@ -136,12 +131,13 @@ pub enum TranscriptItemInit {
 }
 
 impl TranscriptItemInit {
-    pub fn set_render_batch_index(&mut self, render_batch_index: usize) {
+    #[cfg(debug_assertions)]
+    pub fn item_index(&self) -> usize {
         match self {
-            Self::Message(init) => init.render_batch_index = render_batch_index,
-            Self::ToolCall(init) => init.render_batch_index = render_batch_index,
-            Self::ToolBurst(init) => init.render_batch_index = render_batch_index,
-            Self::Subagent(init) => init.render_batch_index = render_batch_index,
+            Self::Message(init) => init.item_index,
+            Self::ToolCall(init) => init.item_index,
+            Self::ToolBurst(init) => init.item_index,
+            Self::Subagent(init) => init.item_index,
         }
     }
 }
@@ -174,9 +170,9 @@ pub enum TranscriptRowOutput {
         session_id: String,
         transcript_item_index: i64,
     },
+    #[cfg(debug_assertions)]
     RowBuilt {
         item_index: usize,
-        render_batch_index: usize,
         kind: TranscriptRowBuildKind,
         build_duration_ms: u128,
     },
@@ -220,7 +216,6 @@ impl From<TranscriptRowKind> for TranscriptRowBuildKind {
 #[derive(Debug)]
 pub struct TranscriptRow {
     item_index: usize,
-    render_batch_index: usize,
     transcript_item_index: Option<i64>,
     session_id: Option<String>,
     reasoning_preview: Option<ReasoningPreview>,
@@ -363,7 +358,6 @@ pub fn build_tool_burst_init(
         visible_reasoning_child_count,
         encrypted_only_child_count,
         default_expanded,
-        render_batch_index: 0,
     }
 }
 
@@ -643,7 +637,6 @@ impl FactoryComponent for TranscriptRow {
         match init {
             TranscriptItemInit::Message(m) => Self {
                 item_index: m.item_index,
-                render_batch_index: m.render_batch_index,
                 transcript_item_index: Some(m.transcript_item_index),
                 session_id: Some(m.preview.session_id.clone()),
                 reasoning_preview: Some(m.preview.reasoning_preview),
@@ -667,7 +660,6 @@ impl FactoryComponent for TranscriptRow {
             },
             TranscriptItemInit::ToolCall(tc) => Self {
                 item_index: tc.item_index,
-                render_batch_index: tc.render_batch_index,
                 transcript_item_index: Some(tc.transcript_item_index),
                 session_id: Some(tc.session_id.clone()),
                 reasoning_preview: Some(tc.reasoning_preview),
@@ -691,7 +683,6 @@ impl FactoryComponent for TranscriptRow {
             },
             TranscriptItemInit::ToolBurst(tb) => Self {
                 item_index: tb.item_index,
-                render_batch_index: tb.render_batch_index,
                 transcript_item_index: None,
                 session_id: None,
                 reasoning_preview: None,
@@ -715,7 +706,6 @@ impl FactoryComponent for TranscriptRow {
             },
             TranscriptItemInit::Subagent(sa) => Self {
                 item_index: sa.item_index,
-                render_batch_index: sa.render_batch_index,
                 transcript_item_index: Some(sa.transcript_item_index),
                 session_id: Some(sa.session_id),
                 reasoning_preview: Some(sa.reasoning_preview),
@@ -772,10 +762,10 @@ impl FactoryComponent for TranscriptRow {
                 "Slow transcript row widget build"
             );
         }
+        #[cfg(debug_assertions)]
         sender
             .output(TranscriptRowOutput::RowBuilt {
                 item_index: self.item_index,
-                render_batch_index: self.render_batch_index,
                 kind: self.kind.into(),
                 build_duration_ms: duration.as_millis(),
             })
@@ -1056,7 +1046,6 @@ impl TranscriptRow {
             duration_ms: self.tool_duration_ms,
             highlight_query: self.tool_highlight_query.clone(),
             reasoning_preview: self.reasoning_preview.unwrap_or_default(),
-            render_batch_index: self.render_batch_index,
         };
 
         let build_started_at = Instant::now();
@@ -1386,7 +1375,6 @@ fn transcript_item_init_from_row_with_index(
                 },
                 highlight_query,
                 db_path,
-                render_batch_index: 0,
             })
         }
         TranscriptItemKind::ToolCall => TranscriptItemInit::ToolCall(ToolCallItemInit {
@@ -1409,7 +1397,6 @@ fn transcript_item_init_from_row_with_index(
             duration_ms: row.duration_ms,
             highlight_query,
             reasoning_preview: row.reasoning_preview,
-            render_batch_index: 0,
         }),
         TranscriptItemKind::Subagent => TranscriptItemInit::Subagent(SubagentItemInit {
             item_index,
@@ -1421,7 +1408,6 @@ fn transcript_item_init_from_row_with_index(
                 .clone()
                 .unwrap_or_else(|| "Subagent".to_string()),
             reasoning_preview: row.reasoning_preview,
-            render_batch_index: 0,
         }),
         TranscriptItemKind::Unknown => {
             tracing::warn!(
@@ -1443,7 +1429,6 @@ fn transcript_item_init_from_row_with_index(
                 },
                 highlight_query,
                 db_path,
-                render_batch_index: 0,
             })
         }
     }
@@ -1591,7 +1576,6 @@ mod tests {
             duration_ms: Some(12),
             highlight_query: Some("read".to_string()),
             reasoning_preview: ReasoningPreview::default(),
-            render_batch_index: 0,
         };
         // Only "Read" in tool_name matches; preview has no "read", summary is hidden.
         assert_eq!(count_tool_call_matches(&with_preview), 1);
@@ -1609,7 +1593,6 @@ mod tests {
             duration_ms: Some(12),
             highlight_query: Some("read".to_string()),
             reasoning_preview: ReasoningPreview::default(),
-            render_batch_index: 0,
         };
         // "Read" in tool_name + "read" in summary fallback = 2.
         assert_eq!(count_tool_call_matches(&with_summary_fallback), 2);
@@ -1634,7 +1617,6 @@ mod tests {
                     has_visible_reasoning: true,
                     encrypted_only: false,
                 },
-                render_batch_index: 0,
             },
             |_| {},
             |_, _| {},
@@ -1764,7 +1746,6 @@ mod tests {
                 duration_ms: Some(5),
                 highlight_query: Some("read".to_string()),
                 reasoning_preview: ReasoningPreview::default(),
-                render_batch_index: 0,
             },
             ToolCallItemInit {
                 item_index: 2,
@@ -1778,7 +1759,6 @@ mod tests {
                 duration_ms: Some(8),
                 highlight_query: Some("edit".to_string()),
                 reasoning_preview: ReasoningPreview::default(),
-                render_batch_index: 0,
             },
         ];
 

--- a/src/ui/transcript_row.rs
+++ b/src/ui/transcript_row.rs
@@ -131,7 +131,6 @@ pub enum TranscriptItemInit {
 }
 
 impl TranscriptItemInit {
-    #[cfg(debug_assertions)]
     pub fn item_index(&self) -> usize {
         match self {
             Self::Message(init) => init.item_index,
@@ -170,7 +169,6 @@ pub enum TranscriptRowOutput {
         session_id: String,
         transcript_item_index: i64,
     },
-    #[cfg(debug_assertions)]
     RowBuilt {
         item_index: usize,
         kind: TranscriptRowBuildKind,
@@ -762,7 +760,6 @@ impl FactoryComponent for TranscriptRow {
                 "Slow transcript row widget build"
             );
         }
-        #[cfg(debug_assertions)]
         sender
             .output(TranscriptRowOutput::RowBuilt {
                 item_index: self.item_index,


### PR DESCRIPTION
## Summary
- make SessionDetail row-build breakdown metrics available in normal app runs when using `RUST_LOG=info,sessions_chronicle=debug`
- rerun issue #140 on the real full-app open path and update the report with the captured scheduling vs row-build data
- document the full-app measurement approach in a focused spec for the issue-140 follow-up

## Test Plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo test session_detail_records_render_batch_measurements -- --nocapture`
- [x] `cargo test session_detail::tests -- --nocapture`
- [x] `cargo test --all --no-fail-fast`