### PR TITLE
feat: lazily hydrate session detail transcript rows

### DIFF
--- a/data/resources/style.css
+++ b/data/resources/style.css
@@ -15,6 +15,11 @@
   margin-bottom: 8px;
 }
 
+.transcript-row-placeholder {
+  border-radius: 6px;
+  background: alpha(currentColor, 0.035);
+}
+
 /* Role-specific accent colors */
 .role-user {
   border-left-color: #3584e4;

--- a/docs/reports/2026-05-05-session-detail-issue-143-benchmark-report.md
+++ b/docs/reports/2026-05-05-session-detail-issue-143-benchmark-report.md
@@ -1,0 +1,135 @@
+# Session Detail Issue 143 Benchmark Report
+
+## Scope
+
+- Date: 2026-05-05
+- Target session: `019dc51a-f0cd-79c1-ba79-45fedac889c2`
+- AI assistant: Codex
+- Historical baseline: `docs/reports/2026-05-02-session-detail-issue-142-investigation-report.md`
+- Branch under test: `lazy-rows`
+- Branch HEAD during measurement: `6500b06`
+- Measurement types:
+  - real full-app manual rerun
+  - shell-only gate test added for issue #143
+
+## Protocol
+
+### A. Full-app manual rerun
+
+Run command pattern used for each run:
+
+```bash
+RUST_LOG=info,sessions_chronicle=debug cargo run > /tmp/opencode/issue143-manual-runN.log 2>&1
+```
+
+Scenario:
+
+1. Launch the application from the current branch with debug logs redirected to a file.
+2. Wait for background indexing to complete.
+3. Click session `019dc51a-f0cd-79c1-ba79-45fedac889c2` exactly once.
+4. Do not perform search before the click.
+5. Wait for the detail view to settle, then close the app.
+
+Log files:
+
+- `/tmp/opencode/issue143-manual-run1.log`
+- `/tmp/opencode/issue143-manual-run2.log`
+- `/tmp/opencode/issue143-manual-run3.log`
+
+### B. Shell-only gate rerun
+
+Run command pattern used for each run:
+
+```bash
+SESSION_DETAIL_ISSUE_142_SOURCE_FILE=/home/mcizo/.codex/sessions/2026/04/25/rollout-2026-04-25T16-46-10-019dc51a-f0cd-79c1-ba79-45fedac889c2.jsonl \
+  cargo test session_detail_issue_142_shell_weight_gate_reference_session -- --ignored --nocapture
+```
+
+This path exercises the new ignored shell-weight gate test introduced by issue #143. It measures the first-page push budget for the current lazy-row implementation without the extra variability of a manual click path.
+
+Log files:
+
+- `/tmp/opencode/issue143-benchmark/run-1.log`
+- `/tmp/opencode/issue143-benchmark/run-2.log`
+- `/tmp/opencode/issue143-benchmark/run-3.log`
+
+## Historical Baseline (#142)
+
+From `docs/reports/2026-05-02-session-detail-issue-142-investigation-report.md`:
+
+| Variant | Run | Max schedule gap | First-page load to factory push | Max post-drop residual |
+| --- | ---: | ---: | ---: | ---: |
+| baseline | 1 | 1335 ms | 7855 ms | 1334 ms |
+| baseline | 2 | 1346 ms | 7652 ms | 1346 ms |
+| baseline | 3 | 1377 ms | 7885 ms | 1376 ms |
+| baseline | median | 1346 ms | 7855 ms | 1346 ms |
+
+## Current Branch Results
+
+### Full-app manual rerun
+
+| Variant | Run | Max schedule gap | First-page load to factory push | Max post-drop residual |
+| --- | ---: | ---: | ---: | ---: |
+| issue-143-full-app | 1 | 1364 ms | 7909 ms | 1364 ms |
+| issue-143-full-app | 2 | 1346 ms | 7914 ms | 1346 ms |
+| issue-143-full-app | 3 | 1412 ms | 8146 ms | 1412 ms |
+| issue-143-full-app | median | 1364 ms | 7914 ms | 1364 ms |
+
+### Median comparison vs historical baseline
+
+| Variant | Median max schedule gap | Delta vs baseline | Median first-page load to factory push | Delta vs baseline | Verdict |
+| --- | ---: | ---: | ---: | ---: | --- |
+| baseline (#142) | 1346 ms | 0.0% | 7855 ms | 0.0% | Historical reference |
+| issue-143-full-app | 1364 ms | +1.3% | 7914 ms | +0.8% | No full-app improvement in manual rerun |
+
+The manual rerun stays effectively flat against the historical #142 baseline. The current lazy-row implementation does not show a measurable win on the full end-to-end click path under this protocol.
+
+## Shell-Only Gate
+
+| Variant | Run | Max schedule gap | First-page load to factory push | Max post-drop residual |
+| --- | ---: | ---: | ---: | ---: |
+| issue-143-shell-only | 1 | 18 ms | 455 ms | 18 ms |
+| issue-143-shell-only | 2 | 17 ms | 450 ms | 17 ms |
+| issue-143-shell-only | 3 | 18 ms | 455 ms | 18 ms |
+| issue-143-shell-only | median | 18 ms | 455 ms | 18 ms |
+
+Gate verdict:
+
+- Required by the design: `median max_schedule_gap_ms <= 50 ms`
+- Observed: `18 ms`
+- Result: pass
+
+## Supporting Metrics
+
+The new metrics added by this PR support a narrower interpretation than the manual full-app rerun alone:
+
+- The shell-only gate is decisively green. The first-page push budget on the reference session dropped from the historical `1346 ms` median baseline to `18 ms` in the dedicated shell-only path.
+- The shell-only runs show `display_item_count=33`, `batch_count=11`, and `total_row_build_duration_ms=0`, which confirms that the current row shells are cheap enough under the dedicated test harness.
+- The manual full-app reruns still show `max_post_drop_residual_ms` equal to `max_schedule_gap_ms` (`1364`, `1346`, `1412`). As in earlier investigations, the dominant cost still looks like GTK or broader main-loop work after the factory guard is dropped, not synchronous row-build time.
+- The new lazy hydration metrics are therefore useful as supporting evidence that the shell itself is no longer the blocking cost, even though the complete interactive app path still does not improve under this manual protocol.
+
+## Interpretation
+
+This rerun splits issue #143 into two distinct outcomes:
+
+1. The new shell-only gate passes comfortably. The lazy-row shell design achieves the explicit shell-weight target from the issue #143 design.
+2. The real full-app manual click path does not improve versus the historical #142 baseline under the protocol used here.
+
+Taken together, that means the PR successfully removes the shell construction cost as the dominant problem in the dedicated gate, but it does not yet move the end-to-end manual benchmark for the reference session.
+
+The strongest reading is:
+
+- row shells are now cheap enough;
+- deferred hydration mechanics are functionally in place;
+- but the manual full-app path is still dominated by scheduling or other GTK main-loop behavior outside the narrow shell-only gate.
+
+## Verdict
+
+- Shell-only gate for issue #143: pass
+- Manual full-app rerun vs #142 baseline: no measurable improvement
+- Recommendation: keep the shell-only gate result as proof that the PR meets its narrow shell-weight goal, but do not present the PR as a full end-to-end benchmark win on the reference click path.
+
+## Hygiene
+
+- The reference session file used for the shell-only gate was `/home/mcizo/.codex/sessions/2026/04/25/rollout-2026-04-25T16-46-10-019dc51a-f0cd-79c1-ba79-45fedac889c2.jsonl`.
+- No transcript content, tool call payload, command output, or Markdown body text was copied into this report.

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -4478,6 +4478,56 @@ fn synthetic_measurement(input: &str) -> String {\n\
         assert!(metrics.worst_row_kind.is_some());
     }
 
+    #[gtk::test]
+    #[ignore = "manual issue #142 shell-weight gate; requires local Codex session file"]
+    fn session_detail_issue_142_shell_weight_gate_reference_session() {
+        let source_file = std::env::var("SESSION_DETAIL_ISSUE_142_SOURCE_FILE")
+            .expect("SESSION_DETAIL_ISSUE_142_SOURCE_FILE must point to the reference JSONL file");
+        let source_file = std::path::Path::new(&source_file);
+        assert!(
+            source_file.exists(),
+            "reference Codex session file must exist at {}",
+            source_file.display()
+        );
+
+        let temp_root = tempfile::tempdir().expect("temp session root");
+        let target_dir = temp_root.path().join("2026/04/25");
+        std::fs::create_dir_all(&target_dir).expect("create session fixture dir");
+        std::fs::copy(
+            source_file,
+            target_dir.join(source_file.file_name().expect("source file name")),
+        )
+        .expect("copy reference session");
+
+        let temp_db = tempfile::NamedTempFile::new().expect("temp db");
+        let mut indexer = crate::database::SessionIndexer::new(temp_db.path()).expect("indexer");
+        indexer
+            .index_codex_sessions(temp_root.path())
+            .expect("index reference Codex session");
+
+        let sessions = crate::database::load_sessions_for_filter(
+            temp_db.path(),
+            &[crate::models::AiAssistant::Codex],
+            &crate::models::ProjectFilter::AllSessions,
+        )
+        .expect("load indexed sessions");
+        let session = sessions
+            .into_iter()
+            .next()
+            .expect("reference session should be indexed");
+
+        let metrics = measure_session_detail_metrics_for_session(temp_db.path(), session);
+        println!("issue-142-reference: {metrics:#?}");
+
+        assert_eq!(metrics.offset, 0);
+        assert_eq!(metrics.source_row_count, INITIAL_PAGE_SIZE);
+        assert!(
+            metrics.max_schedule_gap_ms <= 50,
+            "max_schedule_gap_ms exceeded gate: {}",
+            metrics.max_schedule_gap_ms
+        );
+    }
+
     #[test]
     fn inspector_visibility_output_carries_state() {
         let output = SessionDetailOutput::InspectorVisibilityChanged(true);

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -1740,6 +1740,26 @@ impl Component for SessionDetail {
                 );
             } else {
                 let vadj = widgets.transcript_scrolled_window.vadjustment();
+                let current_value = vadj.value();
+                if !Self::should_apply_hydration_anchor_compensation(
+                    pending_compensation.request_id,
+                    self.transcript_request_id,
+                    pending_compensation.pre_value,
+                    current_value,
+                    HYDRATION_COMPENSATION_SCROLL_EPSILON,
+                ) {
+                    tracing::debug!(
+                        request_id = pending_compensation.request_id,
+                        current_request_id = self.transcript_request_id,
+                        pre_value = pending_compensation.pre_value,
+                        observed_value = current_value,
+                        delta = pending_compensation.delta,
+                        epsilon = HYDRATION_COMPENSATION_SCROLL_EPSILON,
+                        "Skipping hydration anchor compensation at apply"
+                    );
+                    return;
+                }
+
                 let anchored_value = Self::compute_anchored_scroll_value(
                     pending_compensation.pre_value,
                     pending_compensation.delta,
@@ -4227,6 +4247,30 @@ fn synthetic_measurement(input: &str) -> String {\n\
             10,
             160.0,
             160.5,
+            HYDRATION_COMPENSATION_SCROLL_EPSILON,
+        ));
+    }
+
+    #[test]
+    fn hydration_anchor_compensation_rechecks_for_late_user_scroll_drift() {
+        let request_id = 10;
+        let transcript_request_id = 10;
+        let pre_value = 160.0;
+        let sampled_value = 160.5;
+        let apply_value = 166.0;
+
+        assert!(SessionDetail::should_apply_hydration_anchor_compensation(
+            request_id,
+            transcript_request_id,
+            pre_value,
+            sampled_value,
+            HYDRATION_COMPENSATION_SCROLL_EPSILON,
+        ));
+        assert!(!SessionDetail::should_apply_hydration_anchor_compensation(
+            request_id,
+            transcript_request_id,
+            pre_value,
+            apply_value,
             HYDRATION_COMPENSATION_SCROLL_EPSILON,
         ));
     }

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -39,6 +39,7 @@ const HYDRATION_TICK_DELAY_MS: u64 = 16;
 const VIEWPORT_MARGIN_MULTIPLIER: f64 = 1.5;
 const SCROLL_DEBOUNCE_MS: u64 = 60;
 const RESIZE_DEBOUNCE_MS: u64 = 120;
+const HYDRATION_COMPENSATION_SCROLL_EPSILON: f64 = 1.0;
 
 /// Detail view for a single indexed session.
 ///
@@ -67,6 +68,7 @@ pub struct SessionDetail {
     pending_anchor_targets: RefCell<Vec<DeferredHydrationTarget>>,
     deferred_hydration_tick_scheduled: Cell<bool>,
     pending_viewport_hydration_scan: Cell<Option<PendingViewportHydrationScan>>,
+    pending_hydration_anchor_compensation: Cell<Option<PendingHydrationAnchorCompensation>>,
     scroll_debounce_scheduled: Cell<bool>,
     resize_debounce_scheduled: Cell<bool>,
     pending_boundary_tool_rows: Vec<crate::database::TranscriptItemRow>,
@@ -183,6 +185,13 @@ struct PendingHydrationAnchor {
 struct PendingViewportHydrationScan {
     request_id: u64,
     reason: DeferredHydrationReason,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct PendingHydrationAnchorCompensation {
+    request_id: u64,
+    pre_value: f64,
+    delta: f64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -393,6 +402,12 @@ pub enum SessionDetailMsg {
     ExecuteDelayedSearchScroll {
         request_id: u64,
         target: ScrollTarget,
+    },
+    ApplyHydrationAnchorCompensation {
+        request_id: u64,
+        pre_value: f64,
+        delta: f64,
+        observed_value: f64,
     },
     Clear,
     InspectToolCall(String),
@@ -1004,6 +1019,7 @@ impl Component for SessionDetail {
             pending_anchor_targets: RefCell::new(Vec::new()),
             deferred_hydration_tick_scheduled: Cell::new(false),
             pending_viewport_hydration_scan: Cell::new(None),
+            pending_hydration_anchor_compensation: Cell::new(None),
             scroll_debounce_scheduled: Cell::new(false),
             resize_debounce_scheduled: Cell::new(false),
             pending_boundary_tool_rows: Vec::new(),
@@ -1336,6 +1352,39 @@ impl Component for SessionDetail {
                         "Dropping stale delayed search scroll callback"
                     );
                 }
+            }
+            SessionDetailMsg::ApplyHydrationAnchorCompensation {
+                request_id,
+                pre_value,
+                delta,
+                observed_value,
+            } => {
+                if !Self::should_apply_hydration_anchor_compensation(
+                    request_id,
+                    self.transcript_request_id,
+                    pre_value,
+                    observed_value,
+                    HYDRATION_COMPENSATION_SCROLL_EPSILON,
+                ) {
+                    tracing::debug!(
+                        request_id,
+                        current_request_id = self.transcript_request_id,
+                        pre_value,
+                        observed_value,
+                        delta,
+                        epsilon = HYDRATION_COMPENSATION_SCROLL_EPSILON,
+                        "Skipping hydration anchor compensation"
+                    );
+                    return;
+                }
+
+                self.pending_hydration_anchor_compensation.set(Some(
+                    PendingHydrationAnchorCompensation {
+                        request_id,
+                        pre_value,
+                        delta,
+                    },
+                ));
             }
             SessionDetailMsg::ClearSearch => {
                 self.search_query = None;
@@ -1682,6 +1731,32 @@ impl Component for SessionDetail {
             self.schedule_hydration_anchor_compensation(widgets, anchor);
         }
 
+        if let Some(pending_compensation) = self.pending_hydration_anchor_compensation.take() {
+            if pending_compensation.request_id != self.transcript_request_id {
+                tracing::debug!(
+                    request_id = pending_compensation.request_id,
+                    current_request_id = self.transcript_request_id,
+                    "Dropping stale hydration anchor compensation"
+                );
+            } else {
+                let vadj = widgets.transcript_scrolled_window.vadjustment();
+                let anchored_value = Self::compute_anchored_scroll_value(
+                    pending_compensation.pre_value,
+                    pending_compensation.delta,
+                    vadj.lower(),
+                    vadj.upper(),
+                    vadj.page_size(),
+                );
+                vadj.set_value(anchored_value);
+                tracing::debug!(
+                    request_id = pending_compensation.request_id,
+                    delta = pending_compensation.delta,
+                    anchored_value,
+                    "Anchored transcript scroll on hydration"
+                );
+            }
+        }
+
         if let Some(scan) = self.pending_viewport_hydration_scan.take() {
             self.queue_visible_deferred_hydration(widgets, scan);
             self.schedule_hydration_drain();
@@ -1884,6 +1959,7 @@ impl SessionDetail {
         self.pending_anchor_targets.borrow_mut().clear();
         self.deferred_hydration_tick_scheduled.set(false);
         self.pending_viewport_hydration_scan.set(None);
+        self.pending_hydration_anchor_compensation.set(None);
         self.scroll_debounce_scheduled.set(false);
         self.resize_debounce_scheduled.set(false);
         self.pending_search_hydration_target = None;
@@ -1919,6 +1995,20 @@ impl SessionDetail {
     ) -> f64 {
         let max_value = (upper - page_size).max(lower);
         (pre_value + delta).clamp(lower, max_value)
+    }
+
+    fn should_apply_hydration_anchor_compensation(
+        request_id: u64,
+        transcript_request_id: u64,
+        pre_value: f64,
+        observed_value: f64,
+        epsilon: f64,
+    ) -> bool {
+        if request_id != transcript_request_id {
+            return false;
+        }
+
+        (observed_value - pre_value).abs() <= epsilon
     }
 
     fn capture_hydration_anchor(
@@ -1987,6 +2077,7 @@ impl SessionDetail {
         let tick_count = Cell::new(0u8);
         let messages_widget = self.messages.widget().clone();
         let vadj = widgets.transcript_scrolled_window.vadjustment();
+        let input_sender = self.input_sender.clone();
         widgets.scroll_child.add_tick_callback(move |_, _| {
             let ticks = tick_count.get().saturating_add(1);
             tick_count.set(ticks);
@@ -2008,19 +2099,14 @@ impl SessionDetail {
             }
 
             if delta != 0.0 {
-                let anchored_value = Self::compute_anchored_scroll_value(
-                    anchor.pre_value,
-                    delta,
-                    vadj.lower(),
-                    vadj.upper(),
-                    vadj.page_size(),
-                );
-                vadj.set_value(anchored_value);
-                tracing::debug!(
-                    request_id = anchor.request_id,
-                    delta,
-                    "Anchored transcript scroll on hydration"
-                );
+                input_sender
+                    .send(SessionDetailMsg::ApplyHydrationAnchorCompensation {
+                        request_id: anchor.request_id,
+                        pre_value: anchor.pre_value,
+                        delta,
+                        observed_value: vadj.value(),
+                    })
+                    .ok();
             }
             glib::ControlFlow::Break
         });
@@ -4113,6 +4199,35 @@ fn synthetic_measurement(input: &str) -> String {\n\
         ));
         assert!(!SessionDetail::row_is_strictly_above_viewport(
             65.0, 20.0, 60.0
+        ));
+    }
+
+    #[test]
+    fn stale_hydration_anchor_compensation_is_ignored_after_request_change() {
+        assert!(!SessionDetail::should_apply_hydration_anchor_compensation(
+            10,
+            11,
+            160.0,
+            160.0,
+            HYDRATION_COMPENSATION_SCROLL_EPSILON,
+        ));
+    }
+
+    #[test]
+    fn hydration_anchor_compensation_is_skipped_after_user_scroll_change() {
+        assert!(!SessionDetail::should_apply_hydration_anchor_compensation(
+            10,
+            10,
+            160.0,
+            166.0,
+            HYDRATION_COMPENSATION_SCROLL_EPSILON,
+        ));
+        assert!(SessionDetail::should_apply_hydration_anchor_compensation(
+            10,
+            10,
+            160.0,
+            160.5,
+            HYDRATION_COMPENSATION_SCROLL_EPSILON,
         ));
     }
 

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -1,4 +1,4 @@
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -34,6 +34,11 @@ const RENDER_BATCH_SIZE: usize = 3;
 const RENDER_BATCH_DELAY_MS: u64 = 16;
 const DEFERRED_FIRST_PAGE_LOAD_DELAY_MS: u64 = 250;
 const DEFERRED_CLEAR_DELAY_MS: u64 = 250;
+const HYDRATION_BATCH_SIZE: usize = 2;
+const HYDRATION_TICK_DELAY_MS: u64 = 16;
+const VIEWPORT_MARGIN_MULTIPLIER: f64 = 1.5;
+const SCROLL_DEBOUNCE_MS: u64 = 60;
+const RESIZE_DEBOUNCE_MS: u64 = 120;
 
 /// Detail view for a single indexed session.
 ///
@@ -56,6 +61,13 @@ pub struct SessionDetail {
     pending_render_batch: Option<PendingRenderBatch>,
     last_render_metrics: Option<RenderMetrics>,
     deferred_hydrated_items: BTreeSet<usize>,
+    input_sender: relm4::Sender<SessionDetailMsg>,
+    deferred_hydration_queue: RefCell<VecDeque<DeferredHydrationTarget>>,
+    deferred_hydration_queued_items: RefCell<BTreeSet<usize>>,
+    deferred_hydration_tick_scheduled: Cell<bool>,
+    pending_viewport_hydration_scan: Cell<Option<PendingViewportHydrationScan>>,
+    scroll_debounce_scheduled: Cell<bool>,
+    resize_debounce_scheduled: Cell<bool>,
     pending_boundary_tool_rows: Vec<crate::database::TranscriptItemRow>,
     search_query: Option<String>,
     match_positions: Vec<crate::database::MatchPosition>,
@@ -113,6 +125,20 @@ struct PendingRenderBatch {
     items: VecDeque<TranscriptItemInit>,
     first_page_load_to_factory_push_ms: Option<u128>,
     push_complete: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct DeferredHydrationTarget {
+    request_id: u64,
+    display_index: usize,
+    item_index: usize,
+    reason: DeferredHydrationReason,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PendingViewportHydrationScan {
+    request_id: u64,
+    reason: DeferredHydrationReason,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -303,6 +329,17 @@ pub enum SessionDetailMsg {
         reason: DeferredHydrationReason,
         duration_ms: u128,
     },
+    ScrollPositionChanged,
+    ViewportSizeChanged,
+    RunScrollDebouncedHydrationScan {
+        request_id: u64,
+    },
+    RunResizeDebouncedHydrationScan {
+        request_id: u64,
+    },
+    DrainDeferredHydration {
+        request_id: u64,
+    },
     Clear,
     InspectToolCall(String),
     InspectSubagent(String),
@@ -428,6 +465,7 @@ impl Component for SessionDetail {
                         set_show_sidebar: model.inspector_open,
 
                     #[wrap(Some)]
+                    #[name = "transcript_scrolled_window"]
                     set_content = &gtk::ScrolledWindow {
                         set_vexpand: true,
                         set_hscrollbar_policy: gtk::PolicyType::Never,
@@ -906,6 +944,13 @@ impl Component for SessionDetail {
             pending_render_batch: None,
             last_render_metrics: None,
             deferred_hydrated_items: BTreeSet::new(),
+            input_sender: sender.input_sender().clone(),
+            deferred_hydration_queue: RefCell::new(VecDeque::new()),
+            deferred_hydration_queued_items: RefCell::new(BTreeSet::new()),
+            deferred_hydration_tick_scheduled: Cell::new(false),
+            pending_viewport_hydration_scan: Cell::new(None),
+            scroll_debounce_scheduled: Cell::new(false),
+            resize_debounce_scheduled: Cell::new(false),
             pending_boundary_tool_rows: Vec::new(),
             search_query: None,
             match_positions: Vec::new(),
@@ -942,6 +987,26 @@ impl Component for SessionDetail {
                     ))
                     .ok();
             });
+
+        let scroll_sender = sender.input_sender().clone();
+        let vadjustment = widgets.transcript_scrolled_window.vadjustment();
+        vadjustment.connect_value_changed(move |_| {
+            scroll_sender
+                .send(SessionDetailMsg::ScrollPositionChanged)
+                .ok();
+        });
+        let viewport_sender = sender.input_sender().clone();
+        vadjustment.connect_page_size_notify(move |_| {
+            viewport_sender
+                .send(SessionDetailMsg::ViewportSizeChanged)
+                .ok();
+        });
+        let resize_sender = sender.input_sender().clone();
+        widgets.scroll_child.connect_width_request_notify(move |_| {
+            resize_sender
+                .send(SessionDetailMsg::ViewportSizeChanged)
+                .ok();
+        });
 
         ComponentParts { model, widgets }
     }
@@ -1140,6 +1205,61 @@ impl Component for SessionDetail {
                     "Accepted deferred hydration output"
                 );
                 self.continue_pending_jump(&sender);
+            }
+            SessionDetailMsg::ScrollPositionChanged => {
+                if self.scroll_debounce_scheduled.get() {
+                    return;
+                }
+                self.scroll_debounce_scheduled.set(true);
+                let input_sender = self.input_sender.clone();
+                let request_id = self.transcript_request_id;
+                glib::timeout_add_local_once(
+                    Duration::from_millis(SCROLL_DEBOUNCE_MS),
+                    move || {
+                        input_sender
+                            .send(SessionDetailMsg::RunScrollDebouncedHydrationScan { request_id })
+                            .ok();
+                    },
+                );
+            }
+            SessionDetailMsg::ViewportSizeChanged => {
+                if self.resize_debounce_scheduled.get() {
+                    return;
+                }
+                self.resize_debounce_scheduled.set(true);
+                let input_sender = self.input_sender.clone();
+                let request_id = self.transcript_request_id;
+                glib::timeout_add_local_once(
+                    Duration::from_millis(RESIZE_DEBOUNCE_MS),
+                    move || {
+                        input_sender
+                            .send(SessionDetailMsg::RunResizeDebouncedHydrationScan { request_id })
+                            .ok();
+                    },
+                );
+            }
+            SessionDetailMsg::RunScrollDebouncedHydrationScan { request_id } => {
+                self.scroll_debounce_scheduled.set(false);
+                if request_id == self.transcript_request_id {
+                    self.pending_viewport_hydration_scan
+                        .set(Some(PendingViewportHydrationScan {
+                            request_id,
+                            reason: DeferredHydrationReason::ScrollViewport,
+                        }));
+                }
+            }
+            SessionDetailMsg::RunResizeDebouncedHydrationScan { request_id } => {
+                self.resize_debounce_scheduled.set(false);
+                if request_id == self.transcript_request_id {
+                    self.pending_viewport_hydration_scan
+                        .set(Some(PendingViewportHydrationScan {
+                            request_id,
+                            reason: DeferredHydrationReason::ResizeViewport,
+                        }));
+                }
+            }
+            SessionDetailMsg::DrainDeferredHydration { request_id } => {
+                self.drain_deferred_hydration_batch(request_id);
             }
             SessionDetailMsg::ClearSearch => {
                 self.search_query = None;
@@ -1476,6 +1596,11 @@ impl Component for SessionDetail {
                 .add_toast(adw::Toast::new("Could not load full message."));
         }
 
+        if let Some(scan) = self.pending_viewport_hydration_scan.take() {
+            self.queue_visible_deferred_hydration(widgets, scan);
+            self.schedule_hydration_drain();
+        }
+
         if let Some(target) = self.scroll_to_item.take() {
             let messages_widget = self.messages.widget().clone();
             let scroll_child = widgets.scroll_child.clone();
@@ -1637,6 +1762,51 @@ impl SessionDetail {
         self.pending_render_batch = None;
         self.last_render_metrics = None;
         self.deferred_hydrated_items.clear();
+        self.deferred_hydration_queue.borrow_mut().clear();
+        self.deferred_hydration_queued_items.borrow_mut().clear();
+        self.deferred_hydration_tick_scheduled.set(false);
+        self.pending_viewport_hydration_scan.set(None);
+        self.scroll_debounce_scheduled.set(false);
+        self.resize_debounce_scheduled.set(false);
+    }
+
+    fn row_intersects_hydration_window(
+        row_top: f64,
+        row_height: f64,
+        viewport_top: f64,
+        viewport_page_size: f64,
+        margin_multiplier: f64,
+    ) -> bool {
+        let row_bottom = row_top + row_height;
+        let margin = viewport_page_size * margin_multiplier;
+        let hydration_top = viewport_top - margin;
+        let hydration_bottom = viewport_top + viewport_page_size + margin;
+        row_bottom >= hydration_top && row_top <= hydration_bottom
+    }
+
+    fn queue_deferred_hydration_target(&self, target: DeferredHydrationTarget) {
+        let mut queued_items = self.deferred_hydration_queued_items.borrow_mut();
+        if !queued_items.insert(target.item_index) {
+            return;
+        }
+        self.deferred_hydration_queue.borrow_mut().push_back(target);
+    }
+
+    fn schedule_hydration_drain(&self) {
+        if self.deferred_hydration_tick_scheduled.get()
+            || self.deferred_hydration_queue.borrow().is_empty()
+        {
+            return;
+        }
+
+        self.deferred_hydration_tick_scheduled.set(true);
+        let input_sender = self.input_sender.clone();
+        let request_id = self.transcript_request_id;
+        glib::timeout_add_local_once(Duration::from_millis(HYDRATION_TICK_DELAY_MS), move || {
+            input_sender
+                .send(SessionDetailMsg::DrainDeferredHydration { request_id })
+                .ok();
+        });
     }
 
     fn invalidate_search_requests(&mut self) {
@@ -2142,7 +2312,141 @@ impl SessionDetail {
         if let Some(batch) = self.pending_render_batch.as_ref() {
             self.last_render_metrics = Some(render_metrics_for_batch(batch, total_duration_ms));
         }
+        self.pending_viewport_hydration_scan
+            .set(Some(PendingViewportHydrationScan {
+                request_id,
+                reason: if offset == 0 {
+                    DeferredHydrationReason::InitialViewport
+                } else {
+                    DeferredHydrationReason::ScrollViewport
+                },
+            }));
         self.continue_pending_jump(sender);
+    }
+
+    fn queue_visible_deferred_hydration(
+        &self,
+        widgets: &SessionDetailWidgets,
+        scan: PendingViewportHydrationScan,
+    ) {
+        if scan.request_id != self.transcript_request_id {
+            return;
+        }
+
+        let viewport_top = widgets.transcript_scrolled_window.vadjustment().value();
+        let viewport_page_size = widgets.transcript_scrolled_window.vadjustment().page_size();
+        let mut queued_count = 0usize;
+        let messages_widget = self.messages.widget();
+
+        for display_index in 0..self.messages.len() {
+            let Some(row_widget) = messages_widget
+                .observe_children()
+                .item(display_index as u32)
+                .and_then(|obj| obj.downcast::<gtk::Widget>().ok())
+            else {
+                continue;
+            };
+
+            let Some(row_point) = row_widget
+                .compute_point(&widgets.scroll_child, &gtk::graphene::Point::new(0.0, 0.0))
+            else {
+                continue;
+            };
+
+            let row_top = row_point.y() as f64;
+            let row_height = row_widget.height() as f64;
+            if !Self::row_intersects_hydration_window(
+                row_top,
+                row_height,
+                viewport_top,
+                viewport_page_size,
+                VIEWPORT_MARGIN_MULTIPLIER,
+            ) {
+                continue;
+            }
+
+            let Some(item_index) = self
+                .messages
+                .get(display_index)
+                .map(|item| item.item_index())
+            else {
+                continue;
+            };
+            if self.deferred_hydrated_items.contains(&item_index) {
+                continue;
+            }
+
+            self.queue_deferred_hydration_target(DeferredHydrationTarget {
+                request_id: scan.request_id,
+                display_index,
+                item_index,
+                reason: scan.reason,
+            });
+            queued_count += 1;
+        }
+
+        if queued_count > 0 {
+            tracing::debug!(
+                request_id = scan.request_id,
+                ?scan.reason,
+                queued_count,
+                queue_len = self.deferred_hydration_queue.borrow().len(),
+                "Queued viewport deferred hydration targets"
+            );
+        }
+    }
+
+    fn drain_deferred_hydration_batch(&mut self, request_id: u64) {
+        self.deferred_hydration_tick_scheduled.set(false);
+        if request_id != self.transcript_request_id {
+            self.deferred_hydration_queue.borrow_mut().clear();
+            self.deferred_hydration_queued_items.borrow_mut().clear();
+            return;
+        }
+
+        let started_at = Instant::now();
+        let mut hydrated_count = 0usize;
+        let mut max_row_hydration_duration = Duration::ZERO;
+
+        for _ in 0..HYDRATION_BATCH_SIZE {
+            let Some(target) = self.deferred_hydration_queue.borrow_mut().pop_front() else {
+                break;
+            };
+            self.deferred_hydration_queued_items
+                .borrow_mut()
+                .remove(&target.item_index);
+
+            if target.request_id != self.transcript_request_id
+                || target.display_index >= self.messages.len()
+                || self.deferred_hydrated_items.contains(&target.item_index)
+            {
+                continue;
+            }
+
+            let row_started_at = Instant::now();
+            self.messages.send(
+                target.display_index,
+                TranscriptRowMsg::HydrateDeferredContent {
+                    reason: target.reason,
+                },
+            );
+            let row_duration = row_started_at.elapsed();
+            max_row_hydration_duration = max_row_hydration_duration.max(row_duration);
+            hydrated_count += 1;
+        }
+
+        tracing::debug!(
+            request_id,
+            hydrated_count,
+            duration_ms = started_at.elapsed().as_millis(),
+            max_row_hydration_duration_ms = max_row_hydration_duration.as_millis(),
+            remaining_count = self.deferred_hydration_queue.borrow().len(),
+            "Drained deferred hydration batch"
+        );
+
+        if !self.deferred_hydration_queue.borrow().is_empty() {
+            self.schedule_hydration_drain();
+        }
     }
 
     fn apply_first_page_rows(
@@ -3273,6 +3577,47 @@ fn synthetic_measurement(input: &str) -> String {\n\
 
         let parts = controller.state().get();
         assert!(!parts.model.has_more_messages);
+    }
+
+    #[test]
+    fn viewport_intersection_uses_margin() {
+        let intersects_without_margin =
+            SessionDetail::row_intersects_hydration_window(210.0, 20.0, 0.0, 100.0, 0.0);
+        assert!(!intersects_without_margin);
+
+        let intersects_with_margin =
+            SessionDetail::row_intersects_hydration_window(210.0, 20.0, 0.0, 100.0, 1.5);
+        assert!(intersects_with_margin);
+    }
+
+    #[gtk::test]
+    fn queue_deferred_hydration_deduplicates_targets() {
+        let temp_db = tempfile::NamedTempFile::new().expect("temp db");
+        let controller = SessionDetail::builder().launch(temp_db.path().to_path_buf());
+        pump_main_context(|| true);
+        let parts = controller.state().get();
+
+        let target = DeferredHydrationTarget {
+            request_id: 1,
+            display_index: 0,
+            item_index: 42,
+            reason: DeferredHydrationReason::InitialViewport,
+        };
+        parts.model.queue_deferred_hydration_target(target);
+        parts.model.queue_deferred_hydration_target(target);
+
+        assert_eq!(parts.model.deferred_hydration_queue.borrow().len(), 1);
+        assert_eq!(
+            parts.model.deferred_hydration_queued_items.borrow().len(),
+            1
+        );
+        assert!(
+            parts
+                .model
+                .deferred_hydration_queued_items
+                .borrow()
+                .contains(&42)
+        );
     }
 
     #[gtk::test]

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -1809,6 +1809,13 @@ impl SessionDetail {
         });
     }
 
+    fn deferred_target_matches_row(
+        current_item_index: Option<usize>,
+        target_item_index: usize,
+    ) -> bool {
+        matches!(current_item_index, Some(item_index) if item_index == target_item_index)
+    }
+
     fn invalidate_search_requests(&mut self) {
         self.search_request_id = self.search_request_id.wrapping_add(1);
     }
@@ -2420,6 +2427,15 @@ impl SessionDetail {
                 || target.display_index >= self.messages.len()
                 || self.deferred_hydrated_items.contains(&target.item_index)
             {
+                continue;
+            }
+
+            if !Self::deferred_target_matches_row(
+                self.messages
+                    .get(target.display_index)
+                    .map(|row| row.item_index()),
+                target.item_index,
+            ) {
                 continue;
             }
 
@@ -3618,6 +3634,13 @@ fn synthetic_measurement(input: &str) -> String {\n\
                 .borrow()
                 .contains(&42)
         );
+    }
+
+    #[test]
+    fn deferred_target_identity_guard_rejects_mismatch() {
+        assert!(!SessionDetail::deferred_target_matches_row(Some(4), 5));
+        assert!(!SessionDetail::deferred_target_matches_row(None, 5));
+        assert!(SessionDetail::deferred_target_matches_row(Some(5), 5));
     }
 
     #[gtk::test]

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -75,8 +75,9 @@ pub struct SessionDetail {
     current_match: usize,
     pending_jump: Option<usize>,
     loading_jump: bool,
+    pending_search_hydration_target: Option<ScrollTarget>,
     search_request_id: u64,
-    scroll_to_item: Cell<Option<ScrollTarget>>,
+    pending_scroll_after_layout: Cell<Option<ScrollTarget>>,
     pending_toast: Cell<bool>,
     inspector: Controller<ToolInspectorPane>,
     inspector_open: bool,
@@ -91,6 +92,33 @@ pub struct SessionDetail {
 struct ScrollTarget {
     display_index: usize,
     child_index: Option<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PendingLayoutBarrier {
+    tick_count: Cell<u8>,
+    request_id: u64,
+    target: ScrollTarget,
+}
+
+impl PendingLayoutBarrier {
+    fn new(request_id: u64, target: ScrollTarget) -> Self {
+        Self {
+            tick_count: Cell::new(0),
+            request_id,
+            target,
+        }
+    }
+
+    fn next_tick(&self) -> glib::ControlFlow {
+        let ticks = self.tick_count.get().saturating_add(1);
+        self.tick_count.set(ticks);
+        if ticks < 2 {
+            glib::ControlFlow::Continue
+        } else {
+            glib::ControlFlow::Break
+        }
+    }
 }
 
 struct PreparedTranscriptItems {
@@ -958,8 +986,9 @@ impl Component for SessionDetail {
             current_match: 0,
             pending_jump: None,
             loading_jump: false,
+            pending_search_hydration_target: None,
             search_request_id: 0,
-            scroll_to_item: Cell::new(None),
+            pending_scroll_after_layout: Cell::new(None),
             pending_toast: Cell::new(false),
             inspector,
             inspector_open: false,
@@ -1204,7 +1233,11 @@ impl Component for SessionDetail {
                     hydrated_item_count = self.deferred_hydrated_items.len(),
                     "Accepted deferred hydration output"
                 );
-                self.continue_pending_jump(&sender);
+                if reason == DeferredHydrationReason::SearchTarget
+                    && self.pending_search_hydration_target.is_some()
+                {
+                    self.continue_pending_jump(&sender);
+                }
             }
             SessionDetailMsg::ScrollPositionChanged => {
                 if self.scroll_debounce_scheduled.get() {
@@ -1601,17 +1634,37 @@ impl Component for SessionDetail {
             self.schedule_hydration_drain();
         }
 
-        if let Some(target) = self.scroll_to_item.take() {
+        if let Some(target) = self.pending_scroll_after_layout.take() {
             let messages_widget = self.messages.widget().clone();
             let scroll_child = widgets.scroll_child.clone();
-            glib::idle_add_local_once(move || {
+            let layout_barrier = PendingLayoutBarrier::new(self.transcript_request_id, target);
+            widgets.scroll_child.add_tick_callback(move |_, _| {
+                if layout_barrier.next_tick() == glib::ControlFlow::Continue {
+                    return glib::ControlFlow::Continue;
+                }
+
+                let target = layout_barrier.target;
                 let Some(row_widget) = messages_widget
                     .observe_children()
                     .item(target.display_index as u32)
                     .and_then(|obj| obj.downcast::<gtk::Widget>().ok())
                 else {
-                    return;
+                    tracing::warn!(
+                        request_id = layout_barrier.request_id,
+                        display_index = target.display_index,
+                        "Abandoning delayed search scroll: target row missing after layout barrier"
+                    );
+                    return glib::ControlFlow::Break;
                 };
+
+                if row_widget.height() <= 0 {
+                    tracing::warn!(
+                        request_id = layout_barrier.request_id,
+                        display_index = target.display_index,
+                        "Abandoning delayed search scroll: target row has zero height after layout barrier"
+                    );
+                    return glib::ControlFlow::Break;
+                }
 
                 if let Some(child_index) = target.child_index
                     && let Some((header_button, revealer)) =
@@ -1648,10 +1701,11 @@ impl Component for SessionDetail {
                         Self::scroll_widget_into_view(&child_widget, &scroll_child_for_tick);
                         glib::ControlFlow::Break
                     });
-                    return;
+                    return glib::ControlFlow::Break;
                 }
 
                 Self::scroll_widget_into_view(&row_widget, &scroll_child);
+                glib::ControlFlow::Break
             });
         }
     }
@@ -1768,6 +1822,8 @@ impl SessionDetail {
         self.pending_viewport_hydration_scan.set(None);
         self.scroll_debounce_scheduled.set(false);
         self.resize_debounce_scheduled.set(false);
+        self.pending_search_hydration_target = None;
+        self.pending_scroll_after_layout.set(None);
     }
 
     fn row_intersects_hydration_window(
@@ -2608,6 +2664,8 @@ impl SessionDetail {
         self.current_match = 0;
         self.pending_jump = None;
         self.loading_jump = false;
+        self.pending_search_hydration_target = None;
+        self.pending_scroll_after_layout.set(None);
     }
 
     fn loaded_match_count(&self) -> usize {
@@ -2659,9 +2717,33 @@ impl SessionDetail {
             .copied()
             && self.messages.len() > scroll_target.display_index
         {
+            let Ok(item_index) = usize::try_from(position.item_index) else {
+                tracing::warn!(
+                    item_index = position.item_index,
+                    "search match position is negative and cannot be hydrated"
+                );
+                self.pending_jump = None;
+                self.loading_jump = false;
+                self.pending_search_hydration_target = None;
+                return;
+            };
+
+            if !self.deferred_hydrated_items.contains(&item_index) {
+                self.pending_search_hydration_target = Some(scroll_target);
+                self.queue_deferred_hydration_target(DeferredHydrationTarget {
+                    request_id: self.transcript_request_id,
+                    display_index: scroll_target.display_index,
+                    item_index,
+                    reason: DeferredHydrationReason::SearchTarget,
+                });
+                self.drain_search_target_hydration(scroll_target, item_index);
+                return;
+            }
+
             self.pending_jump = None;
             self.loading_jump = false;
-            self.scroll_to_item.set(Some(scroll_target));
+            self.pending_search_hydration_target = None;
+            self.pending_scroll_after_layout.set(Some(scroll_target));
         } else if (position.item_index as usize) >= self.loaded_count && self.has_more_messages {
             self.load_next_page(sender);
         } else if !self.has_more_messages && (position.item_index as usize) >= self.loaded_count {
@@ -2686,6 +2768,37 @@ impl SessionDetail {
             self.pending_jump = None;
             self.loading_jump = false;
         }
+    }
+
+    fn drain_search_target_hydration(&self, scroll_target: ScrollTarget, item_index: usize) {
+        self.deferred_hydration_queued_items
+            .borrow_mut()
+            .remove(&item_index);
+        self.deferred_hydration_queue
+            .borrow_mut()
+            .retain(|target| target.item_index != item_index);
+
+        if scroll_target.display_index >= self.messages.len()
+            || self.deferred_hydrated_items.contains(&item_index)
+        {
+            return;
+        }
+
+        if !Self::deferred_target_matches_row(
+            self.messages
+                .get(scroll_target.display_index)
+                .map(|row| row.item_index()),
+            item_index,
+        ) {
+            return;
+        }
+
+        self.messages.send(
+            scroll_target.display_index,
+            TranscriptRowMsg::HydrateDeferredContent {
+                reason: DeferredHydrationReason::SearchTarget,
+            },
+        );
     }
 
     fn reload_current_session(
@@ -3429,6 +3542,65 @@ fn synthetic_measurement(input: &str) -> String {\n\
 
         let parts = controller.state().get();
         assert!(parts.model.deferred_hydrated_items.is_empty());
+    }
+
+    #[gtk::test]
+    fn jump_to_loaded_unhydrated_match_waits_for_hydration_output() {
+        let temp_db = tempfile::NamedTempFile::new().expect("temp db");
+        seed_search_transcript(temp_db.path(), "test-session-123", INITIAL_PAGE_SIZE, &[70]);
+
+        let controller = SessionDetail::builder().launch(temp_db.path().to_path_buf());
+        controller.emit(SessionDetailMsg::SetSession {
+            session: Box::new(build_test_session(None, None, 0, 0, 0)),
+            search_query: Some("needle".to_string()),
+        });
+
+        pump_main_context_for(Duration::from_secs(5), || {
+            let parts = controller.state().get();
+            parts.model.pending_search_hydration_target.is_some()
+        });
+
+        {
+            let parts = controller.state().get();
+            assert_eq!(parts.model.pending_jump, Some(0));
+            assert!(parts.model.loading_jump);
+            assert!(parts.model.pending_search_hydration_target.is_some());
+            assert!(parts.model.pending_scroll_after_layout.get().is_none());
+        }
+
+        let request_id = controller.state().get().model.transcript_request_id;
+        controller.emit(SessionDetailMsg::DeferredContentHydrated {
+            request_id,
+            item_index: 70,
+            kind: TranscriptRowBuildKind::Message,
+            reason: DeferredHydrationReason::SearchTarget,
+            duration_ms: 1,
+        });
+
+        pump_main_context_for(Duration::from_secs(5), || {
+            let parts = controller.state().get();
+            !parts.model.loading_jump && parts.model.pending_search_hydration_target.is_none()
+        });
+
+        let parts = controller.state().get();
+        assert_eq!(parts.model.pending_jump, None);
+        assert!(!parts.model.loading_jump);
+        assert!(parts.model.pending_search_hydration_target.is_none());
+        assert!(parts.model.deferred_hydrated_items.contains(&70));
+    }
+
+    #[test]
+    fn two_tick_layout_barrier_requires_second_tick() {
+        let barrier = PendingLayoutBarrier::new(
+            9,
+            ScrollTarget {
+                display_index: 4,
+                child_index: Some(1),
+            },
+        );
+
+        assert_eq!(barrier.next_tick(), glib::ControlFlow::Continue);
+        assert_eq!(barrier.next_tick(), glib::ControlFlow::Break);
     }
 
     #[gtk::test]
@@ -4228,9 +4400,15 @@ fn synthetic_measurement(input: &str) -> String {\n\
         });
 
         controller.emit(SessionDetailMsg::PrevMatch);
-        pump_main_context(|| controller.state().get().model.current_match == 1);
+        pump_main_context(|| {
+            let parts = controller.state().get();
+            parts.model.current_match == 1 && !parts.model.loading_jump
+        });
         controller.emit(SessionDetailMsg::NextMatch);
-        pump_main_context(|| controller.state().get().model.current_match == 0);
+        pump_main_context(|| {
+            let parts = controller.state().get();
+            parts.model.current_match == 0 && !parts.model.loading_jump
+        });
 
         let parts = controller.state().get();
         assert_eq!(parts.model.current_match, 0);

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -1076,7 +1076,8 @@ impl Component for SessionDetail {
                 .ok();
         });
         let resize_sender = sender.input_sender().clone();
-        widgets.scroll_child.connect_width_request_notify(move |_| {
+        let hadjustment = widgets.transcript_scrolled_window.hadjustment();
+        hadjustment.connect_page_size_notify(move |_| {
             resize_sender
                 .send(SessionDetailMsg::ViewportSizeChanged)
                 .ok();
@@ -4478,6 +4479,9 @@ fn synthetic_measurement(input: &str) -> String {\n\
         assert!(metrics.worst_row_kind.is_some());
     }
 
+    // Shell-weight gate only: measures the initial first-page push budget, not
+    // viewport-driven hydration tick stability. Hydration tick cost is validated
+    // manually against large fixtures.
     #[gtk::test]
     #[ignore = "manual issue #142 shell-weight gate; requires local Codex session file"]
     fn session_detail_issue_142_shell_weight_gate_reference_session() {

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -76,8 +76,10 @@ pub struct SessionDetail {
     pending_jump: Option<usize>,
     loading_jump: bool,
     pending_search_hydration_target: Option<ScrollTarget>,
+    pending_search_hydration_item_index: Option<usize>,
     search_request_id: u64,
     pending_scroll_after_layout: Cell<Option<ScrollTarget>>,
+    pending_delayed_search_scroll: Cell<Option<PendingDelayedSearchScroll>>,
     pending_toast: Cell<bool>,
     inspector: Controller<ToolInspectorPane>,
     inspector_open: bool,
@@ -89,7 +91,7 @@ pub struct SessionDetail {
 /// `child_index` is present, the target is a child entry inside an expanded
 /// burst row rather than the row container itself.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct ScrollTarget {
+pub(crate) struct ScrollTarget {
     display_index: usize,
     child_index: Option<usize>,
 }
@@ -167,6 +169,12 @@ struct DeferredHydrationTarget {
 struct PendingViewportHydrationScan {
     request_id: u64,
     reason: DeferredHydrationReason,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PendingDelayedSearchScroll {
+    request_id: u64,
+    target: ScrollTarget,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -367,6 +375,10 @@ pub enum SessionDetailMsg {
     },
     DrainDeferredHydration {
         request_id: u64,
+    },
+    ExecuteDelayedSearchScroll {
+        request_id: u64,
+        target: ScrollTarget,
     },
     Clear,
     InspectToolCall(String),
@@ -987,8 +999,10 @@ impl Component for SessionDetail {
             pending_jump: None,
             loading_jump: false,
             pending_search_hydration_target: None,
+            pending_search_hydration_item_index: None,
             search_request_id: 0,
             pending_scroll_after_layout: Cell::new(None),
+            pending_delayed_search_scroll: Cell::new(None),
             pending_toast: Cell::new(false),
             inspector,
             inspector_open: false,
@@ -1235,6 +1249,7 @@ impl Component for SessionDetail {
                 );
                 if reason == DeferredHydrationReason::SearchTarget
                     && self.pending_search_hydration_target.is_some()
+                    && self.pending_search_hydration_item_index == Some(item_index)
                 {
                     self.continue_pending_jump(&sender);
                 }
@@ -1293,6 +1308,19 @@ impl Component for SessionDetail {
             }
             SessionDetailMsg::DrainDeferredHydration { request_id } => {
                 self.drain_deferred_hydration_batch(request_id);
+            }
+            SessionDetailMsg::ExecuteDelayedSearchScroll { request_id, target } => {
+                if request_id == self.transcript_request_id {
+                    self.pending_delayed_search_scroll
+                        .set(Some(PendingDelayedSearchScroll { request_id, target }));
+                } else {
+                    tracing::debug!(
+                        request_id,
+                        current_request_id = self.transcript_request_id,
+                        display_index = target.display_index,
+                        "Dropping stale delayed search scroll callback"
+                    );
+                }
             }
             SessionDetailMsg::ClearSearch => {
                 self.search_query = None;
@@ -1635,78 +1663,88 @@ impl Component for SessionDetail {
         }
 
         if let Some(target) = self.pending_scroll_after_layout.take() {
-            let messages_widget = self.messages.widget().clone();
-            let scroll_child = widgets.scroll_child.clone();
+            let input_sender = self.input_sender.clone();
             let layout_barrier = PendingLayoutBarrier::new(self.transcript_request_id, target);
             widgets.scroll_child.add_tick_callback(move |_, _| {
                 if layout_barrier.next_tick() == glib::ControlFlow::Continue {
                     return glib::ControlFlow::Continue;
                 }
 
-                let target = layout_barrier.target;
-                let Some(row_widget) = messages_widget
-                    .observe_children()
-                    .item(target.display_index as u32)
-                    .and_then(|obj| obj.downcast::<gtk::Widget>().ok())
-                else {
-                    tracing::warn!(
-                        request_id = layout_barrier.request_id,
-                        display_index = target.display_index,
-                        "Abandoning delayed search scroll: target row missing after layout barrier"
-                    );
-                    return glib::ControlFlow::Break;
-                };
-
-                if row_widget.height() <= 0 {
-                    tracing::warn!(
-                        request_id = layout_barrier.request_id,
-                        display_index = target.display_index,
-                        "Abandoning delayed search scroll: target row has zero height after layout barrier"
-                    );
-                    return glib::ControlFlow::Break;
-                }
-
-                if let Some(child_index) = target.child_index
-                    && let Some((header_button, revealer)) =
-                        Self::tool_burst_header_and_revealer(&row_widget)
-                {
-                    if !revealer.reveals_child() {
-                        header_button.emit_clicked();
-                    }
-                    let scroll_child_for_tick = scroll_child.clone();
-                    let revealer_for_tick = revealer.clone();
-                    let tick_count = std::cell::Cell::new(0u32);
-                    revealer.add_tick_callback(move |_, _| {
-                        let ticks = tick_count.get() + 1;
-                        tick_count.set(ticks);
-                        if ticks > 60 {
-                            return glib::ControlFlow::Break;
-                        }
-
-                        let Some(child_box) = revealer_for_tick
-                            .child()
-                            .and_then(|w| w.downcast::<gtk::Box>().ok())
-                        else {
-                            return glib::ControlFlow::Break;
-                        };
-
-                        let Some(child_widget) = child_box
-                            .observe_children()
-                            .item(child_index as u32)
-                            .and_then(|obj| obj.downcast::<gtk::Widget>().ok())
-                        else {
-                            return glib::ControlFlow::Continue;
-                        };
-
-                        Self::scroll_widget_into_view(&child_widget, &scroll_child_for_tick);
-                        glib::ControlFlow::Break
-                    });
-                    return glib::ControlFlow::Break;
-                }
-
-                Self::scroll_widget_into_view(&row_widget, &scroll_child);
+                input_sender
+                    .send(SessionDetailMsg::ExecuteDelayedSearchScroll {
+                        request_id: layout_barrier.request_id,
+                        target: layout_barrier.target,
+                    })
+                    .ok();
                 glib::ControlFlow::Break
             });
+        }
+
+        if let Some(pending_scroll) = self.pending_delayed_search_scroll.take() {
+            let target = pending_scroll.target;
+            let messages_widget = self.messages.widget().clone();
+            let scroll_child = widgets.scroll_child.clone();
+            let Some(row_widget) = messages_widget
+                .observe_children()
+                .item(target.display_index as u32)
+                .and_then(|obj| obj.downcast::<gtk::Widget>().ok())
+            else {
+                tracing::warn!(
+                    request_id = pending_scroll.request_id,
+                    display_index = target.display_index,
+                    "Abandoning delayed search scroll: target row missing after layout barrier"
+                );
+                return;
+            };
+
+            if row_widget.height() <= 0 {
+                tracing::warn!(
+                    request_id = pending_scroll.request_id,
+                    display_index = target.display_index,
+                    "Abandoning delayed search scroll: target row has zero height after layout barrier"
+                );
+                return;
+            }
+
+            if let Some(child_index) = target.child_index
+                && let Some((header_button, revealer)) =
+                    Self::tool_burst_header_and_revealer(&row_widget)
+            {
+                if !revealer.reveals_child() {
+                    header_button.emit_clicked();
+                }
+                let scroll_child_for_tick = scroll_child.clone();
+                let revealer_for_tick = revealer.clone();
+                let tick_count = std::cell::Cell::new(0u32);
+                revealer.add_tick_callback(move |_, _| {
+                    let ticks = tick_count.get() + 1;
+                    tick_count.set(ticks);
+                    if ticks > 60 {
+                        return glib::ControlFlow::Break;
+                    }
+
+                    let Some(child_box) = revealer_for_tick
+                        .child()
+                        .and_then(|w| w.downcast::<gtk::Box>().ok())
+                    else {
+                        return glib::ControlFlow::Break;
+                    };
+
+                    let Some(child_widget) = child_box
+                        .observe_children()
+                        .item(child_index as u32)
+                        .and_then(|obj| obj.downcast::<gtk::Widget>().ok())
+                    else {
+                        return glib::ControlFlow::Continue;
+                    };
+
+                    Self::scroll_widget_into_view(&child_widget, &scroll_child_for_tick);
+                    glib::ControlFlow::Break
+                });
+                return;
+            }
+
+            Self::scroll_widget_into_view(&row_widget, &scroll_child);
         }
     }
 }
@@ -1823,7 +1861,9 @@ impl SessionDetail {
         self.scroll_debounce_scheduled.set(false);
         self.resize_debounce_scheduled.set(false);
         self.pending_search_hydration_target = None;
+        self.pending_search_hydration_item_index = None;
         self.pending_scroll_after_layout.set(None);
+        self.pending_delayed_search_scroll.set(None);
     }
 
     fn row_intersects_hydration_window(
@@ -2665,7 +2705,9 @@ impl SessionDetail {
         self.pending_jump = None;
         self.loading_jump = false;
         self.pending_search_hydration_target = None;
+        self.pending_search_hydration_item_index = None;
         self.pending_scroll_after_layout.set(None);
+        self.pending_delayed_search_scroll.set(None);
     }
 
     fn loaded_match_count(&self) -> usize {
@@ -2725,11 +2767,13 @@ impl SessionDetail {
                 self.pending_jump = None;
                 self.loading_jump = false;
                 self.pending_search_hydration_target = None;
+                self.pending_search_hydration_item_index = None;
                 return;
             };
 
             if !self.deferred_hydrated_items.contains(&item_index) {
                 self.pending_search_hydration_target = Some(scroll_target);
+                self.pending_search_hydration_item_index = Some(item_index);
                 self.queue_deferred_hydration_target(DeferredHydrationTarget {
                     request_id: self.transcript_request_id,
                     display_index: scroll_target.display_index,
@@ -2743,6 +2787,7 @@ impl SessionDetail {
             self.pending_jump = None;
             self.loading_jump = false;
             self.pending_search_hydration_target = None;
+            self.pending_search_hydration_item_index = None;
             self.pending_scroll_after_layout.set(Some(scroll_target));
         } else if (position.item_index as usize) >= self.loaded_count && self.has_more_messages {
             self.load_next_page(sender);
@@ -2754,6 +2799,7 @@ impl SessionDetail {
             );
             self.pending_jump = None;
             self.loading_jump = false;
+            self.pending_search_hydration_item_index = None;
         } else {
             debug_assert!(
                 false,
@@ -2767,6 +2813,7 @@ impl SessionDetail {
             );
             self.pending_jump = None;
             self.loading_jump = false;
+            self.pending_search_hydration_item_index = None;
         }
     }
 
@@ -3565,6 +3612,7 @@ fn synthetic_measurement(input: &str) -> String {\n\
             assert_eq!(parts.model.pending_jump, Some(0));
             assert!(parts.model.loading_jump);
             assert!(parts.model.pending_search_hydration_target.is_some());
+            assert_eq!(parts.model.pending_search_hydration_item_index, Some(70));
             assert!(parts.model.pending_scroll_after_layout.get().is_none());
         }
 
@@ -3586,7 +3634,78 @@ fn synthetic_measurement(input: &str) -> String {\n\
         assert_eq!(parts.model.pending_jump, None);
         assert!(!parts.model.loading_jump);
         assert!(parts.model.pending_search_hydration_target.is_none());
+        assert!(parts.model.pending_search_hydration_item_index.is_none());
         assert!(parts.model.deferred_hydrated_items.contains(&70));
+    }
+
+    #[gtk::test]
+    fn stale_delayed_search_scroll_callback_is_ignored_after_request_change() {
+        let temp_db = tempfile::NamedTempFile::new().expect("temp db");
+        seed_message_transcript(temp_db.path(), "test-session-123", INITIAL_PAGE_SIZE);
+
+        let controller = SessionDetail::builder().launch(temp_db.path().to_path_buf());
+        controller.emit(SessionDetailMsg::SetSession {
+            session: Box::new(build_test_session(None, None, 0, 0, 0)),
+            search_query: None,
+        });
+
+        pump_main_context(|| {
+            let parts = controller.state().get();
+            !parts.model.loading_first_page && parts.model.pending_render_batch.is_none()
+        });
+
+        let stale_request_id = controller.state().get().model.transcript_request_id;
+        controller.emit(SessionDetailMsg::Clear);
+        pump_main_context(|| controller.state().get().model.session.is_none());
+
+        controller.emit(SessionDetailMsg::ExecuteDelayedSearchScroll {
+            request_id: stale_request_id,
+            target: ScrollTarget {
+                display_index: 0,
+                child_index: None,
+            },
+        });
+        pump_main_context(|| true);
+
+        let parts = controller.state().get();
+        assert!(parts.model.pending_delayed_search_scroll.get().is_none());
+    }
+
+    #[gtk::test]
+    fn search_target_hydration_resume_requires_matching_item_index() {
+        let temp_db = tempfile::NamedTempFile::new().expect("temp db");
+        seed_search_transcript(temp_db.path(), "test-session-123", INITIAL_PAGE_SIZE, &[70]);
+
+        let controller = SessionDetail::builder().launch(temp_db.path().to_path_buf());
+        controller.emit(SessionDetailMsg::SetSession {
+            session: Box::new(build_test_session(None, None, 0, 0, 0)),
+            search_query: Some("needle".to_string()),
+        });
+
+        pump_main_context_for(Duration::from_secs(5), || {
+            controller
+                .state()
+                .get()
+                .model
+                .pending_search_hydration_item_index
+                == Some(70)
+        });
+
+        let request_id = controller.state().get().model.transcript_request_id;
+        controller.emit(SessionDetailMsg::DeferredContentHydrated {
+            request_id,
+            item_index: 71,
+            kind: TranscriptRowBuildKind::Message,
+            reason: DeferredHydrationReason::SearchTarget,
+            duration_ms: 1,
+        });
+        pump_main_context(|| true);
+
+        let parts = controller.state().get();
+        assert_eq!(parts.model.pending_jump, Some(0));
+        assert!(parts.model.loading_jump);
+        assert_eq!(parts.model.pending_search_hydration_item_index, Some(70));
+        assert!(parts.model.pending_scroll_after_layout.get().is_none());
     }
 
     #[test]

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -64,6 +64,7 @@ pub struct SessionDetail {
     input_sender: relm4::Sender<SessionDetailMsg>,
     deferred_hydration_queue: RefCell<VecDeque<DeferredHydrationTarget>>,
     deferred_hydration_queued_items: RefCell<BTreeSet<usize>>,
+    pending_anchor_targets: RefCell<Vec<DeferredHydrationTarget>>,
     deferred_hydration_tick_scheduled: Cell<bool>,
     pending_viewport_hydration_scan: Cell<Option<PendingViewportHydrationScan>>,
     scroll_debounce_scheduled: Cell<bool>,
@@ -163,6 +164,19 @@ struct DeferredHydrationTarget {
     display_index: usize,
     item_index: usize,
     reason: DeferredHydrationReason,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct HydrationAnchorRow {
+    display_index: usize,
+    pre_height: i32,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct PendingHydrationAnchor {
+    request_id: u64,
+    pre_value: f64,
+    rows: Vec<HydrationAnchorRow>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -987,6 +1001,7 @@ impl Component for SessionDetail {
             input_sender: sender.input_sender().clone(),
             deferred_hydration_queue: RefCell::new(VecDeque::new()),
             deferred_hydration_queued_items: RefCell::new(BTreeSet::new()),
+            pending_anchor_targets: RefCell::new(Vec::new()),
             deferred_hydration_tick_scheduled: Cell::new(false),
             pending_viewport_hydration_scan: Cell::new(None),
             scroll_debounce_scheduled: Cell::new(false),
@@ -1657,6 +1672,16 @@ impl Component for SessionDetail {
                 .add_toast(adw::Toast::new("Could not load full message."));
         }
 
+        let pending_anchor_targets = self.pending_anchor_targets.replace(Vec::new());
+        if let Some(request_id) = pending_anchor_targets
+            .first()
+            .map(|target| target.request_id)
+            && let Some(anchor) =
+                self.capture_hydration_anchor(widgets, request_id, &pending_anchor_targets)
+        {
+            self.schedule_hydration_anchor_compensation(widgets, anchor);
+        }
+
         if let Some(scan) = self.pending_viewport_hydration_scan.take() {
             self.queue_visible_deferred_hydration(widgets, scan);
             self.schedule_hydration_drain();
@@ -1856,6 +1881,7 @@ impl SessionDetail {
         self.deferred_hydrated_items.clear();
         self.deferred_hydration_queue.borrow_mut().clear();
         self.deferred_hydration_queued_items.borrow_mut().clear();
+        self.pending_anchor_targets.borrow_mut().clear();
         self.deferred_hydration_tick_scheduled.set(false);
         self.pending_viewport_hydration_scan.set(None);
         self.scroll_debounce_scheduled.set(false);
@@ -1878,6 +1904,126 @@ impl SessionDetail {
         let hydration_top = viewport_top - margin;
         let hydration_bottom = viewport_top + viewport_page_size + margin;
         row_bottom >= hydration_top && row_top <= hydration_bottom
+    }
+
+    fn row_is_strictly_above_viewport(row_y: f64, row_height: f64, viewport_top: f64) -> bool {
+        row_y + row_height < viewport_top
+    }
+
+    fn compute_anchored_scroll_value(
+        pre_value: f64,
+        delta: f64,
+        lower: f64,
+        upper: f64,
+        page_size: f64,
+    ) -> f64 {
+        let max_value = (upper - page_size).max(lower);
+        (pre_value + delta).clamp(lower, max_value)
+    }
+
+    fn capture_hydration_anchor(
+        &self,
+        widgets: &SessionDetailWidgets,
+        request_id: u64,
+        batch: &[DeferredHydrationTarget],
+    ) -> Option<PendingHydrationAnchor> {
+        let vadj = widgets.transcript_scrolled_window.vadjustment();
+        let pre_value = vadj.value();
+        if pre_value <= 0.0 {
+            return None;
+        }
+        if batch
+            .iter()
+            .all(|target| target.reason == DeferredHydrationReason::InitialViewport)
+        {
+            return None;
+        }
+
+        let mut rows = Vec::new();
+        let messages_widget = self.messages.widget();
+        let viewport_top = pre_value;
+        for target in batch {
+            if target.request_id != request_id || target.display_index >= self.messages.len() {
+                continue;
+            }
+            let Some(row_widget) = messages_widget
+                .observe_children()
+                .item(target.display_index as u32)
+                .and_then(|obj| obj.downcast::<gtk::Widget>().ok())
+            else {
+                continue;
+            };
+            let Some(point) = row_widget
+                .compute_point(&widgets.scroll_child, &gtk::graphene::Point::new(0.0, 0.0))
+            else {
+                continue;
+            };
+            let row_height = row_widget.height().max(1) as f64;
+            if !Self::row_is_strictly_above_viewport(point.y() as f64, row_height, viewport_top) {
+                continue;
+            }
+            rows.push(HydrationAnchorRow {
+                display_index: target.display_index,
+                pre_height: row_widget.height().max(1),
+            });
+        }
+
+        if rows.is_empty() {
+            None
+        } else {
+            Some(PendingHydrationAnchor {
+                request_id,
+                pre_value,
+                rows,
+            })
+        }
+    }
+
+    fn schedule_hydration_anchor_compensation(
+        &self,
+        widgets: &SessionDetailWidgets,
+        anchor: PendingHydrationAnchor,
+    ) {
+        let tick_count = Cell::new(0u8);
+        let messages_widget = self.messages.widget().clone();
+        let vadj = widgets.transcript_scrolled_window.vadjustment();
+        widgets.scroll_child.add_tick_callback(move |_, _| {
+            let ticks = tick_count.get().saturating_add(1);
+            tick_count.set(ticks);
+            if ticks < 2 {
+                return glib::ControlFlow::Continue;
+            }
+
+            let mut delta = 0.0f64;
+            for row in &anchor.rows {
+                let Some(row_widget) = messages_widget
+                    .observe_children()
+                    .item(row.display_index as u32)
+                    .and_then(|obj| obj.downcast::<gtk::Widget>().ok())
+                else {
+                    continue;
+                };
+                let post_height = row_widget.height().max(1);
+                delta += f64::from(post_height - row.pre_height);
+            }
+
+            if delta != 0.0 {
+                let anchored_value = Self::compute_anchored_scroll_value(
+                    anchor.pre_value,
+                    delta,
+                    vadj.lower(),
+                    vadj.upper(),
+                    vadj.page_size(),
+                );
+                vadj.set_value(anchored_value);
+                tracing::debug!(
+                    request_id = anchor.request_id,
+                    delta,
+                    "Anchored transcript scroll on hydration"
+                );
+            }
+            glib::ControlFlow::Break
+        });
     }
 
     fn queue_deferred_hydration_target(&self, target: DeferredHydrationTarget) {
@@ -2510,6 +2656,7 @@ impl SessionDetail {
         let started_at = Instant::now();
         let mut hydrated_count = 0usize;
         let mut max_row_hydration_duration = Duration::ZERO;
+        let mut batch_targets = Vec::new();
 
         for _ in 0..HYDRATION_BATCH_SIZE {
             let Some(target) = self.deferred_hydration_queue.borrow_mut().pop_front() else {
@@ -2535,6 +2682,14 @@ impl SessionDetail {
                 continue;
             }
 
+            batch_targets.push(target);
+        }
+
+        if !batch_targets.is_empty() {
+            *self.pending_anchor_targets.borrow_mut() = batch_targets.clone();
+        }
+
+        for target in batch_targets {
             let row_started_at = Instant::now();
             self.messages.send(
                 target.display_index,
@@ -3932,6 +4087,33 @@ fn synthetic_measurement(input: &str) -> String {\n\
         assert!(!SessionDetail::deferred_target_matches_row(Some(4), 5));
         assert!(!SessionDetail::deferred_target_matches_row(None, 5));
         assert!(SessionDetail::deferred_target_matches_row(Some(5), 5));
+    }
+
+    #[test]
+    fn scroll_anchor_delta_clamps_to_adjustment_range() {
+        let anchored = SessionDetail::compute_anchored_scroll_value(120.0, 50.0, 0.0, 200.0, 60.0);
+        assert_eq!(anchored, 140.0);
+
+        let clamped_low =
+            SessionDetail::compute_anchored_scroll_value(10.0, -50.0, 0.0, 200.0, 60.0);
+        assert_eq!(clamped_low, 0.0);
+
+        let clamped_high =
+            SessionDetail::compute_anchored_scroll_value(190.0, 50.0, 0.0, 200.0, 60.0);
+        assert_eq!(clamped_high, 140.0);
+    }
+
+    #[test]
+    fn rows_strictly_above_viewport_are_anchor_candidates() {
+        assert!(SessionDetail::row_is_strictly_above_viewport(
+            20.0, 30.0, 60.0
+        ));
+        assert!(!SessionDetail::row_is_strictly_above_viewport(
+            40.0, 20.0, 60.0
+        ));
+        assert!(!SessionDetail::row_is_strictly_above_viewport(
+            65.0, 20.0, 60.0
+        ));
     }
 
     #[gtk::test]

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -23,8 +23,8 @@ use crate::ui::transcript_display::{
     trailing_tool_rows_from_display,
 };
 use crate::ui::transcript_row::{
-    TranscriptItemInit, TranscriptRow, TranscriptRowBuildKind, TranscriptRowOutput,
-    transcript_item_init_from_display_item,
+    DeferredHydrationReason, TranscriptItemInit, TranscriptRow, TranscriptRowBuildKind,
+    TranscriptRowMsg, TranscriptRowOutput, transcript_item_init_from_display_item,
 };
 
 const INITIAL_PAGE_SIZE: usize = 75;
@@ -55,6 +55,7 @@ pub struct SessionDetail {
     transcript_request_id: u64,
     pending_render_batch: Option<PendingRenderBatch>,
     last_render_metrics: Option<RenderMetrics>,
+    deferred_hydrated_items: BTreeSet<usize>,
     pending_boundary_tool_rows: Vec<crate::database::TranscriptItemRow>,
     search_query: Option<String>,
     match_positions: Vec<crate::database::MatchPosition>,
@@ -294,6 +295,13 @@ pub enum SessionDetailMsg {
         item_index: usize,
         kind: TranscriptRowBuildKind,
         build_duration_ms: u128,
+    },
+    DeferredContentHydrated {
+        request_id: u64,
+        item_index: usize,
+        kind: TranscriptRowBuildKind,
+        reason: DeferredHydrationReason,
+        duration_ms: u128,
     },
     Clear,
     InspectToolCall(String),
@@ -858,6 +866,19 @@ impl Component for SessionDetail {
                     kind,
                     build_duration_ms,
                 },
+                TranscriptRowOutput::DeferredContentHydrated {
+                    request_id,
+                    item_index,
+                    kind,
+                    reason,
+                    duration_ms,
+                } => SessionDetailMsg::DeferredContentHydrated {
+                    request_id,
+                    item_index,
+                    kind,
+                    reason,
+                    duration_ms,
+                },
             });
 
         let db_path = Arc::new(db_path);
@@ -884,6 +905,7 @@ impl Component for SessionDetail {
             transcript_request_id: 0,
             pending_render_batch: None,
             last_render_metrics: None,
+            deferred_hydrated_items: BTreeSet::new(),
             pending_boundary_tool_rows: Vec::new(),
             search_query: None,
             match_positions: Vec::new(),
@@ -1088,6 +1110,36 @@ impl Component for SessionDetail {
                 build_duration_ms,
             } => {
                 self.record_transcript_row_build(sender, item_index, kind, build_duration_ms);
+            }
+            SessionDetailMsg::DeferredContentHydrated {
+                ref request_id,
+                item_index,
+                kind,
+                reason,
+                duration_ms,
+            } => {
+                if *request_id != self.transcript_request_id {
+                    tracing::debug!(
+                        request_id,
+                        current_request_id = self.transcript_request_id,
+                        item_index,
+                        ?kind,
+                        "Dropping stale deferred hydration notification"
+                    );
+                    return;
+                }
+                self.deferred_hydrated_items.insert(item_index);
+                tracing::info!(
+                    request_id,
+                    item_index,
+                    ?kind,
+                    ?reason,
+                    duration_ms,
+                    row_msg_type = %std::any::type_name::<TranscriptRowMsg>(),
+                    hydrated_item_count = self.deferred_hydrated_items.len(),
+                    "Accepted deferred hydration output"
+                );
+                self.continue_pending_jump(&sender);
             }
             SessionDetailMsg::ClearSearch => {
                 self.search_query = None;
@@ -1544,6 +1596,7 @@ impl SessionDetail {
         matched_item_indexes: &BTreeSet<i64>,
         db_path: Arc<PathBuf>,
         base_display_index: usize,
+        request_id: u64,
     ) -> PreparedTranscriptItems {
         let mut items = Vec::new();
         let mut display_targets_by_item_index = BTreeMap::new();
@@ -1569,6 +1622,7 @@ impl SessionDetail {
                 session_id,
                 item_highlight,
                 db_path.clone(),
+                request_id,
             ));
         }
 
@@ -1582,6 +1636,7 @@ impl SessionDetail {
         self.transcript_request_id = self.transcript_request_id.wrapping_add(1);
         self.pending_render_batch = None;
         self.last_render_metrics = None;
+        self.deferred_hydrated_items.clear();
     }
 
     fn invalidate_search_requests(&mut self) {
@@ -2116,6 +2171,7 @@ impl SessionDetail {
             &matched_item_indexes,
             db_path,
             0,
+            request_id,
         );
         let display_item_count = prepared.items.len();
         self.extend_display_targets(prepared.display_targets_by_item_index);
@@ -2447,6 +2503,7 @@ impl SessionDetail {
                     session_id,
                     item_highlight,
                     db_path.clone(),
+                    request_id,
                 ));
             }
         }
@@ -2459,6 +2516,7 @@ impl SessionDetail {
             &matched_item_indexes,
             db_path,
             page_start,
+            request_id,
         );
         let display_item_count = prepared.items.len();
 
@@ -2912,6 +2970,7 @@ fn synthetic_measurement(input: &str) -> String {\n\
             &matched_item_indexes,
             Arc::new(PathBuf::from("/tmp/test.db")),
             0,
+            1,
         );
 
         assert_eq!(prepared.items.len(), 2);
@@ -2962,6 +3021,7 @@ fn synthetic_measurement(input: &str) -> String {\n\
             &matched_item_indexes,
             Arc::new(PathBuf::from("/tmp/test.db")),
             0,
+            1,
         );
 
         match &prepared.items[0] {
@@ -2993,6 +3053,62 @@ fn synthetic_measurement(input: &str) -> String {\n\
                 std::mem::discriminant(other)
             ),
         }
+    }
+
+    #[test]
+    fn build_display_items_assigns_active_transcript_request_id() {
+        let rows = vec![
+            transcript_message_row(0, crate::models::Role::Assistant, "hello"),
+            transcript_tool_row(1, "Read"),
+            transcript_subagent_row(2, "Explore"),
+        ];
+        let matched_item_indexes = BTreeSet::new();
+
+        let prepared = SessionDetail::build_display_items(
+            rows,
+            "session-1",
+            None,
+            &matched_item_indexes,
+            Arc::new(PathBuf::from("/tmp/test.db")),
+            0,
+            77,
+        );
+
+        assert_eq!(prepared.items.len(), 3);
+        for item in &prepared.items {
+            assert_eq!(item.request_id(), 77);
+        }
+    }
+
+    #[gtk::test]
+    fn stale_deferred_hydration_output_is_discarded() {
+        let temp_db = tempfile::NamedTempFile::new().expect("temp db");
+        seed_message_transcript(temp_db.path(), "test-session-123", INITIAL_PAGE_SIZE);
+
+        let controller = SessionDetail::builder().launch(temp_db.path().to_path_buf());
+        controller.emit(SessionDetailMsg::SetSession {
+            session: Box::new(build_test_session(None, None, 0, 0, 0)),
+            search_query: None,
+        });
+
+        pump_main_context(|| {
+            let parts = controller.state().get();
+            !parts.model.loading_first_page && parts.model.pending_render_batch.is_none()
+        });
+
+        let current_request_id = controller.state().get().model.transcript_request_id;
+        controller.emit(SessionDetailMsg::DeferredContentHydrated {
+            request_id: current_request_id.wrapping_add(1),
+            item_index: 0,
+            kind: TranscriptRowBuildKind::Message,
+            reason: DeferredHydrationReason::SearchTarget,
+            duration_ms: 3,
+        });
+
+        pump_main_context(|| true);
+
+        let parts = controller.state().get();
+        assert!(parts.model.deferred_hydrated_items.is_empty());
     }
 
     #[gtk::test]
@@ -3224,6 +3340,7 @@ fn synthetic_measurement(input: &str) -> String {\n\
             &matched_item_indexes,
             Arc::new(PathBuf::from("/tmp/test.db")),
             0,
+            1,
         );
         let counts = SessionDetail::count_render_item_kinds(&prepared.items);
 

--- a/src/ui/transcript_row.rs
+++ b/src/ui/transcript_row.rs
@@ -34,6 +34,16 @@ const TOOL_ICONS: ToolCategoryIcons = ToolCategoryIcons {
 const SLOW_ROW_WIDGET_BUILD: Duration = Duration::from_millis(10);
 const SLOW_CONTENT_RENDER: Duration = Duration::from_millis(10);
 
+const MESSAGE_PLACEHOLDER_MIN_LINES: usize = 2;
+const MESSAGE_PLACEHOLDER_MAX_LINES: usize = 24;
+const MESSAGE_PLACEHOLDER_WRAP_CHARS: usize = 80;
+const MESSAGE_PLACEHOLDER_ASSISTANT_EXTRA_LINES: usize = 4;
+const ESTIMATED_LINE_HEIGHT_PX: i32 = 22;
+const MESSAGE_HEADER_AND_SPACING_HEIGHT_PX: i32 = 56;
+const TOOL_CALL_PLACEHOLDER_HEIGHT_PX: i32 = 48;
+const TOOL_BURST_HEADER_HEIGHT_PX: i32 = 44;
+const SUBAGENT_PLACEHOLDER_HEIGHT_PX: i32 = 40;
+
 /// Return the model display text for a transcript header.
 /// Only assistant messages with a non-empty model value produce output.
 fn model_label_text(role: Role, model: Option<&str>) -> Option<String> {
@@ -57,6 +67,7 @@ pub struct MessageItemInit {
     pub preview: MessagePreview,
     pub highlight_query: Option<String>,
     pub db_path: Arc<PathBuf>,
+    pub request_id: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -90,6 +101,7 @@ pub struct ToolCallItemInit {
     pub highlight_query: Option<String>,
     /// Presence flags for associated reasoning attachment.
     pub reasoning_preview: ReasoningPreview,
+    pub request_id: u64,
 }
 
 impl ToolCallItemInit {
@@ -112,6 +124,7 @@ pub struct ToolBurstItemInit {
     pub visible_reasoning_child_count: usize,
     pub encrypted_only_child_count: usize,
     pub default_expanded: bool,
+    pub request_id: u64,
 }
 
 pub struct SubagentItemInit {
@@ -121,6 +134,7 @@ pub struct SubagentItemInit {
     pub subagent_id: String,
     pub title: String,
     pub reasoning_preview: ReasoningPreview,
+    pub request_id: u64,
 }
 
 pub enum TranscriptItemInit {
@@ -139,6 +153,36 @@ impl TranscriptItemInit {
             Self::Subagent(init) => init.item_index,
         }
     }
+
+    pub fn request_id(&self) -> u64 {
+        match self {
+            Self::Message(init) => init.request_id,
+            Self::ToolCall(init) => init.request_id,
+            Self::ToolBurst(init) => init.request_id,
+            Self::Subagent(init) => init.request_id,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Hydration reason
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeferredHydrationReason {
+    InitialViewport,
+    ScrollViewport,
+    ResizeViewport,
+    SearchTarget,
+    UserExpand,
+    UserInspect,
+    UserToolBurstToggle,
+}
+
+impl DeferredHydrationReason {
+    pub fn is_search_critical(self) -> bool {
+        matches!(self, Self::SearchTarget)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -148,7 +192,9 @@ impl TranscriptItemInit {
 #[derive(Debug)]
 pub enum TranscriptRowMsg {
     ToggleExpand,
+    ToggleToolBurst,
     InspectClicked,
+    HydrateDeferredContent { reason: DeferredHydrationReason },
 }
 
 #[derive(Debug)]
@@ -173,6 +219,13 @@ pub enum TranscriptRowOutput {
         item_index: usize,
         kind: TranscriptRowBuildKind,
         build_duration_ms: u128,
+    },
+    DeferredContentHydrated {
+        request_id: u64,
+        item_index: usize,
+        kind: TranscriptRowBuildKind,
+        reason: DeferredHydrationReason,
+        duration_ms: u128,
     },
 }
 
@@ -212,12 +265,16 @@ impl From<TranscriptRowKind> for TranscriptRowBuildKind {
 // ---------------------------------------------------------------------------
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct TranscriptRow {
     item_index: usize,
     transcript_item_index: Option<i64>,
     session_id: Option<String>,
     reasoning_preview: Option<ReasoningPreview>,
     kind: TranscriptRowKind,
+    request_id: u64,
+    hydrated: bool,
+    placeholder_height_request: i32,
 
     // --- Message state ---
     preview: Option<MessagePreview>,
@@ -301,6 +358,36 @@ fn render_content(
     match_count
 }
 
+fn estimate_message_placeholder_lines(preview: &MessagePreview) -> usize {
+    let explicit_lines = preview.content_preview.matches('\n').count() + 1;
+    let non_newline_chars = preview
+        .content_preview
+        .chars()
+        .filter(|ch| *ch != '\n')
+        .count();
+    let wrapped_lines = non_newline_chars.div_ceil(MESSAGE_PLACEHOLDER_WRAP_CHARS);
+    let role_bias = if preview.role == Role::Assistant {
+        MESSAGE_PLACEHOLDER_ASSISTANT_EXTRA_LINES
+    } else {
+        0
+    };
+
+    (explicit_lines + wrapped_lines + role_bias)
+        .clamp(MESSAGE_PLACEHOLDER_MIN_LINES, MESSAGE_PLACEHOLDER_MAX_LINES)
+}
+
+fn estimate_message_placeholder_height(preview: &MessagePreview) -> i32 {
+    (estimate_message_placeholder_lines(preview) as i32 * ESTIMATED_LINE_HEIGHT_PX)
+        + MESSAGE_HEADER_AND_SPACING_HEIGHT_PX
+}
+
+fn placeholder_widget(height_request: i32) -> gtk::Box {
+    let placeholder = gtk::Box::new(gtk::Orientation::Vertical, 0);
+    placeholder.add_css_class("transcript-row-placeholder");
+    placeholder.set_size_request(-1, height_request.max(1));
+    placeholder
+}
+
 fn count_tool_call_matches(init: &ToolCallItemInit) -> usize {
     let Some(query) = init.highlight_query.as_deref() else {
         return 0;
@@ -317,6 +404,7 @@ pub fn build_tool_burst_init(
     item_index: usize,
     tool_calls: Vec<ToolCallItemInit>,
     default_expanded: bool,
+    request_id: u64,
 ) -> ToolBurstItemInit {
     let mut category_counts = BTreeMap::new();
     let mut error_count = 0usize;
@@ -356,6 +444,7 @@ pub fn build_tool_burst_init(
         visible_reasoning_child_count,
         encrypted_only_child_count,
         default_expanded,
+        request_id,
     }
 }
 
@@ -639,6 +728,9 @@ impl FactoryComponent for TranscriptRow {
                 session_id: Some(m.preview.session_id.clone()),
                 reasoning_preview: Some(m.preview.reasoning_preview),
                 kind: TranscriptRowKind::Message,
+                request_id: m.request_id,
+                hydrated: false,
+                placeholder_height_request: estimate_message_placeholder_height(&m.preview),
                 preview: Some(m.preview),
                 highlight_query: m.highlight_query,
                 db_path: Some(m.db_path),
@@ -662,6 +754,9 @@ impl FactoryComponent for TranscriptRow {
                 session_id: Some(tc.session_id.clone()),
                 reasoning_preview: Some(tc.reasoning_preview),
                 kind: TranscriptRowKind::ToolCall,
+                request_id: tc.request_id,
+                hydrated: false,
+                placeholder_height_request: TOOL_CALL_PLACEHOLDER_HEIGHT_PX,
                 preview: None,
                 highlight_query: None,
                 db_path: None,
@@ -685,6 +780,9 @@ impl FactoryComponent for TranscriptRow {
                 session_id: None,
                 reasoning_preview: None,
                 kind: TranscriptRowKind::ToolBurst,
+                request_id: tb.request_id,
+                hydrated: tb.default_expanded,
+                placeholder_height_request: TOOL_BURST_HEADER_HEIGHT_PX,
                 preview: None,
                 highlight_query: None,
                 db_path: None,
@@ -708,6 +806,9 @@ impl FactoryComponent for TranscriptRow {
                 session_id: Some(sa.session_id),
                 reasoning_preview: Some(sa.reasoning_preview),
                 kind: TranscriptRowKind::Subagent,
+                request_id: sa.request_id,
+                hydrated: true,
+                placeholder_height_request: SUBAGENT_PLACEHOLDER_HEIGHT_PX,
                 preview: None,
                 highlight_query: None,
                 db_path: None,
@@ -856,6 +957,8 @@ impl FactoryComponent for TranscriptRow {
                 }
                 TranscriptRowKind::Message => {}
             },
+            TranscriptRowMsg::ToggleToolBurst => {}
+            TranscriptRowMsg::HydrateDeferredContent { .. } => {}
         }
     }
 
@@ -904,6 +1007,14 @@ impl FactoryComponent for TranscriptRow {
 }
 
 impl TranscriptRow {
+    pub fn item_index(&self) -> usize {
+        self.item_index
+    }
+
+    pub fn is_hydrated(&self) -> bool {
+        self.hydrated
+    }
+
     /// Build the widget tree for a message transcript item.
     fn build_message_widgets(
         &mut self,
@@ -1059,6 +1170,7 @@ impl TranscriptRow {
             duration_ms: self.tool_duration_ms,
             highlight_query: self.tool_highlight_query.clone(),
             reasoning_preview: self.reasoning_preview.unwrap_or_default(),
+            request_id: self.request_id,
         };
 
         let build_started_at = Instant::now();
@@ -1351,6 +1463,7 @@ fn transcript_item_init_from_row(
         session_id,
         highlight_query,
         db_path,
+        1,
     )
 }
 
@@ -1360,6 +1473,7 @@ fn transcript_item_init_from_row_with_index(
     session_id: &str,
     highlight_query: Option<String>,
     db_path: Arc<PathBuf>,
+    request_id: u64,
 ) -> TranscriptItemInit {
     use crate::models::{ToolCallStatus, TranscriptItemKind};
 
@@ -1388,6 +1502,7 @@ fn transcript_item_init_from_row_with_index(
                 },
                 highlight_query,
                 db_path,
+                request_id,
             })
         }
         TranscriptItemKind::ToolCall => TranscriptItemInit::ToolCall(ToolCallItemInit {
@@ -1410,6 +1525,7 @@ fn transcript_item_init_from_row_with_index(
             duration_ms: row.duration_ms,
             highlight_query,
             reasoning_preview: row.reasoning_preview,
+            request_id,
         }),
         TranscriptItemKind::Subagent => TranscriptItemInit::Subagent(SubagentItemInit {
             item_index,
@@ -1421,6 +1537,7 @@ fn transcript_item_init_from_row_with_index(
                 .clone()
                 .unwrap_or_else(|| "Subagent".to_string()),
             reasoning_preview: row.reasoning_preview,
+            request_id,
         }),
         TranscriptItemKind::Unknown => {
             tracing::warn!(
@@ -1442,6 +1559,7 @@ fn transcript_item_init_from_row_with_index(
                 },
                 highlight_query,
                 db_path,
+                request_id,
             })
         }
     }
@@ -1453,6 +1571,7 @@ pub fn transcript_item_init_from_display_item(
     session_id: &str,
     highlight_query: Option<String>,
     db_path: Arc<PathBuf>,
+    request_id: u64,
 ) -> TranscriptItemInit {
     match item {
         crate::ui::transcript_display::DisplayTranscriptItem::Single(row) => {
@@ -1462,6 +1581,7 @@ pub fn transcript_item_init_from_display_item(
                 session_id,
                 highlight_query,
                 db_path,
+                request_id,
             )
         }
         crate::ui::transcript_display::DisplayTranscriptItem::ToolBurst(burst) => {
@@ -1475,6 +1595,7 @@ pub fn transcript_item_init_from_display_item(
                         session_id,
                         highlight_query.clone(),
                         db_path.clone(),
+                        request_id,
                     ) {
                         TranscriptItemInit::ToolCall(tool_call) => Some(tool_call),
                         other => {
@@ -1488,7 +1609,12 @@ pub fn transcript_item_init_from_display_item(
                     }
                 })
                 .collect();
-            TranscriptItemInit::ToolBurst(build_tool_burst_init(display_index, tool_calls, false))
+            TranscriptItemInit::ToolBurst(build_tool_burst_init(
+                display_index,
+                tool_calls,
+                false,
+                request_id,
+            ))
         }
     }
 }
@@ -1589,6 +1715,7 @@ mod tests {
             duration_ms: Some(12),
             highlight_query: Some("read".to_string()),
             reasoning_preview: ReasoningPreview::default(),
+            request_id: 1,
         };
         // Only "Read" in tool_name matches; preview has no "read", summary is hidden.
         assert_eq!(count_tool_call_matches(&with_preview), 1);
@@ -1606,6 +1733,7 @@ mod tests {
             duration_ms: Some(12),
             highlight_query: Some("read".to_string()),
             reasoning_preview: ReasoningPreview::default(),
+            request_id: 1,
         };
         // "Read" in tool_name + "read" in summary fallback = 2.
         assert_eq!(count_tool_call_matches(&with_summary_fallback), 2);
@@ -1630,6 +1758,7 @@ mod tests {
                     has_visible_reasoning: true,
                     encrypted_only: false,
                 },
+                request_id: 1,
             },
             |_| {},
             |_, _| {},
@@ -1759,6 +1888,7 @@ mod tests {
                 duration_ms: Some(5),
                 highlight_query: Some("read".to_string()),
                 reasoning_preview: ReasoningPreview::default(),
+                request_id: 1,
             },
             ToolCallItemInit {
                 item_index: 2,
@@ -1772,10 +1902,11 @@ mod tests {
                 duration_ms: Some(8),
                 highlight_query: Some("edit".to_string()),
                 reasoning_preview: ReasoningPreview::default(),
+                request_id: 1,
             },
         ];
 
-        let burst = build_tool_burst_init(10, tool_calls, false);
+        let burst = build_tool_burst_init(10, tool_calls, false, 1);
         assert_eq!(burst.error_count, 1);
         assert_eq!(burst.total_duration_ms, Some(13));
         assert_eq!(burst.match_count, 4);
@@ -1828,6 +1959,7 @@ mod tests {
             "session-1",
             None,
             Arc::new(PathBuf::from("/tmp/test.db")),
+            1,
         );
 
         let TranscriptItemInit::ToolBurst(burst_init) = init else {
@@ -1951,5 +2083,84 @@ mod tests {
             preview_from_row(&row).as_deref(),
             Some("fallback summary from db")
         );
+    }
+
+    #[test]
+    fn transcript_item_init_from_display_item_carries_request_id() {
+        let item = crate::ui::transcript_display::DisplayTranscriptItem::Single(Box::new(
+            crate::database::TranscriptItemRow {
+                item_index: 42,
+                kind: crate::models::TranscriptItemKind::Message,
+                reasoning_preview: crate::models::ReasoningPreview::default(),
+                message_index: Some(42),
+                role: Some(Role::Assistant),
+                content_preview: Some("hello".to_string()),
+                content_len: Some(5),
+                timestamp: Some(0),
+                model: Some("test-model".to_string()),
+                tool_call_id: None,
+                tool_name: None,
+                tool_status: None,
+                tool_summary: None,
+                tool_input_json: None,
+                tool_output_text: None,
+                duration_ms: None,
+                subagent_id: None,
+                subagent_title: None,
+                subagent_prompt: None,
+            },
+        ));
+
+        let init = transcript_item_init_from_display_item(
+            3,
+            &item,
+            "session-1",
+            None,
+            Arc::new(PathBuf::from("/tmp/test.db")),
+            99,
+        );
+
+        assert_eq!(init.request_id(), 99);
+    }
+
+    #[test]
+    fn message_placeholder_height_biases_assistant_rows_upward() {
+        let user_preview = MessagePreview {
+            session_id: "session-1".to_string(),
+            message_index: 1,
+            role: Role::User,
+            content_preview: "short question".to_string(),
+            content_len: 14,
+            timestamp: Utc.timestamp_opt(0, 0).single().unwrap(),
+            model: None,
+            reasoning_preview: ReasoningPreview::default(),
+        };
+        let assistant_preview = MessagePreview {
+            role: Role::Assistant,
+            model: Some("test-model".to_string()),
+            ..user_preview.clone()
+        };
+
+        assert!(
+            estimate_message_placeholder_height(&assistant_preview)
+                > estimate_message_placeholder_height(&user_preview)
+        );
+    }
+
+    #[test]
+    fn placeholder_height_caps_very_long_message_previews() {
+        let preview = MessagePreview {
+            session_id: "session-1".to_string(),
+            message_index: 1,
+            role: Role::Assistant,
+            content_preview: "very long assistant line ".repeat(500),
+            content_len: 12_000,
+            timestamp: Utc.timestamp_opt(0, 0).single().unwrap(),
+            model: Some("test-model".to_string()),
+            reasoning_preview: ReasoningPreview::default(),
+        };
+
+        assert_eq!(estimate_message_placeholder_lines(&preview), 24);
+        assert_eq!(estimate_message_placeholder_height(&preview), 24 * 22 + 56);
     }
 }

--- a/src/ui/transcript_row.rs
+++ b/src/ui/transcript_row.rs
@@ -1745,6 +1745,87 @@ pub fn transcript_item_init_from_display_item(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use relm4::factory::FactoryVecDeque;
+
+    fn pump_main_context() {
+        let context = gtk::glib::MainContext::default();
+        while context.pending() {
+            context.iteration(false);
+        }
+    }
+
+    fn collect_descendants(root: &gtk::Widget) -> Vec<gtk::Widget> {
+        let mut stack = Vec::new();
+        let mut out = Vec::new();
+        stack.push(root.clone());
+        while let Some(widget) = stack.pop() {
+            out.push(widget.clone());
+            if let Some(mut child) = widget.first_child() {
+                loop {
+                    stack.push(child.clone());
+                    let Some(next) = child.next_sibling() else {
+                        break;
+                    };
+                    child = next;
+                }
+            }
+        }
+        out
+    }
+
+    fn first_factory_row_root(rows: &FactoryVecDeque<TranscriptRow>) -> gtk::Box {
+        rows.widget()
+            .first_child()
+            .and_then(|child| child.downcast::<gtk::Box>().ok())
+            .expect("factory should mount a transcript row")
+    }
+
+    fn first_message_content_container(row_root: &gtk::Box) -> gtk::Box {
+        row_root
+            .first_child()
+            .and_then(|header| header.next_sibling())
+            .and_then(|content| content.downcast::<gtk::Box>().ok())
+            .expect("message row should contain a content container")
+    }
+
+    fn message_init(content_preview: &str) -> TranscriptItemInit {
+        TranscriptItemInit::Message(MessageItemInit {
+            item_index: 0,
+            transcript_item_index: 0,
+            preview: MessagePreview {
+                session_id: "session-1".to_string(),
+                message_index: 0,
+                role: Role::User,
+                content_preview: content_preview.to_string(),
+                content_len: content_preview.len(),
+                timestamp: Utc::now(),
+                model: None,
+                reasoning_preview: ReasoningPreview::default(),
+            },
+            highlight_query: None,
+            db_path: Arc::new(PathBuf::from("/tmp/sessions-chronicle-test.db")),
+            request_id: 1,
+        })
+    }
+
+    fn single_tool_burst_init() -> TranscriptItemInit {
+        let tool_call = ToolCallItemInit {
+            item_index: 1,
+            transcript_item_index: 1,
+            session_id: "session-1".to_string(),
+            tool_call_id: "call-1".to_string(),
+            tool_name: "Read".to_string(),
+            status: ToolCallStatus::Completed,
+            preview: Some("src/main.rs:1-20".to_string()),
+            summary: None,
+            duration_ms: Some(5),
+            highlight_query: None,
+            reasoning_preview: ReasoningPreview::default(),
+            request_id: 1,
+        };
+
+        TranscriptItemInit::ToolBurst(build_tool_burst_init(10, vec![tool_call], false, 1))
+    }
 
     fn row_box_children(row: &gtk::Box) -> Vec<gtk::Widget> {
         let mut children = Vec::new();
@@ -2048,86 +2129,132 @@ mod tests {
 
     #[gtk::test]
     fn message_shell_mounts_placeholder_without_textview() {
-        let content_container = gtk::Box::new(gtk::Orientation::Vertical, 4);
-        let placeholder = placeholder_widget(48);
-        content_container.append(&placeholder);
+        let mut rows: FactoryVecDeque<TranscriptRow> =
+            FactoryVecDeque::builder().launch_default().detach();
+        {
+            let mut guard = rows.guard();
+            guard.push_back(message_init("hello world"));
+        }
+        pump_main_context();
 
-        let first = content_container.first_child().expect("placeholder child");
-        assert!(first.downcast_ref::<gtk::Box>().is_some());
+        let row_root = first_factory_row_root(&rows);
+        let content_container = first_message_content_container(&row_root);
+        let placeholder = content_container
+            .first_child()
+            .expect("placeholder should be mounted initially");
         assert!(
-            content_container
-                .observe_children()
-                .iter::<gtk::Widget>()
-                .flatten()
+            placeholder
+                .css_classes()
+                .iter()
+                .any(|class_name| class_name.as_str() == "transcript-row-placeholder")
+        );
+
+        let descendants = collect_descendants(content_container.upcast_ref());
+        assert!(
+            descendants
+                .iter()
                 .all(|child| child.downcast_ref::<gtk::TextView>().is_none())
+        );
+        assert!(
+            descendants
+                .iter()
+                .all(|child| child.downcast_ref::<gtk::Label>().is_none())
         );
     }
 
     #[gtk::test]
     fn hydrate_message_replaces_placeholder_and_is_idempotent() {
-        let content_container = gtk::Box::new(gtk::Orientation::Vertical, 4);
-        let placeholder = placeholder_widget(48);
-        content_container.append(&placeholder);
+        let mut rows: FactoryVecDeque<TranscriptRow> =
+            FactoryVecDeque::builder().launch_default().detach();
+        {
+            let mut guard = rows.guard();
+            guard.push_back(message_init("hello world"));
+        }
+        pump_main_context();
 
-        let preview = MessagePreview {
-            session_id: "session-1".to_string(),
-            message_index: 0,
-            role: Role::User,
-            content_preview: "hello world".to_string(),
-            content_len: 11,
-            timestamp: Utc::now(),
-            model: None,
-            reasoning_preview: ReasoningPreview::default(),
-        };
-
-        content_container.remove(&placeholder);
-        render_content(
-            &content_container,
-            &preview.content_preview,
-            preview.role,
-            None,
+        rows.send(
+            0,
+            TranscriptRowMsg::HydrateDeferredContent {
+                reason: DeferredHydrationReason::InitialViewport,
+            },
         );
+        pump_main_context();
+
+        let row_root = first_factory_row_root(&rows);
+        let content_container = first_message_content_container(&row_root);
         let first_hydration_children = content_container.observe_children().n_items();
-
-        render_content(
-            &content_container,
-            &preview.content_preview,
-            preview.role,
-            None,
+        let first_child = content_container
+            .first_child()
+            .expect("hydration should render content");
+        assert!(
+            !first_child
+                .css_classes()
+                .iter()
+                .any(|class_name| class_name.as_str() == "transcript-row-placeholder")
         );
+
+        rows.send(
+            0,
+            TranscriptRowMsg::HydrateDeferredContent {
+                reason: DeferredHydrationReason::InitialViewport,
+            },
+        );
+        pump_main_context();
+
+        let row_root = first_factory_row_root(&rows);
+        let content_container = first_message_content_container(&row_root);
         let second_hydration_children = content_container.observe_children().n_items();
 
         assert_eq!(first_hydration_children, 1);
         assert_eq!(second_hydration_children, 1);
-        assert!(
-            content_container
-                .first_child()
-                .and_then(|w| w.downcast::<gtk::Label>().ok())
-                .is_some()
-        );
     }
 
     #[gtk::test]
     fn tool_burst_children_are_not_mounted_until_hydration() {
-        let children = gtk::Box::new(gtk::Orientation::Vertical, 0);
+        let mut rows: FactoryVecDeque<TranscriptRow> =
+            FactoryVecDeque::builder().launch_default().detach();
+        {
+            let mut guard = rows.guard();
+            guard.push_back(single_tool_burst_init());
+        }
+        pump_main_context();
+
+        let row_root = first_factory_row_root(&rows);
+        let revealer = row_root
+            .last_child()
+            .and_then(|child| child.downcast::<gtk::Revealer>().ok())
+            .expect("tool burst row should mount a revealer");
+        let children = revealer
+            .child()
+            .and_then(|child| child.downcast::<gtk::Box>().ok())
+            .expect("tool burst revealer should contain a children box");
         assert!(children.first_child().is_none());
 
-        let init = ToolCallItemInit {
-            item_index: 1,
-            transcript_item_index: 1,
-            session_id: "session-1".to_string(),
-            tool_call_id: "call-1".to_string(),
-            tool_name: "Read".to_string(),
-            status: ToolCallStatus::Completed,
-            preview: Some("src/main.rs:1-20".to_string()),
-            summary: None,
-            duration_ms: Some(5),
-            highlight_query: None,
-            reasoning_preview: ReasoningPreview::default(),
-            request_id: 1,
-        };
-        hydrate_tool_call_preview(&children, &init);
-        assert!(children.first_child().is_some());
+        rows.send(0, TranscriptRowMsg::ToggleToolBurst);
+        pump_main_context();
+
+        let row_root = first_factory_row_root(&rows);
+        let revealer = row_root
+            .last_child()
+            .and_then(|child| child.downcast::<gtk::Revealer>().ok())
+            .expect("tool burst row should keep a revealer after hydration");
+        let children = revealer
+            .child()
+            .and_then(|child| child.downcast::<gtk::Box>().ok())
+            .expect("tool burst revealer should keep a children box");
+        let first_hydrated_children = children.observe_children().n_items();
+
+        rows.send(
+            0,
+            TranscriptRowMsg::HydrateDeferredContent {
+                reason: DeferredHydrationReason::InitialViewport,
+            },
+        );
+        pump_main_context();
+
+        let second_hydrated_children = children.observe_children().n_items();
+        assert_eq!(first_hydrated_children, 1);
+        assert_eq!(second_hydrated_children, 1);
     }
 
     #[test]

--- a/src/ui/transcript_row.rs
+++ b/src/ui/transcript_row.rs
@@ -309,9 +309,30 @@ pub struct TranscriptRowWidgets {
     // Message widgets
     content_container: gtk::Box,
     expand_button: gtk::Button,
+    placeholder: Option<gtk::Box>,
+    tool_call_preview_container: Option<gtk::Box>,
+    tool_burst_children: Option<gtk::Box>,
+    tool_burst_revealer: Option<gtk::Revealer>,
+    tool_burst_arrow_icon: Option<gtk::Image>,
+    tool_burst_header_button: Option<gtk::Button>,
     // ToolCall widgets (needed for inspect button sensitivity)
     // Subagent widgets
     // (Nothing dynamic for tool/subagent in Phase 3)
+}
+
+impl TranscriptRowWidgets {
+    fn inert() -> Self {
+        Self {
+            content_container: gtk::Box::new(gtk::Orientation::Vertical, 0),
+            expand_button: gtk::Button::new(),
+            placeholder: None,
+            tool_call_preview_container: None,
+            tool_burst_children: None,
+            tool_burst_revealer: None,
+            tool_burst_arrow_icon: None,
+            tool_burst_header_button: None,
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -489,13 +510,38 @@ pub fn format_tool_burst_match_badge_accessible_label(match_count: usize) -> Str
     format!("{match_count} search matches inside this group")
 }
 
-fn should_build_tool_burst_children_on_mount(default_expanded: bool) -> bool {
-    default_expanded
+fn should_build_tool_burst_children_on_mount(_default_expanded: bool) -> bool {
+    false
 }
 
 struct ToolCallWidgetRefs {
     root: gtk::Box,
+    preview_container: gtk::Box,
     match_count: usize,
+}
+
+fn hydrate_tool_call_preview(container: &gtk::Box, init: &ToolCallItemInit) {
+    while let Some(child) = container.first_child() {
+        container.remove(&child);
+    }
+
+    if let Some(preview) = init.displayed_preview() {
+        let preview_label = gtk::Label::new(None);
+        preview_label.add_css_class("caption");
+        preview_label.add_css_class("dim-label");
+        preview_label.add_css_class("preview-label");
+        preview_label.set_halign(gtk::Align::Start);
+        preview_label.set_margin_start(32);
+        preview_label.set_margin_bottom(4);
+        preview_label.set_ellipsize(gtk::pango::EllipsizeMode::End);
+        if let Some(query) = init.highlight_query.as_deref() {
+            let (markup, _) = highlight::highlight_text(preview, query);
+            preview_label.set_markup(&markup);
+        } else {
+            preview_label.set_label(preview);
+        }
+        container.append(&preview_label);
+    }
 }
 
 fn build_tool_call_widget(
@@ -584,26 +630,12 @@ fn build_tool_call_widget(
     row.append(&inspect_btn);
     root.append(&row);
 
-    if let Some(preview) = init.displayed_preview() {
-        let preview_label = gtk::Label::new(None);
-        preview_label.add_css_class("caption");
-        preview_label.add_css_class("dim-label");
-        preview_label.add_css_class("preview-label");
-        preview_label.set_halign(gtk::Align::Start);
-        preview_label.set_margin_start(32);
-        preview_label.set_margin_bottom(4);
-        preview_label.set_ellipsize(gtk::pango::EllipsizeMode::End);
-        if let Some(query) = init.highlight_query.as_deref() {
-            let (markup, _) = highlight::highlight_text(preview, query);
-            preview_label.set_markup(&markup);
-        } else {
-            preview_label.set_label(preview);
-        }
-        root.append(&preview_label);
-    }
+    let preview_container = gtk::Box::new(gtk::Orientation::Vertical, 0);
+    root.append(&preview_container);
 
     ToolCallWidgetRefs {
         root,
+        preview_container,
         match_count: count_tool_call_matches(init),
     }
 }
@@ -781,7 +813,7 @@ impl FactoryComponent for TranscriptRow {
                 reasoning_preview: None,
                 kind: TranscriptRowKind::ToolBurst,
                 request_id: tb.request_id,
-                hydrated: tb.default_expanded,
+                hydrated: false,
                 placeholder_height_request: TOOL_BURST_HEADER_HEIGHT_PX,
                 preview: None,
                 highlight_query: None,
@@ -807,7 +839,7 @@ impl FactoryComponent for TranscriptRow {
                 reasoning_preview: Some(sa.reasoning_preview),
                 kind: TranscriptRowKind::Subagent,
                 request_id: sa.request_id,
-                hydrated: true,
+                hydrated: false,
                 placeholder_height_request: SUBAGENT_PLACEHOLDER_HEIGHT_PX,
                 preview: None,
                 highlight_query: None,
@@ -899,6 +931,11 @@ impl FactoryComponent for TranscriptRow {
                 if self.kind != TranscriptRowKind::Message {
                     return;
                 }
+                self.hydrate_deferred_content(
+                    widgets,
+                    DeferredHydrationReason::UserExpand,
+                    &sender,
+                );
                 let Some(ref preview) = self.preview else {
                     return;
                 };
@@ -941,6 +978,11 @@ impl FactoryComponent for TranscriptRow {
             }
             TranscriptRowMsg::InspectClicked => match self.kind {
                 TranscriptRowKind::ToolCall => {
+                    self.hydrate_deferred_content(
+                        widgets,
+                        DeferredHydrationReason::UserInspect,
+                        &sender,
+                    );
                     if let Some(ref id) = self.tool_call_id {
                         sender
                             .output(TranscriptRowOutput::InspectToolCall(id.clone()))
@@ -949,6 +991,11 @@ impl FactoryComponent for TranscriptRow {
                 }
                 TranscriptRowKind::ToolBurst => {}
                 TranscriptRowKind::Subagent => {
+                    self.hydrate_deferred_content(
+                        widgets,
+                        DeferredHydrationReason::UserInspect,
+                        &sender,
+                    );
                     if let Some(ref id) = self.subagent_id {
                         sender
                             .output(TranscriptRowOutput::InspectSubagent(id.clone()))
@@ -957,8 +1004,36 @@ impl FactoryComponent for TranscriptRow {
                 }
                 TranscriptRowKind::Message => {}
             },
-            TranscriptRowMsg::ToggleToolBurst => {}
-            TranscriptRowMsg::HydrateDeferredContent { .. } => {}
+            TranscriptRowMsg::ToggleToolBurst => {
+                if self.kind != TranscriptRowKind::ToolBurst {
+                    return;
+                }
+                self.hydrate_deferred_content(
+                    widgets,
+                    DeferredHydrationReason::UserToolBurstToggle,
+                    &sender,
+                );
+                let Some(revealer) = widgets.tool_burst_revealer.as_ref() else {
+                    return;
+                };
+                let Some(arrow_icon) = widgets.tool_burst_arrow_icon.as_ref() else {
+                    return;
+                };
+                let Some(header_button) = widgets.tool_burst_header_button.as_ref() else {
+                    return;
+                };
+                let expanded = !revealer.reveals_child();
+                revealer.set_reveal_child(expanded);
+                arrow_icon.set_icon_name(Some(if expanded {
+                    "pan-down-symbolic"
+                } else {
+                    "pan-end-symbolic"
+                }));
+                header_button.update_state(&[gtk::accessible::State::Expanded(Some(expanded))]);
+            }
+            TranscriptRowMsg::HydrateDeferredContent { reason } => {
+                self.hydrate_deferred_content(widgets, reason, &sender);
+            }
         }
     }
 
@@ -1013,6 +1088,101 @@ impl TranscriptRow {
 
     pub fn is_hydrated(&self) -> bool {
         self.hydrated
+    }
+
+    fn emit_deferred_hydrated(
+        &self,
+        sender: &FactorySender<Self>,
+        reason: DeferredHydrationReason,
+        duration_ms: u128,
+    ) {
+        sender
+            .output(TranscriptRowOutput::DeferredContentHydrated {
+                request_id: self.request_id,
+                item_index: self.item_index,
+                kind: self.kind.into(),
+                reason,
+                duration_ms,
+            })
+            .ok();
+    }
+
+    fn tool_call_init_for_render(&self) -> ToolCallItemInit {
+        ToolCallItemInit {
+            item_index: self.item_index,
+            transcript_item_index: self.transcript_item_index.unwrap_or_default(),
+            session_id: self.session_id.clone().unwrap_or_default(),
+            tool_call_id: self.tool_call_id.clone().unwrap_or_default(),
+            tool_name: self
+                .tool_name
+                .clone()
+                .unwrap_or_else(|| "unknown".to_string()),
+            status: self.tool_status.unwrap_or(ToolCallStatus::Unknown),
+            preview: self.tool_preview.clone(),
+            summary: self.tool_summary.clone(),
+            duration_ms: self.tool_duration_ms,
+            highlight_query: self.tool_highlight_query.clone(),
+            reasoning_preview: self.reasoning_preview.unwrap_or_default(),
+            request_id: self.request_id,
+        }
+    }
+
+    fn hydrate_deferred_content(
+        &mut self,
+        widgets: &mut TranscriptRowWidgets,
+        reason: DeferredHydrationReason,
+        sender: &FactorySender<Self>,
+    ) -> bool {
+        let started_at = Instant::now();
+        let mut hydrated_now = false;
+
+        match self.kind {
+            TranscriptRowKind::Message => {
+                if let Some(placeholder) = widgets.placeholder.take() {
+                    widgets.content_container.remove(&placeholder);
+                }
+                if let Some(preview) = self.preview.as_ref() {
+                    render_content(
+                        &widgets.content_container,
+                        &preview.content_preview,
+                        preview.role,
+                        self.highlight_query.as_deref(),
+                    );
+                }
+                hydrated_now = true;
+            }
+            TranscriptRowKind::ToolCall => {
+                if let Some(container) = widgets.tool_call_preview_container.as_ref() {
+                    hydrate_tool_call_preview(container, &self.tool_call_init_for_render());
+                }
+                hydrated_now = true;
+            }
+            TranscriptRowKind::ToolBurst => {
+                if let (Some(children), Some(burst)) = (
+                    widgets.tool_burst_children.as_ref(),
+                    self.tool_burst.as_ref(),
+                ) {
+                    if children.first_child().is_none() {
+                        populate_tool_burst_children(children, burst, sender, self.item_index);
+                    }
+                }
+                hydrated_now = true;
+            }
+            TranscriptRowKind::Subagent => {
+                hydrated_now = true;
+            }
+        }
+
+        if !self.hydrated {
+            self.hydrated = true;
+            self.emit_deferred_hydrated(sender, reason, started_at.elapsed().as_millis());
+            return true;
+        }
+
+        if hydrated_now {
+            self.emit_deferred_hydrated(sender, reason, started_at.elapsed().as_millis());
+        }
+        false
     }
 
     /// Build the widget tree for a message transcript item.
@@ -1114,38 +1284,18 @@ impl TranscriptRow {
         }
         root.append(&expand_button);
 
-        // Render initial content
-        let render_started_at = Instant::now();
-        let match_count = render_content(
-            &content_container,
-            &preview.content_preview,
-            preview.role,
-            self.highlight_query.as_deref(),
-        );
-        let render_duration = render_started_at.elapsed();
-        tracing::debug!(
-            item_index = self.item_index,
-            transcript_item_index = ?self.transcript_item_index,
-            role = ?preview.role,
-            content_len = preview.content_preview.len(),
-            match_count,
-            render_duration_ms = render_duration.as_millis(),
-            "Rendered transcript message content"
-        );
-        if render_duration >= SLOW_CONTENT_RENDER {
-            tracing::info!(
-                item_index = self.item_index,
-                transcript_item_index = ?self.transcript_item_index,
-                role = ?preview.role,
-                content_len = preview.content_preview.len(),
-                match_count,
-                render_duration_ms = render_duration.as_millis(),
-                "Slow transcript message content render"
-            );
-        }
+        let placeholder = placeholder_widget(self.placeholder_height_request);
+        content_container.append(&placeholder);
+
         TranscriptRowWidgets {
             content_container,
             expand_button,
+            placeholder: Some(placeholder),
+            tool_call_preview_container: None,
+            tool_burst_children: None,
+            tool_burst_revealer: None,
+            tool_burst_arrow_icon: None,
+            tool_burst_header_button: None,
         }
     }
 
@@ -1155,23 +1305,7 @@ impl TranscriptRow {
         root: &gtk::Box,
         sender: FactorySender<Self>,
     ) -> TranscriptRowWidgets {
-        let init = ToolCallItemInit {
-            item_index: self.item_index,
-            transcript_item_index: self.transcript_item_index.unwrap_or_default(),
-            session_id: self.session_id.clone().unwrap_or_default(),
-            tool_call_id: self.tool_call_id.clone().unwrap_or_default(),
-            tool_name: self
-                .tool_name
-                .clone()
-                .unwrap_or_else(|| "unknown".to_string()),
-            status: self.tool_status.unwrap_or(ToolCallStatus::Unknown),
-            preview: self.tool_preview.clone(),
-            summary: self.tool_summary.clone(),
-            duration_ms: self.tool_duration_ms,
-            highlight_query: self.tool_highlight_query.clone(),
-            reasoning_preview: self.reasoning_preview.unwrap_or_default(),
-            request_id: self.request_id,
-        };
+        let init = self.tool_call_init_for_render();
 
         let build_started_at = Instant::now();
         let refs = build_tool_call_widget(
@@ -1209,6 +1343,12 @@ impl TranscriptRow {
         TranscriptRowWidgets {
             content_container: gtk::Box::new(gtk::Orientation::Vertical, 0),
             expand_button: gtk::Button::new(),
+            placeholder: None,
+            tool_call_preview_container: Some(refs.preview_container),
+            tool_burst_children: None,
+            tool_burst_revealer: None,
+            tool_burst_arrow_icon: None,
+            tool_burst_header_button: None,
         }
     }
 
@@ -1218,10 +1358,7 @@ impl TranscriptRow {
         sender: FactorySender<Self>,
     ) -> TranscriptRowWidgets {
         let Some(burst) = self.tool_burst.as_ref() else {
-            return TranscriptRowWidgets {
-                content_container: gtk::Box::new(gtk::Orientation::Vertical, 0),
-                expand_button: gtk::Button::new(),
-            };
+            return TranscriptRowWidgets::inert();
         };
 
         root.add_css_class("tool-call-group");
@@ -1348,26 +1485,9 @@ impl TranscriptRow {
         }
 
         {
-            let revealer = revealer.clone();
-            let arrow_icon = arrow_icon.clone();
-            let children = children.clone();
-            let children_built = children_built.clone();
-            let burst = burst.clone();
             let sender = sender.clone();
-            let item_index = self.item_index;
-            header_button.connect_clicked(move |btn| {
-                let expanded = !revealer.reveals_child();
-                if expanded && !children_built.get() {
-                    populate_tool_burst_children(&children, &burst, &sender, item_index);
-                    children_built.set(true);
-                }
-                revealer.set_reveal_child(expanded);
-                arrow_icon.set_icon_name(Some(if expanded {
-                    "pan-down-symbolic"
-                } else {
-                    "pan-end-symbolic"
-                }));
-                btn.update_state(&[gtk::accessible::State::Expanded(Some(expanded))]);
+            header_button.connect_clicked(move |_| {
+                sender.input(TranscriptRowMsg::ToggleToolBurst);
             });
         }
         header_button.update_state(&[gtk::accessible::State::Expanded(Some(
@@ -1380,6 +1500,12 @@ impl TranscriptRow {
         TranscriptRowWidgets {
             content_container: gtk::Box::new(gtk::Orientation::Vertical, 0),
             expand_button: gtk::Button::new(),
+            placeholder: None,
+            tool_call_preview_container: None,
+            tool_burst_children: Some(children),
+            tool_burst_revealer: Some(revealer),
+            tool_burst_arrow_icon: Some(arrow_icon),
+            tool_burst_header_button: Some(header_button),
         }
     }
 
@@ -1424,10 +1550,7 @@ impl TranscriptRow {
         root.append(&row);
 
         // Return dummy widgets struct
-        TranscriptRowWidgets {
-            content_container: gtk::Box::new(gtk::Orientation::Vertical, 0),
-            expand_button: gtk::Button::new(),
-        }
+        TranscriptRowWidgets::inert()
     }
 
     /// Update expand button label/sensitivity after state changes.
@@ -1920,7 +2043,91 @@ mod tests {
     #[test]
     fn tool_burst_children_are_built_only_when_initially_expanded() {
         assert!(!should_build_tool_burst_children_on_mount(false));
-        assert!(should_build_tool_burst_children_on_mount(true));
+        assert!(!should_build_tool_burst_children_on_mount(true));
+    }
+
+    #[gtk::test]
+    fn message_shell_mounts_placeholder_without_textview() {
+        let content_container = gtk::Box::new(gtk::Orientation::Vertical, 4);
+        let placeholder = placeholder_widget(48);
+        content_container.append(&placeholder);
+
+        let first = content_container.first_child().expect("placeholder child");
+        assert!(first.downcast_ref::<gtk::Box>().is_some());
+        assert!(
+            content_container
+                .observe_children()
+                .iter::<gtk::Widget>()
+                .flatten()
+                .all(|child| child.downcast_ref::<gtk::TextView>().is_none())
+        );
+    }
+
+    #[gtk::test]
+    fn hydrate_message_replaces_placeholder_and_is_idempotent() {
+        let content_container = gtk::Box::new(gtk::Orientation::Vertical, 4);
+        let placeholder = placeholder_widget(48);
+        content_container.append(&placeholder);
+
+        let preview = MessagePreview {
+            session_id: "session-1".to_string(),
+            message_index: 0,
+            role: Role::User,
+            content_preview: "hello world".to_string(),
+            content_len: 11,
+            timestamp: Utc::now(),
+            model: None,
+            reasoning_preview: ReasoningPreview::default(),
+        };
+
+        content_container.remove(&placeholder);
+        render_content(
+            &content_container,
+            &preview.content_preview,
+            preview.role,
+            None,
+        );
+        let first_hydration_children = content_container.observe_children().n_items();
+
+        render_content(
+            &content_container,
+            &preview.content_preview,
+            preview.role,
+            None,
+        );
+        let second_hydration_children = content_container.observe_children().n_items();
+
+        assert_eq!(first_hydration_children, 1);
+        assert_eq!(second_hydration_children, 1);
+        assert!(
+            content_container
+                .first_child()
+                .and_then(|w| w.downcast::<gtk::Label>().ok())
+                .is_some()
+        );
+    }
+
+    #[gtk::test]
+    fn tool_burst_children_are_not_mounted_until_hydration() {
+        let children = gtk::Box::new(gtk::Orientation::Vertical, 0);
+        assert!(children.first_child().is_none());
+
+        let init = ToolCallItemInit {
+            item_index: 1,
+            transcript_item_index: 1,
+            session_id: "session-1".to_string(),
+            tool_call_id: "call-1".to_string(),
+            tool_name: "Read".to_string(),
+            status: ToolCallStatus::Completed,
+            preview: Some("src/main.rs:1-20".to_string()),
+            summary: None,
+            duration_ms: Some(5),
+            highlight_query: None,
+            reasoning_preview: ReasoningPreview::default(),
+            request_id: 1,
+        };
+        hydrate_tool_call_preview(&children, &init);
+        assert!(children.first_child().is_some());
     }
 
     #[test]

--- a/src/ui/transcript_row.rs
+++ b/src/ui/transcript_row.rs
@@ -388,7 +388,7 @@ fn estimate_message_placeholder_lines(preview: &MessagePreview) -> usize {
         .filter(|ch| *ch != '\n')
         .count();
     let wrapped_lines = non_newline_chars.div_ceil(MESSAGE_PLACEHOLDER_WRAP_CHARS);
-    let content_lines = explicit_lines.max(wrapped_lines);
+    let content_lines = explicit_lines + wrapped_lines;
     let role_bias = if preview.role == Role::Assistant {
         MESSAGE_PLACEHOLDER_ASSISTANT_EXTRA_LINES
     } else {
@@ -1085,11 +1085,6 @@ impl FactoryComponent for TranscriptRow {
 impl TranscriptRow {
     pub fn item_index(&self) -> usize {
         self.item_index
-    }
-
-    #[allow(dead_code)]
-    pub fn is_hydrated(&self) -> bool {
-        self.hydrated
     }
 
     fn emit_deferred_hydrated(
@@ -2492,7 +2487,7 @@ mod tests {
     }
 
     #[test]
-    fn placeholder_lines_do_not_double_count_single_long_line() {
+    fn placeholder_lines_sum_explicit_breaks_and_wrapped_remainder() {
         let long_line = "x".repeat(MESSAGE_PLACEHOLDER_WRAP_CHARS * 2);
         let preview = MessagePreview {
             session_id: "session-1".to_string(),
@@ -2505,11 +2500,12 @@ mod tests {
             reasoning_preview: ReasoningPreview::default(),
         };
 
-        assert_eq!(estimate_message_placeholder_lines(&preview), 2);
+        // Spec: explicit_lines (1) + wrapped_lines (2) = 3
+        assert_eq!(estimate_message_placeholder_lines(&preview), 3);
     }
 
     #[test]
-    fn placeholder_lines_keep_explicit_multiline_count_without_wrap_growth() {
+    fn placeholder_lines_add_wrapped_remainder_to_explicit_breaks() {
         let preview = MessagePreview {
             session_id: "session-1".to_string(),
             message_index: 1,
@@ -2521,6 +2517,7 @@ mod tests {
             reasoning_preview: ReasoningPreview::default(),
         };
 
-        assert_eq!(estimate_message_placeholder_lines(&preview), 2);
+        // Spec: explicit_lines (2) + wrapped_lines (1) = 3
+        assert_eq!(estimate_message_placeholder_lines(&preview), 3);
     }
 }

--- a/src/ui/transcript_row.rs
+++ b/src/ui/transcript_row.rs
@@ -366,14 +366,14 @@ fn estimate_message_placeholder_lines(preview: &MessagePreview) -> usize {
         .filter(|ch| *ch != '\n')
         .count();
     let wrapped_lines = non_newline_chars.div_ceil(MESSAGE_PLACEHOLDER_WRAP_CHARS);
+    let content_lines = explicit_lines.max(wrapped_lines);
     let role_bias = if preview.role == Role::Assistant {
         MESSAGE_PLACEHOLDER_ASSISTANT_EXTRA_LINES
     } else {
         0
     };
 
-    (explicit_lines + wrapped_lines + role_bias)
-        .clamp(MESSAGE_PLACEHOLDER_MIN_LINES, MESSAGE_PLACEHOLDER_MAX_LINES)
+    (content_lines + role_bias).clamp(MESSAGE_PLACEHOLDER_MIN_LINES, MESSAGE_PLACEHOLDER_MAX_LINES)
 }
 
 fn estimate_message_placeholder_height(preview: &MessagePreview) -> i32 {
@@ -2162,5 +2162,38 @@ mod tests {
 
         assert_eq!(estimate_message_placeholder_lines(&preview), 24);
         assert_eq!(estimate_message_placeholder_height(&preview), 24 * 22 + 56);
+    }
+
+    #[test]
+    fn placeholder_lines_do_not_double_count_single_long_line() {
+        let long_line = "x".repeat(MESSAGE_PLACEHOLDER_WRAP_CHARS * 2);
+        let preview = MessagePreview {
+            session_id: "session-1".to_string(),
+            message_index: 1,
+            role: Role::User,
+            content_preview: long_line,
+            content_len: 1_000,
+            timestamp: Utc.timestamp_opt(0, 0).single().unwrap(),
+            model: None,
+            reasoning_preview: ReasoningPreview::default(),
+        };
+
+        assert_eq!(estimate_message_placeholder_lines(&preview), 2);
+    }
+
+    #[test]
+    fn placeholder_lines_keep_explicit_multiline_count_without_wrap_growth() {
+        let preview = MessagePreview {
+            session_id: "session-1".to_string(),
+            message_index: 1,
+            role: Role::User,
+            content_preview: "short\nline".to_string(),
+            content_len: 10,
+            timestamp: Utc.timestamp_opt(0, 0).single().unwrap(),
+            model: None,
+            reasoning_preview: ReasoningPreview::default(),
+        };
+
+        assert_eq!(estimate_message_placeholder_lines(&preview), 2);
     }
 }

--- a/src/ui/transcript_row.rs
+++ b/src/ui/transcript_row.rs
@@ -32,7 +32,6 @@ const TOOL_ICONS: ToolCategoryIcons = ToolCategoryIcons {
     other: icon_names::BUILD,
 };
 const SLOW_ROW_WIDGET_BUILD: Duration = Duration::from_millis(10);
-const SLOW_CONTENT_RENDER: Duration = Duration::from_millis(10);
 
 const MESSAGE_PLACEHOLDER_MIN_LINES: usize = 2;
 const MESSAGE_PLACEHOLDER_MAX_LINES: usize = 24;
@@ -154,6 +153,7 @@ impl TranscriptItemInit {
         }
     }
 
+    #[allow(dead_code)]
     pub fn request_id(&self) -> u64 {
         match self {
             Self::Message(init) => init.request_id,
@@ -180,6 +180,7 @@ pub enum DeferredHydrationReason {
 }
 
 impl DeferredHydrationReason {
+    #[allow(dead_code)]
     pub fn is_search_critical(self) -> bool {
         matches!(self, Self::SearchTarget)
     }
@@ -1086,6 +1087,7 @@ impl TranscriptRow {
         self.item_index
     }
 
+    #[allow(dead_code)]
     pub fn is_hydrated(&self) -> bool {
         self.hydrated
     }
@@ -1134,7 +1136,6 @@ impl TranscriptRow {
         sender: &FactorySender<Self>,
     ) -> bool {
         let started_at = Instant::now();
-        let mut hydrated_now = false;
 
         match self.kind {
             TranscriptRowKind::Message => {
@@ -1149,28 +1150,22 @@ impl TranscriptRow {
                         self.highlight_query.as_deref(),
                     );
                 }
-                hydrated_now = true;
             }
             TranscriptRowKind::ToolCall => {
                 if let Some(container) = widgets.tool_call_preview_container.as_ref() {
                     hydrate_tool_call_preview(container, &self.tool_call_init_for_render());
                 }
-                hydrated_now = true;
             }
             TranscriptRowKind::ToolBurst => {
                 if let (Some(children), Some(burst)) = (
                     widgets.tool_burst_children.as_ref(),
                     self.tool_burst.as_ref(),
-                ) {
-                    if children.first_child().is_none() {
-                        populate_tool_burst_children(children, burst, sender, self.item_index);
-                    }
+                ) && children.first_child().is_none()
+                {
+                    populate_tool_burst_children(children, burst, sender, self.item_index);
                 }
-                hydrated_now = true;
             }
-            TranscriptRowKind::Subagent => {
-                hydrated_now = true;
-            }
+            TranscriptRowKind::Subagent => {}
         }
 
         if !self.hydrated {
@@ -1179,9 +1174,7 @@ impl TranscriptRow {
             return true;
         }
 
-        if hydrated_now {
-            self.emit_deferred_hydrated(sender, reason, started_at.elapsed().as_millis());
-        }
+        self.emit_deferred_hydrated(sender, reason, started_at.elapsed().as_millis());
         false
     }
 


### PR DESCRIPTION
## Summary

cf #143 

- defer heavy transcript row content in session detail so rows mount as lightweight shells and hydrate on demand
- add request-epoch tracking, viewport hydration scheduling, search-target gating, and scroll anchoring to keep lazy hydration correct while paging and searching
- add performance gate coverage plus row/session detail tests for hydration, stale-request guards, delayed scroll barriers, and anchor compensation

## Test Plan
- cargo fmt --all -- --check
- cargo clippy --all -- -D warnings
- cargo test --all --no-fail-fast