### PR TITLE
feat: batch post-indexing session list inserts

### DIFF
--- a/docs/reports/2026-05-06-session-list-post-indexing-reload-instrumentation-report.md
+++ b/docs/reports/2026-05-06-session-list-post-indexing-reload-instrumentation-report.md
@@ -1,0 +1,148 @@
+# SessionList Post-Indexing Reload Instrumentation Report
+
+## Context
+
+- Issue: [#145 — Measure the visible freeze at the end of SessionList background indexing](https://github.com/supermaciz/sessions-chronicle/issues/145)
+- Branch under test: `post-indexing-reload`
+- Branch HEAD during measurement: `c20334d`
+- Date: 2026-05-06
+- Goal: identify whether the post-indexing `SessionList` freeze is dominated by synchronous reload work or by work that continues after `drop(guard)`.
+
+## Scope
+
+- Build/run path: locally installed development binary
+- Run command used for each run:
+
+```bash
+RUST_LOG=info,sessions_chronicle=debug ~/.local/bin/sessions-chronicle > /tmp/sessions-chronicle-issue-145-runN.log 2>&1
+```
+
+- Dataset: default local development dataset with all four AI assistant sources enabled
+- Observed list size after post-indexing reload: `row_count=888`
+- Observed indexing completion range across runs:
+  - `indexed=1291-1296`
+  - `skipped=650-655`
+  - `removed=0`
+
+This report uses the new `sessionlist.post_indexing_reload.measured` event only. No session titles, transcript content, search text, tool call payloads, or raw command output are copied here.
+
+## Protocol
+
+For each run:
+
+1. Launch the application with debug logs redirected to a file.
+2. Wait for background indexing to complete.
+3. Capture the single `sessionlist.post_indexing_reload.measured` event emitted for the post-indexing completion cycle.
+4. Close the application after the measured reload completes.
+
+Log files:
+
+- `/tmp/sessions-chronicle-issue-145-run1.log`
+- `/tmp/sessions-chronicle-issue-145-run2.log`
+- `/tmp/sessions-chronicle-issue-145-run3.log`
+- `/tmp/sessions-chronicle-issue-145-run4.log`
+- `/tmp/sessions-chronicle-issue-145-run5.log`
+
+Measurement note:
+
+- Runs 1-3 were launched in parallel and are kept as supporting data only.
+- Runs 4-5 were launched sequentially, one process at a time, and are the more trustworthy confirmation set.
+
+## Run Results
+
+| Run | Mode | indexed | skipped | removed | row_count | fetch_ms | clear_ms | push_ms | next_idle_delay_ms | next_frame_delay_ms | total_reload_ms | User-visible freeze |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| 1 | parallel | 1292 | 654 | 0 | 888 | 9 | 230 | 3 | 467 | 9 | 1251 | yes |
+| 2 | parallel | 1296 | 650 | 0 | 888 | 10 | 255 | 3 | 496 | 10 | 1336 | yes |
+| 3 | parallel | 1292 | 654 | 0 | 888 | 15 | 259 | 3 | 485 | 10 | 1349 | yes |
+| 4 | sequential | 1291 | 655 | 0 | 888 | 11 | 222 | 3 | 463 | 10 | 1216 | yes |
+| 5 | sequential | 1291 | 655 | 0 | 888 | 9 | 308 | 3 | 469 | 9 | 1301 | yes |
+
+## Sequential Confirmation Set
+
+The sequential reruns keep the same overall shape as the initial parallel captures:
+
+- `fetch_ms`: `9-11 ms`
+- `clear_ms`: `222-308 ms`
+- `push_ms`: `3 ms`
+- `next_idle_delay_ms`: `463-469 ms`
+- `next_frame_delay_ms`: `9-10 ms`
+- `total_reload_ms`: `1216-1301 ms`
+
+Even without overlap from concurrent launches, the reload still shows a clearly user-visible pause dominated by `clear_ms` plus the large post-drop idle delay.
+
+## Aggregate Medians And Worst Case
+
+| Field | Median | Worst run |
+| --- | ---: | ---: |
+| `fetch_ms` | 10 ms | 15 ms |
+| `clear_ms` | 255 ms | 308 ms |
+| `push_ms` | 3 ms | 3 ms |
+| `next_idle_delay_ms` | 469 ms | 496 ms |
+| `next_frame_delay_ms` | 10 ms | 10 ms |
+| `total_reload_ms` | 1301 ms | 1349 ms |
+
+## Interpretation
+
+### What is clearly not the bottleneck
+
+- Database fetch is small: `9-15 ms`.
+- Row insertion into the factory is also small: `3 ms` in every run.
+- The first frame callback arrives quickly once it is scheduled: `9-10 ms`.
+
+These numbers argue strongly against database access or `push_back` itself being the dominant source of the freeze.
+
+### What is expensive
+
+- `guard.clear()` is already expensive on its own: `222-308 ms`.
+- The largest delay is still after `drop(guard)`: `next_idle_delay_ms=463-496 ms`.
+- End-to-end measured reload time is consistently high: `1216-1349 ms`.
+
+The pattern remains stable in the sequential reruns and matches the earlier parallel captures: synchronous fetch and push are cheap, but the full clear/rebuild cycle is expensive and GTK/main-loop work remains backed up after the guard is dropped.
+
+### User-facing severity
+
+At this dataset scale, the freeze is user-noticeable.
+
+Reasoning:
+
+- `clear_ms` alone is far above a 60 Hz frame budget (`~16 ms`) and above the `~100 ms` threshold where transitions stop feeling instantaneous.
+- `next_idle_delay_ms` near half a second means the main loop does not regain control promptly after the synchronous reload path.
+- `total_reload_ms` above 1.2 seconds makes the end-of-indexing transition clearly visible even though the user did not explicitly request it.
+
+## Decision
+
+Dominant phase: post-drop idle delay, with a secondary synchronous cost in full factory clear.
+
+Recommended next step: reduce GTK realization/layout pressure with a narrow batched-insertion experiment.
+
+Why this is the narrowest justified follow-up:
+
+- `push_ms` is only `3 ms`, so the problem is not raw per-row `push_back` throughput.
+- `clear_ms` is substantial and the current strategy still rebuilds the entire list in one cycle.
+- `next_idle_delay_ms` is the largest measured phase, which points at work that GTK or the main loop must process after the list has been cleared and rebuilt.
+- Batched insertion is smaller and safer than jumping directly to pagination or windowing, while still targeting the measured pressure point from the report.
+
+## Recommendation
+
+The next implementation issue should test one constrained change first:
+
+1. Keep the current fetch query.
+2. Replace the single full repopulation pass with batched row insertion after clear.
+3. Re-run this exact measurement protocol.
+4. Compare `clear_ms`, `next_idle_delay_ms`, and `total_reload_ms` against this report.
+
+Success criterion for that follow-up:
+
+- materially reduce `next_idle_delay_ms` from the current `469 ms` aggregate median
+- materially reduce `total_reload_ms` from the current `1301 ms` aggregate median
+- preserve current selection restoration behavior
+
+If batched insertion does not materially reduce the post-drop idle delay, the next investigation should move to more structural list-update strategies such as diff-based updates or pagination/windowing.
+
+## Evidence Summary
+
+- The instrumentation successfully separated synchronous fetch, clear, push, selection, idle, and frame phases.
+- The measured cycle was reproduced five times on a realistic local dataset, including two sequential reruns without concurrent launch overlap.
+- The freeze is explainable with measured data rather than guesswork.
+- The narrowest evidence-backed next step is to reduce post-clear GTK pressure, starting with batched insertion.

--- a/docs/superpowers/specs/2026-05-06-session-list-post-indexing-batched-insertion-design.md
+++ b/docs/superpowers/specs/2026-05-06-session-list-post-indexing-batched-insertion-design.md
@@ -18,6 +18,19 @@ This points away from database fetch time and away from raw `push_back` throughp
 
 The report in `docs/reports/2026-05-06-session-list-post-indexing-reload-instrumentation-report.md` recommends a narrow batched-insertion experiment as the next step.
 
+## Hypothesis
+
+This experiment is not trying to reduce raw `push_back` CPU time. The baseline already shows `push_ms=3 ms`, so splitting the direct push loop cannot explain a large win by itself.
+
+The hypothesis is narrower: pushing 888 rows into a `gtk::ListBox`-backed factory in one main-loop turn triggers GTK realization, layout, allocation, and frame-clock work that is processed after the factory guard is dropped. That deferred GTK work is the likely source of the large `next_idle_delay_ms` value. By yielding between bounded insertion bursts, GTK may be able to amortize row realization/layout work across multiple main-loop turns instead of processing the full pressure spike after one monolithic rebuild.
+
+This means the experiment can have two valid outcomes:
+
+- perceived responsiveness improves because the main loop regains control sooner between batches;
+- total wall-clock reload duration stays flat or increases because the work is spread across more idle turns.
+
+For acceptance, responsiveness wins over absolute total duration. `next_idle_delay_ms` is the primary success metric; `total_reload_ms` is a secondary guardrail, not the sole pass/fail criterion.
+
 ## Goal
 
 Reduce the user-visible end-of-indexing freeze by changing only the measured post-indexing `SessionList` reload path from one full repopulation pass to batched row insertion.
@@ -37,6 +50,8 @@ Keep the existing synchronous fetch, but split the post-indexing list rebuild in
 
 Only `SessionListMsg::ReloadAfterIndexing` uses this path. Other reload messages keep the current immediate behavior.
 
+This deliberately leaves `clear_ms` untouched in the first experiment. `clear()` is expensive, but changing deletion strategy at the same time would make the result harder to interpret: a win could come from batched removal, batched insertion, or both. This design isolates batched insertion first. If the result is insufficient, batched clear/removal becomes the next minimal experiment before jumping to diffing or pagination.
+
 The batcher should:
 
 1. fetch all sessions synchronously with the current query;
@@ -47,6 +62,8 @@ The batcher should:
 6. reuse the current measurement event so the same report fields can be compared before and after the experiment.
 
 This is the narrowest change that directly targets the measured pressure point without broadening issue 145 into a general `SessionList` rewrite.
+
+Use a fixed initial batch size of `64` rows. At the measured scale of 888 rows, that yields roughly 14 insertion turns. Since baseline raw `push_ms` is only `3 ms`, the batch size is not chosen to reduce CPU loop time; it is chosen to create enough yield points for GTK/main-loop work without stretching the rebuild across dozens of tiny batches.
 
 ## Alternatives Considered
 
@@ -61,6 +78,12 @@ Trade-off: more consistent behavior, but wider behavioral change than the issue 
 Keep existing rows and compute additions/removals/reorders instead of clearing the list.
 
 Trade-off: may ultimately be better than full clear/rebuild, but requires more state bookkeeping and a more complex correctness surface. It is too large for the next experiment after the current instrumentation report.
+
+### Batch Clear Instead Of Push
+
+Remove existing rows in chunks, then keep the current monolithic push pass.
+
+Trade-off: this isolates the `clear_ms` cost, which is the second-largest measured phase. It is a valid follow-up if batched insertion does not reduce the post-drop idle delay enough. It is not the first experiment because the current user-visible symptom is dominated by post-drop idle delay, and batching insertion tests whether GTK row realization/layout pressure can be amortized without changing removal semantics.
 
 ### Pagination Or Windowing First
 
@@ -92,6 +115,14 @@ Only one post-indexing batch run may be active at a time. Starting a new measure
 
 For ordinary reloads, preserve today’s behavior.
 
+At the start of every ordinary reload path, explicitly cancel any in-flight post-indexing batch:
+
+1. invalidate the batch token;
+2. drop `pending_post_indexing_batch`;
+3. continue with the current immediate reload implementation.
+
+Cancellation must be explicit. A search/filter/pin reload that happens while a post-indexing batch is active must not race with stale callbacks that keep pushing old rows.
+
 For `ReloadAfterIndexing` only:
 
 1. select the current session ID before clearing, as today;
@@ -99,11 +130,17 @@ For `ReloadAfterIndexing` only:
 3. clear the factory immediately;
 4. store all fetched rows into `pending_post_indexing_batch` instead of pushing them all at once;
 5. schedule the first idle callback that inserts one batch;
-6. each batch inserts at most `N` rows, then either:
+6. each batch inserts at most `POST_INDEXING_RELOAD_BATCH_SIZE` rows, then either:
    - schedules the next idle callback if rows remain, or
    - finalizes selection restoration and emits the existing measurement summary when all rows are inserted.
 
 The initial implementation should use a fixed batch size constant. A simple starting point is preferable to adaptive heuristics in this issue.
+
+Use:
+
+```rust
+const POST_INDEXING_RELOAD_BATCH_SIZE: usize = 64;
+```
 
 ### Batch Scheduling
 
@@ -129,15 +166,39 @@ Selection restoration behavior must remain unchanged from the user’s perspecti
 
 Restoring selection before all rows are present would create unnecessary repeated work and could produce transient wrong selections while the list is incomplete.
 
+If the user changes selection during the batched rebuild, the final deferred restoration must not overwrite that interaction. The implementation should track whether the list selection changed after the clear and before finalization. If it did, skip the deferred restore and preserve the user's current selection/focus state.
+
+This can be implemented with a small boolean flag on the pending batch, set by selection-change handling while the batch is active. If that signal is not already wired in a usable place, use the minimum local signal connection needed to detect user-visible selection changes during the active batch.
+
+### Visual Transition
+
+The experiment accepts a visible trade-off: the list may briefly appear empty and then refill by batches instead of freezing and then appearing fully populated.
+
+That is acceptable for this issue because the path is limited to indexing completion, which is not an explicit user-initiated search or filter action. If the batched refill is visually worse than the current freeze, the experiment should be considered a poor UX result even if the idle metric improves.
+
 ### Measurement Strategy
 
 Keep the current `sessionlist.post_indexing_reload.measured` event name and field set so the current report remains directly comparable.
 
-Interpretation changes for the experiment:
+Do not redefine existing field semantics:
 
-- `push_ms` should describe only the synchronous work done before the first batch is handed back to the main loop;
-- the overall win or loss should be judged mainly by `next_idle_delay_ms` and `total_reload_ms`;
-- if useful, one or more `debug` events may be added for per-batch row counts and per-batch push duration, but the final `info` summary must remain the primary artifact.
+- `fetch_ms` remains the synchronous fetch duration before batching starts;
+- `clear_ms` remains the synchronous factory clear duration;
+- `push_ms` remains comparable to the old value by representing the sum of all batch push durations;
+- `row_count` remains the total number of rows inserted;
+- `next_idle_delay_ms` is measured from the end of the synchronous clear/setup phase until the next idle callback after control is yielded;
+- `next_frame_delay_ms` is measured from the same post-setup point until the next frame callback;
+- `total_reload_ms` measures from the start of the measured reload through the final post-batch summary point, after the last batch, selection handling, idle timing, and frame timing needed for the final summary.
+
+Add new fields to make the batched path interpretable without changing existing field meaning:
+
+- `batch_count`;
+- `batch_size`;
+- `max_batch_push_ms`;
+- `total_batch_push_ms` as an explicit alias of the comparable `push_ms`;
+- `user_selection_changed_during_batch`.
+
+One or more `debug` events may be added for per-batch row counts and per-batch push duration, but the final `info` summary must remain the primary artifact.
 
 The acceptance comparison is against the current measured baseline in the report, not against a new metric family.
 
@@ -147,7 +208,7 @@ The batcher is best-effort and must not change user-visible semantics beyond res
 
 - if a new measured post-indexing reload starts while a previous batch run is still inserting rows, invalidate the previous run first;
 - stale callbacks must return without mutating the list or logging a final summary;
-- ordinary unmeasured reload paths may continue to replace the list immediately, which implicitly cancels any stale post-indexing batch run.
+- ordinary unmeasured reload paths must explicitly invalidate and drop any active post-indexing batch before replacing the list immediately.
 
 No retries, no debounce logic, and no queue shared with unrelated UI work should be introduced here.
 
@@ -155,9 +216,13 @@ No retries, no debounce logic, and no queue shared with unrelated UI work should
 
 Automated coverage should stay narrow and behavior-focused:
 
-- unit test for batch invalidation/cancellation helper if a helper type is extracted;
+- deterministic unit test for the batch state transition helper used by `PendingPostIndexingBatch`;
 - GTK test proving `ReloadAfterIndexing` still ends with the expected rows and preserved selection behavior;
-- GTK test proving a second measured reload invalidates the first batch run if this can be expressed reliably in component tests.
+- GTK test proving a second measured reload invalidates the first batch run;
+- GTK test proving an ordinary reload cancels an active post-indexing batch before replacing the list;
+- GTK test proving a user selection made during an active batch is not overwritten by final deferred restoration.
+
+If GTK timing makes one of these tests impractical, replace it with a deterministic unit test around the extracted batch state transition helper. The replacement test must prove the same correction property: stale callbacks cannot mutate the list, ordinary reloads cancel the active batch, and user selection changes suppress deferred restoration.
 
 Verification commands:
 
@@ -179,7 +244,8 @@ The experiment is successful when all of the following are true:
 - ordinary reload behavior is unchanged;
 - selection restoration semantics are preserved;
 - the instrumentation remains directly comparable with the current report;
-- sequential reruns show a material reduction in `next_idle_delay_ms` or `total_reload_ms` versus the current baseline;
+- sequential reruns reduce median `next_idle_delay_ms` by at least 40% versus the `469 ms` aggregate baseline, or below `250 ms`;
+- median `total_reload_ms` does not exceed the `1301 ms` aggregate baseline by more than 25%, unless manual observation shows a clear responsiveness improvement and the report documents that trade-off explicitly;
 - if no material improvement appears, the result is still useful and should guide the next narrower follow-up.
 
 ## Decision

--- a/docs/superpowers/specs/2026-05-06-session-list-post-indexing-batched-insertion-design.md
+++ b/docs/superpowers/specs/2026-05-06-session-list-post-indexing-batched-insertion-design.md
@@ -1,0 +1,190 @@
+# SessionList Post-Indexing Batched Insertion - Design
+
+**Date:** 2026-05-06  
+**Status:** Proposed  
+**Issue:** [#145](https://github.com/supermaciz/sessions-chronicle/issues/145)
+
+## Context
+
+The post-indexing reload instrumentation for issue 145 now shows a consistent bottleneck profile on a realistic local dataset:
+
+- `fetch_ms` stays low (`9-15 ms`);
+- `push_ms` stays low (`3 ms`);
+- `clear_ms` is already expensive (`222-308 ms`);
+- `next_idle_delay_ms` remains very large (`463-496 ms`);
+- `total_reload_ms` remains high (`1216-1349 ms`).
+
+This points away from database fetch time and away from raw `push_back` throughput. The current full clear-and-rebuild strategy appears to create enough GTK/main-loop pressure that the user sees a visible freeze after indexing completes.
+
+The report in `docs/reports/2026-05-06-session-list-post-indexing-reload-instrumentation-report.md` recommends a narrow batched-insertion experiment as the next step.
+
+## Goal
+
+Reduce the user-visible end-of-indexing freeze by changing only the measured post-indexing `SessionList` reload path from one full repopulation pass to batched row insertion.
+
+## Non-Goals
+
+- No batching for search, manual filter changes, pin toggles, or ordinary `Reload` paths.
+- No pagination, windowing, or virtualization in this change.
+- No diff-based update engine.
+- No query/index/database changes.
+- No changes to `SessionDetail`.
+- No persistent scheduling framework shared across unrelated components.
+
+## Recommended Approach
+
+Keep the existing synchronous fetch, but split the post-indexing list rebuild into small main-loop batches after the list has been cleared.
+
+Only `SessionListMsg::ReloadAfterIndexing` uses this path. Other reload messages keep the current immediate behavior.
+
+The batcher should:
+
+1. fetch all sessions synchronously with the current query;
+2. clear the current factory immediately;
+3. queue the fetched `SessionRowInit` items in component state;
+4. append a bounded number of rows per idle callback;
+5. restore selection only after the final batch completes;
+6. reuse the current measurement event so the same report fields can be compared before and after the experiment.
+
+This is the narrowest change that directly targets the measured pressure point without broadening issue 145 into a general `SessionList` rewrite.
+
+## Alternatives Considered
+
+### Batch Every Reload Reason
+
+Apply the same batcher to search, sidebar filters, pinning, and explicit reloads.
+
+Trade-off: more consistent behavior, but wider behavioral change than the issue justifies. It would make regressions harder to attribute and would slow down interactive filter/search paths that were not identified as problematic.
+
+### Diff-Based Incremental Update
+
+Keep existing rows and compute additions/removals/reorders instead of clearing the list.
+
+Trade-off: may ultimately be better than full clear/rebuild, but requires more state bookkeeping and a more complex correctness surface. It is too large for the next experiment after the current instrumentation report.
+
+### Pagination Or Windowing First
+
+Reduce rendered row count structurally instead of changing insertion cadence.
+
+Trade-off: valid long-term fallback if batching is insufficient, but larger in scope and more invasive to list semantics. The measured next step should stay smaller.
+
+## Design
+
+### Dedicated Pending Batch State
+
+Keep the current `reload_sessions()` entry point, but add a small post-indexing-only pending batch state to `SessionList`, for example:
+
+```rust
+pending_post_indexing_batch: Option<PendingPostIndexingBatch>
+```
+
+`PendingPostIndexingBatch` should hold only what the component needs to finish one in-flight rebuild:
+
+- queued `SessionRowInit` items still to be inserted;
+- total row count;
+- previously selected session ID;
+- selection restoration flags accumulated until completion;
+- the invalidation token for stale idle callbacks.
+
+Only one post-indexing batch run may be active at a time. Starting a new measured reload invalidates the previous batch state and drops stale callbacks silently.
+
+### Reload Flow
+
+For ordinary reloads, preserve today’s behavior.
+
+For `ReloadAfterIndexing` only:
+
+1. select the current session ID before clearing, as today;
+2. fetch the sessions synchronously, as today;
+3. clear the factory immediately;
+4. store all fetched rows into `pending_post_indexing_batch` instead of pushing them all at once;
+5. schedule the first idle callback that inserts one batch;
+6. each batch inserts at most `N` rows, then either:
+   - schedules the next idle callback if rows remain, or
+   - finalizes selection restoration and emits the existing measurement summary when all rows are inserted.
+
+The initial implementation should use a fixed batch size constant. A simple starting point is preferable to adaptive heuristics in this issue.
+
+### Batch Scheduling
+
+Use main-loop idle callbacks so GTK can regain control between insertion bursts.
+
+The callback contract should be:
+
+- exit immediately if its invalidation token is stale;
+- take the next bounded slice of pending rows;
+- push those rows into the existing `FactoryVecDeque`;
+- if rows remain, schedule one more idle callback and stop;
+- if rows are exhausted, run the same selection restoration semantics as today.
+
+This keeps the change local to `SessionList` and avoids introducing worker threads or background channels.
+
+### Selection Restoration
+
+Selection restoration behavior must remain unchanged from the user’s perspective:
+
+- if the previously selected session still exists after the reload, select it;
+- otherwise fall back to `ensure_selection()`;
+- only perform this once, after the final batch is inserted.
+
+Restoring selection before all rows are present would create unnecessary repeated work and could produce transient wrong selections while the list is incomplete.
+
+### Measurement Strategy
+
+Keep the current `sessionlist.post_indexing_reload.measured` event name and field set so the current report remains directly comparable.
+
+Interpretation changes for the experiment:
+
+- `push_ms` should describe only the synchronous work done before the first batch is handed back to the main loop;
+- the overall win or loss should be judged mainly by `next_idle_delay_ms` and `total_reload_ms`;
+- if useful, one or more `debug` events may be added for per-batch row counts and per-batch push duration, but the final `info` summary must remain the primary artifact.
+
+The acceptance comparison is against the current measured baseline in the report, not against a new metric family.
+
+### Error Handling And Cancellation
+
+The batcher is best-effort and must not change user-visible semantics beyond responsiveness:
+
+- if a new measured post-indexing reload starts while a previous batch run is still inserting rows, invalidate the previous run first;
+- stale callbacks must return without mutating the list or logging a final summary;
+- ordinary unmeasured reload paths may continue to replace the list immediately, which implicitly cancels any stale post-indexing batch run.
+
+No retries, no debounce logic, and no queue shared with unrelated UI work should be introduced here.
+
+## Testing Strategy
+
+Automated coverage should stay narrow and behavior-focused:
+
+- unit test for batch invalidation/cancellation helper if a helper type is extracted;
+- GTK test proving `ReloadAfterIndexing` still ends with the expected rows and preserved selection behavior;
+- GTK test proving a second measured reload invalidates the first batch run if this can be expressed reliably in component tests.
+
+Verification commands:
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --all -- -D warnings`
+- `cargo test --all --no-fail-fast`
+
+Manual verification remains required:
+
+1. re-run the issue-145 logging protocol;
+2. compare the new `next_idle_delay_ms`, `clear_ms`, and `total_reload_ms` against the current report;
+3. confirm the end-of-indexing transition is visibly improved or unchanged.
+
+## Acceptance Criteria
+
+The experiment is successful when all of the following are true:
+
+- batching is limited to `ReloadAfterIndexing`;
+- ordinary reload behavior is unchanged;
+- selection restoration semantics are preserved;
+- the instrumentation remains directly comparable with the current report;
+- sequential reruns show a material reduction in `next_idle_delay_ms` or `total_reload_ms` versus the current baseline;
+- if no material improvement appears, the result is still useful and should guide the next narrower follow-up.
+
+## Decision
+
+- Proceed with a fixed-size, post-indexing-only batched insertion experiment.
+- Keep fetch synchronous and keep all non-post-indexing reload paths unchanged.
+- Use the existing instrumentation as the comparison framework.
+- Treat this as a measured experiment, not as the final architecture for large `SessionList` updates.

--- a/src/app/handlers/indexing.rs
+++ b/src/app/handlers/indexing.rs
@@ -4,7 +4,7 @@ use crate::indexing_worker::IndexingWorkerInput;
 use crate::models::{IndexingError, PerSourceResult};
 use crate::ui::analytics_view::AnalyticsViewMsg;
 use crate::ui::modals::indexing_status::IndexingStatusMsg;
-use crate::ui::session_list::SessionListMsg;
+use crate::ui::session_list::{IndexingReloadContext, SessionListMsg};
 use crate::ui::sidebar::SidebarMsg;
 
 use super::super::App;
@@ -99,11 +99,18 @@ impl App {
             .emit(SessionListMsg::SetSourceResults(per_source.clone()));
 
         if should_reload_sessions_after_indexing(indexed, removed, self.pending_reindex_feedback) {
-            if self.refresh_sidebar_projects() {
-                self.emit_session_list_filters();
-            } else {
-                self.session_list.emit(SessionListMsg::Reload);
-            }
+            self.refresh_sidebar_projects();
+            self.session_list.emit(SessionListMsg::ReloadAfterIndexing {
+                assistants: self.filter_state.tools.clone(),
+                project_filter: self.filter_state.project_filter.clone(),
+                context: IndexingReloadContext {
+                    indexed,
+                    skipped,
+                    removed,
+                    pending_reindex_feedback: self.pending_reindex_feedback,
+                    errors_present: !self.last_errors_detail.is_empty(),
+                },
+            });
         }
 
         let analytics_outcome = analytics_indexing_completion_outcome(self.active_workspace);

--- a/src/ui/session_list.rs
+++ b/src/ui/session_list.rs
@@ -572,7 +572,7 @@ impl SimpleComponent for SessionList {
                 self.active_tools = tools.clone();
                 self.project_filter = project_filter;
                 self.all_tools_selected = tools.len() == AiAssistant::ALL.len();
-                self.reload_sessions(&sender);
+                self.reload_sessions();
             }
             SessionListMsg::SetSearchQuery(query) => {
                 if !Self::search_query_changed(&self.search_query, &query) {
@@ -580,10 +580,10 @@ impl SimpleComponent for SessionList {
                 }
 
                 self.search_query = query;
-                self.reload_sessions(&sender);
+                self.reload_sessions();
             }
             SessionListMsg::Reload => {
-                self.reload_sessions(&sender);
+                self.reload_sessions();
             }
             SessionListMsg::ReloadAfterIndexing {
                 assistants,
@@ -1136,75 +1136,33 @@ impl SessionList {
         self.schedule_post_indexing_batch(sender, token);
     }
 
-    fn reload_sessions(&mut self, sender: &ComponentSender<Self>) {
+    fn reload_sessions(&mut self) {
         self.cancel_post_indexing_batch();
 
         let previously_selected_id = self.selected_session_id();
 
-        let fetch_started_at = Instant::now();
         let fetched = Self::fetch_sessions(
             &self.db_path,
             &self.active_tools,
             &self.project_filter,
             &self.search_query,
         );
-        let fetch_duration = fetch_started_at.elapsed();
-        let row_count = fetched.len();
 
         let mut guard = self.sessions.guard();
 
-        let clear_started_at = Instant::now();
         guard.clear();
-        let clear_duration = clear_started_at.elapsed();
 
-        let push_started_at = Instant::now();
         for session in fetched {
             guard.push_back(SessionRowInit { session });
         }
-        let push_duration = push_started_at.elapsed();
         drop(guard);
 
-        let maybe_token = self
-            .active_post_indexing_measurement
-            .as_ref()
-            .map(|active| active.token.clone());
-
-        if let Some(active) = self.active_post_indexing_measurement.as_mut() {
-            active.record_sync_phases(
-                previously_selected_id.is_some(),
-                fetch_duration,
-                clear_duration,
-                push_duration,
-                row_count,
-            );
-        }
-
-        if let Some(token) = maybe_token {
-            self.schedule_post_indexing_callbacks(sender, token, Instant::now());
-        }
-
-        let mut selection_restore_attempted = false;
-        let mut selection_restore_succeeded = false;
-        let mut ensure_selection_fallback_ran = false;
-
         if let Some(session_id) = previously_selected_id {
-            selection_restore_attempted = true;
-            selection_restore_succeeded = self.select_session_by_id(&session_id);
-            if !selection_restore_succeeded {
-                ensure_selection_fallback_ran = true;
+            if !self.select_session_by_id(&session_id) {
                 self.ensure_selection();
             }
         } else {
-            ensure_selection_fallback_ran = true;
             self.ensure_selection();
-        }
-
-        if let Some(active) = self.active_post_indexing_measurement.as_mut() {
-            active.record_selection(
-                selection_restore_attempted,
-                selection_restore_succeeded,
-                ensure_selection_fallback_ran,
-            );
         }
     }
 }

--- a/src/ui/session_list.rs
+++ b/src/ui/session_list.rs
@@ -32,6 +32,7 @@ pub struct SessionList {
     source_results_available: bool,
     active_post_indexing_measurement: Option<ActivePostIndexingMeasurement>,
     pending_post_indexing_batch: Option<PendingPostIndexingBatch>,
+    selection_signal_handler: Option<glib::SignalHandlerId>,
 }
 
 #[derive(Debug)]
@@ -240,6 +241,7 @@ struct PendingPostIndexingBatch {
     remaining_sessions: VecDeque<Session>,
     previously_selected_id: Option<String>,
     user_selection_changed: bool,
+    had_focus_before_reload: bool,
 }
 
 impl PendingPostIndexingBatch {
@@ -253,7 +255,17 @@ impl PendingPostIndexingBatch {
             remaining_sessions: sessions.into(),
             previously_selected_id,
             user_selection_changed: false,
+            had_focus_before_reload: false,
         }
+    }
+
+    fn with_focus_state(mut self, had_focus_before_reload: bool) -> Self {
+        self.had_focus_before_reload = had_focus_before_reload;
+        self
+    }
+
+    fn had_focus_before_reload(&self) -> bool {
+        self.had_focus_before_reload
     }
 
     fn token_matches(&self, token: &MeasurementToken) -> bool {
@@ -300,6 +312,17 @@ struct EmptyStateViewModel {
 
 fn parse_session_id_query(query: &str) -> Option<&str> {
     query.trim().strip_prefix("id:").map(str::trim)
+}
+
+fn focus_is_within(widget: &impl IsA<gtk::Widget>) -> bool {
+    let widget_ref = widget.upcast_ref::<gtk::Widget>();
+    let Some(root) = widget_ref.root() else {
+        return false;
+    };
+    let Some(focused) = root.focus() else {
+        return false;
+    };
+    focused.eq(widget_ref) || focused.is_ancestor(widget_ref)
 }
 
 fn compute_empty_state(
@@ -483,6 +506,7 @@ impl SimpleComponent for SessionList {
             source_results_available: false,
             active_post_indexing_measurement: None,
             pending_post_indexing_batch: None,
+            selection_signal_handler: None,
         };
 
         // Populate initial data
@@ -502,9 +526,10 @@ impl SimpleComponent for SessionList {
         });
 
         let selection_sender = sender.input_sender().clone();
-        session_list_box.connect_selected_rows_changed(move |_| {
+        let selection_signal_handler = session_list_box.connect_selected_rows_changed(move |_| {
             let _ = selection_sender.send(SessionListMsg::PostIndexingSelectionChanged);
         });
+        model.selection_signal_handler = Some(selection_signal_handler);
 
         if model.sessions.is_empty() {
             widgets
@@ -810,6 +835,12 @@ impl SessionList {
                 ensure_selection_fallback_ran = true;
                 self.ensure_selection();
             }
+
+            if batch.had_focus_before_reload()
+                && let Some(row) = self.sessions.widget().selected_row()
+            {
+                row.grab_focus();
+            }
         }
 
         if let Some(active) = self.active_post_indexing_measurement.as_mut() {
@@ -1003,11 +1034,20 @@ impl SessionList {
         let fetch_duration = fetch_started_at.elapsed();
         let row_count = fetched.len();
 
+        let list_box = self.sessions.widget().clone();
+        let had_focus_before_reload = focus_is_within(&list_box);
+        let blocked_handler = self.selection_signal_handler.as_ref();
+        if let Some(handler) = blocked_handler {
+            list_box.block_signal(handler);
+        }
         let mut guard = self.sessions.guard();
         let clear_started_at = Instant::now();
         guard.clear();
         let clear_duration = clear_started_at.elapsed();
         drop(guard);
+        if let Some(handler) = blocked_handler {
+            list_box.unblock_signal(handler);
+        }
 
         let Some(token) = self
             .active_post_indexing_measurement
@@ -1027,11 +1067,10 @@ impl SessionList {
             );
         }
 
-        self.pending_post_indexing_batch = Some(PendingPostIndexingBatch::new(
-            token.clone(),
-            fetched,
-            previously_selected_id,
-        ));
+        self.pending_post_indexing_batch = Some(
+            PendingPostIndexingBatch::new(token.clone(), fetched, previously_selected_id)
+                .with_focus_state(had_focus_before_reload),
+        );
 
         let after_setup_at = Instant::now();
         self.schedule_post_indexing_callbacks(sender, token.clone(), after_setup_at);
@@ -2127,6 +2166,151 @@ mod tests {
         };
 
         assert_eq!(selected_session_id, "alpha-claude-new");
+    }
+
+    #[gtk::test]
+    fn previously_selected_session_survives_post_indexing_reload_with_no_user_interaction() {
+        let temp_db = TempDatabase::new();
+        temp_db.seed_project_sidebar_fixture();
+
+        let controller = SessionList::builder().launch(temp_db.path.clone());
+
+        pump_main_context(|| {
+            let parts = controller.state().get();
+            parts.model.sessions.len() == 5
+        });
+
+        let root = controller.widget().clone().upcast::<gtk::Widget>();
+        let list_box = find_list_box(&root).expect("list box");
+
+        let target_index = {
+            let parts = controller.state().get();
+            (0..parts.model.sessions.len())
+                .find(|index| {
+                    parts
+                        .model
+                        .sessions
+                        .get(*index)
+                        .map(|row| row.session_id() == "alpha-claude-old")
+                        .unwrap_or(false)
+                })
+                .expect("alpha-claude-old in initial dataset")
+        };
+
+        let target_row = list_box
+            .row_at_index(target_index as i32)
+            .expect("alpha-claude-old row");
+        list_box.select_row(Some(&target_row));
+        pump_main_context(|| {
+            list_box.selected_row().map(|row| row.index()) == Some(target_index as i32)
+        });
+
+        controller.emit(SessionListMsg::ReloadAfterIndexing {
+            assistants: vec![AiAssistant::ClaudeCode],
+            project_filter: ProjectFilter::Project(1),
+            context: IndexingReloadContext {
+                indexed: 1,
+                skipped: 0,
+                removed: 0,
+                pending_reindex_feedback: false,
+                errors_present: false,
+            },
+        });
+
+        pump_main_context(|| {
+            let parts = controller.state().get();
+            parts.model.pending_post_indexing_batch.is_none() && parts.model.sessions.len() == 2
+        });
+
+        drain_main_context();
+
+        let final_selected_id = {
+            let parts = controller.state().get();
+            let selected_index = list_box
+                .selected_row()
+                .map(|row| row.index() as usize)
+                .expect("a row should remain selected after the post-indexing reload");
+            parts
+                .model
+                .sessions
+                .get(selected_index)
+                .map(|row| row.session_id().to_string())
+                .expect("selected session present")
+        };
+
+        assert_eq!(final_selected_id, "alpha-claude-old");
+    }
+
+    #[gtk::test]
+    fn post_indexing_reload_restores_focus_when_listbox_was_focused() {
+        let temp_db = TempDatabase::new();
+        temp_db.seed_project_sidebar_fixture();
+
+        let controller = SessionList::builder().launch(temp_db.path.clone());
+
+        let window = gtk::Window::new();
+        window.set_child(Some(controller.widget()));
+        window.present();
+
+        pump_main_context(|| {
+            let parts = controller.state().get();
+            parts.model.sessions.len() == 5
+        });
+
+        let root = controller.widget().clone().upcast::<gtk::Widget>();
+        let list_box = find_list_box(&root).expect("list box");
+
+        let target_index = {
+            let parts = controller.state().get();
+            (0..parts.model.sessions.len())
+                .find(|index| {
+                    parts
+                        .model
+                        .sessions
+                        .get(*index)
+                        .map(|row| row.session_id() == "alpha-claude-old")
+                        .unwrap_or(false)
+                })
+                .expect("alpha-claude-old in initial dataset")
+        };
+
+        let target_row = list_box
+            .row_at_index(target_index as i32)
+            .expect("alpha-claude-old row");
+        list_box.select_row(Some(&target_row));
+        target_row.grab_focus();
+        pump_main_context(|| target_row.has_focus());
+        assert!(
+            target_row.has_focus(),
+            "row should have focus before reload"
+        );
+
+        controller.emit(SessionListMsg::ReloadAfterIndexing {
+            assistants: vec![AiAssistant::ClaudeCode],
+            project_filter: ProjectFilter::Project(1),
+            context: IndexingReloadContext {
+                indexed: 1,
+                skipped: 0,
+                removed: 0,
+                pending_reindex_feedback: false,
+                errors_present: false,
+            },
+        });
+
+        pump_main_context(|| {
+            let parts = controller.state().get();
+            parts.model.pending_post_indexing_batch.is_none() && parts.model.sessions.len() == 2
+        });
+
+        drain_main_context();
+
+        let restored_row = list_box.selected_row().expect("selected row after reload");
+        assert!(
+            restored_row.has_focus(),
+            "selected row should regain focus after the post-indexing reload"
+        );
+
+        window.set_child(None::<&gtk::Widget>);
     }
 
     #[gtk::test]

--- a/src/ui/session_list.rs
+++ b/src/ui/session_list.rs
@@ -31,6 +31,7 @@ pub struct SessionList {
     source_results: Vec<PerSourceResult>,
     source_results_available: bool,
     active_post_indexing_measurement: Option<ActivePostIndexingMeasurement>,
+    pending_post_indexing_batch: Option<PendingPostIndexingBatch>,
 }
 
 #[derive(Debug)]
@@ -54,6 +55,10 @@ pub enum SessionListMsg {
         token: MeasurementToken,
         delay_ms: u128,
     },
+    PostIndexingReloadBatch {
+        token: MeasurementToken,
+    },
+    PostIndexingSelectionChanged,
     SetIndexing(bool),
     SetSourceResults(Vec<PerSourceResult>),
     SessionActivated(i32),
@@ -159,6 +164,7 @@ struct ActivePostIndexingMeasurement {
     selection_restore_attempted: bool,
     selection_restore_succeeded: bool,
     ensure_selection_fallback_ran: bool,
+    user_selection_changed_during_batch: bool,
     next_idle_delay: CallbackTiming,
     next_frame_delay: CallbackTiming,
 }
@@ -186,6 +192,7 @@ impl ActivePostIndexingMeasurement {
             selection_restore_attempted: false,
             selection_restore_succeeded: false,
             ensure_selection_fallback_ran: false,
+            user_selection_changed_during_batch: false,
             next_idle_delay: CallbackTiming::Pending,
             next_frame_delay: CallbackTiming::Pending,
         }
@@ -473,6 +480,7 @@ impl SimpleComponent for SessionList {
             source_results: vec![],
             source_results_available: false,
             active_post_indexing_measurement: None,
+            pending_post_indexing_batch: None,
         };
 
         // Populate initial data
@@ -489,6 +497,11 @@ impl SimpleComponent for SessionList {
         let input_sender = sender.input_sender().clone();
         session_list_box.connect_row_activated(move |_, row| {
             let _ = input_sender.send(SessionListMsg::SessionActivated(row.index()));
+        });
+
+        let selection_sender = sender.input_sender().clone();
+        session_list_box.connect_selected_rows_changed(move |_| {
+            let _ = selection_sender.send(SessionListMsg::PostIndexingSelectionChanged);
         });
 
         if model.sessions.is_empty() {
@@ -553,6 +566,12 @@ impl SimpleComponent for SessionList {
             }
             SessionListMsg::PostIndexingReloadFrameMeasured { token, delay_ms } => {
                 self.record_post_indexing_frame(token, delay_ms);
+            }
+            SessionListMsg::PostIndexingReloadBatch { token } => {
+                self.run_post_indexing_batch(&sender, token);
+            }
+            SessionListMsg::PostIndexingSelectionChanged => {
+                self.mark_post_indexing_selection_changed();
             }
             SessionListMsg::SetIndexing(indexing) => {
                 self.indexing = indexing;
@@ -743,9 +762,7 @@ impl SessionList {
     }
 
     fn start_post_indexing_measurement(&mut self, context: IndexingReloadContext) {
-        if let Some(active) = &self.active_post_indexing_measurement {
-            active.token.invalidate();
-        }
+        self.cancel_post_indexing_batch();
 
         self.active_post_indexing_measurement = Some(ActivePostIndexingMeasurement::new(
             context,
@@ -753,6 +770,32 @@ impl SessionList {
             &self.project_filter,
             &self.search_query,
         ));
+    }
+
+    fn cancel_post_indexing_batch(&mut self) {
+        if let Some(batch) = self.pending_post_indexing_batch.take() {
+            batch.invalidate();
+        }
+
+        if let Some(active) = self.active_post_indexing_measurement.take() {
+            active.token.invalidate();
+        }
+    }
+
+    fn mark_post_indexing_selection_changed(&mut self) {
+        if let Some(batch) = self.pending_post_indexing_batch.as_mut() {
+            batch.mark_user_selection_changed();
+            if let Some(active) = self.active_post_indexing_measurement.as_mut() {
+                active.user_selection_changed_during_batch = true;
+            }
+        }
+    }
+
+    fn run_post_indexing_batch(
+        &mut self,
+        _sender: &ComponentSender<Self>,
+        _token: MeasurementToken,
+    ) {
     }
 
     fn current_post_indexing_measurement_mut(
@@ -1475,6 +1518,99 @@ mod tests {
         batch.invalidate();
         assert!(!callback_token.is_valid());
         assert!(!batch.token_matches(&callback_token));
+    }
+
+    #[gtk::test]
+    fn cancel_post_indexing_batch_invalidates_pending_batch_and_measurement() {
+        let temp_db = tempfile::NamedTempFile::new().expect("temp db");
+        let controller = SessionList::builder().launch(temp_db.path().to_path_buf());
+        let context = IndexingReloadContext {
+            indexed: 1,
+            skipped: 0,
+            removed: 0,
+            pending_reindex_feedback: false,
+            errors_present: false,
+        };
+
+        let callback_token = {
+            let mut parts = controller.state().get_mut();
+            parts.model.start_post_indexing_measurement(context);
+            let token = parts
+                .model
+                .active_post_indexing_measurement
+                .as_ref()
+                .expect("active measurement")
+                .token
+                .clone();
+            parts.model.pending_post_indexing_batch = Some(PendingPostIndexingBatch::new(
+                token.clone(),
+                vec![make_test_session("pending")],
+                None,
+            ));
+            token
+        };
+
+        {
+            let mut parts = controller.state().get_mut();
+            parts.model.cancel_post_indexing_batch();
+            assert!(parts.model.pending_post_indexing_batch.is_none());
+            assert!(parts.model.active_post_indexing_measurement.is_none());
+        }
+
+        assert!(!callback_token.is_valid());
+    }
+
+    #[gtk::test]
+    fn start_post_indexing_measurement_cancels_previous_pending_batch() {
+        let temp_db = tempfile::NamedTempFile::new().expect("temp db");
+        let controller = SessionList::builder().launch(temp_db.path().to_path_buf());
+        let first_context = IndexingReloadContext {
+            indexed: 1,
+            skipped: 0,
+            removed: 0,
+            pending_reindex_feedback: false,
+            errors_present: false,
+        };
+        let second_context = IndexingReloadContext {
+            indexed: 2,
+            skipped: 0,
+            removed: 0,
+            pending_reindex_feedback: false,
+            errors_present: false,
+        };
+
+        let first_token = {
+            let mut parts = controller.state().get_mut();
+            parts.model.start_post_indexing_measurement(first_context);
+            let token = parts
+                .model
+                .active_post_indexing_measurement
+                .as_ref()
+                .expect("first measurement")
+                .token
+                .clone();
+            parts.model.pending_post_indexing_batch = Some(PendingPostIndexingBatch::new(
+                token.clone(),
+                vec![make_test_session("first")],
+                None,
+            ));
+            parts.model.start_post_indexing_measurement(second_context);
+            token
+        };
+
+        let parts = controller.state().get();
+        assert!(parts.model.pending_post_indexing_batch.is_none());
+        assert!(!first_token.is_valid());
+        assert_eq!(
+            parts
+                .model
+                .active_post_indexing_measurement
+                .as_ref()
+                .expect("second measurement")
+                .context
+                .indexed,
+            2
+        );
     }
 
     #[gtk::test]

--- a/src/ui/session_list.rs
+++ b/src/ui/session_list.rs
@@ -231,6 +231,10 @@ impl ActivePostIndexingMeasurement {
         self.push_duration += duration;
         self.max_batch_push_duration = self.max_batch_push_duration.max(duration);
     }
+
+    fn record_deferred_clear(&mut self, duration: Duration) {
+        self.clear_duration = duration;
+    }
 }
 
 const POST_INDEXING_RELOAD_BATCH_SIZE: usize = 64;
@@ -867,8 +871,9 @@ impl SessionList {
         }
 
         let rows = batch.take_next_rows(POST_INDEXING_RELOAD_BATCH_SIZE);
-        let batch_push_started_at = Instant::now();
+        let mut deferred_clear_duration: Option<Duration> = None;
 
+        let batch_push_started_at = Instant::now();
         if batch.needs_clear {
             let list_box = self.sessions.widget().clone();
             let blocked_handler = self.selection_signal_handler.as_ref();
@@ -876,7 +881,9 @@ impl SessionList {
                 list_box.block_signal(handler);
             }
             let mut guard = self.sessions.guard();
+            let clear_started_at = Instant::now();
             guard.clear();
+            deferred_clear_duration = Some(clear_started_at.elapsed());
             for session in rows {
                 guard.push_back(SessionRowInit { session });
             }
@@ -891,10 +898,14 @@ impl SessionList {
                 guard.push_back(SessionRowInit { session });
             }
         }
-
-        let batch_push_duration = batch_push_started_at.elapsed();
+        let batch_push_duration = batch_push_started_at
+            .elapsed()
+            .saturating_sub(deferred_clear_duration.unwrap_or(Duration::ZERO));
 
         if let Some(active) = self.current_post_indexing_measurement_mut(&token) {
+            if let Some(clear_duration) = deferred_clear_duration {
+                active.record_deferred_clear(clear_duration);
+            }
             active.record_batch_push(batch_push_duration);
         }
 

--- a/src/ui/session_list.rs
+++ b/src/ui/session_list.rs
@@ -242,6 +242,7 @@ struct PendingPostIndexingBatch {
     previously_selected_id: Option<String>,
     user_selection_changed: bool,
     had_focus_before_reload: bool,
+    needs_clear: bool,
 }
 
 impl PendingPostIndexingBatch {
@@ -256,6 +257,7 @@ impl PendingPostIndexingBatch {
             previously_selected_id,
             user_selection_changed: false,
             had_focus_before_reload: false,
+            needs_clear: true,
         }
     }
 
@@ -866,12 +868,30 @@ impl SessionList {
 
         let rows = batch.take_next_rows(POST_INDEXING_RELOAD_BATCH_SIZE);
         let batch_push_started_at = Instant::now();
-        {
+
+        if batch.needs_clear {
+            let list_box = self.sessions.widget().clone();
+            let blocked_handler = self.selection_signal_handler.as_ref();
+            if let Some(handler) = blocked_handler {
+                list_box.block_signal(handler);
+            }
+            let mut guard = self.sessions.guard();
+            guard.clear();
+            for session in rows {
+                guard.push_back(SessionRowInit { session });
+            }
+            drop(guard);
+            if let Some(handler) = blocked_handler {
+                list_box.unblock_signal(handler);
+            }
+            batch.needs_clear = false;
+        } else {
             let mut guard = self.sessions.guard();
             for session in rows {
                 guard.push_back(SessionRowInit { session });
             }
         }
+
         let batch_push_duration = batch_push_started_at.elapsed();
 
         if let Some(active) = self.current_post_indexing_measurement_mut(&token) {
@@ -1036,18 +1056,6 @@ impl SessionList {
 
         let list_box = self.sessions.widget().clone();
         let had_focus_before_reload = focus_is_within(&list_box);
-        let blocked_handler = self.selection_signal_handler.as_ref();
-        if let Some(handler) = blocked_handler {
-            list_box.block_signal(handler);
-        }
-        let mut guard = self.sessions.guard();
-        let clear_started_at = Instant::now();
-        guard.clear();
-        let clear_duration = clear_started_at.elapsed();
-        drop(guard);
-        if let Some(handler) = blocked_handler {
-            list_box.unblock_signal(handler);
-        }
 
         let Some(token) = self
             .active_post_indexing_measurement
@@ -1061,7 +1069,7 @@ impl SessionList {
             active.record_sync_phases(
                 previously_selected_id.is_some(),
                 fetch_duration,
-                clear_duration,
+                Duration::ZERO,
                 Duration::ZERO,
                 row_count,
             );
@@ -1962,12 +1970,12 @@ mod tests {
 
         pump_main_context(|| {
             let parts = controller.state().get();
-            parts.model.sessions.len() == 0 && parts.model.pending_post_indexing_batch.is_some()
+            parts.model.pending_post_indexing_batch.is_some() && parts.model.sessions.len() == 75
         });
 
         {
             let parts = controller.state().get();
-            assert_eq!(parts.model.sessions.len(), 0);
+            assert_eq!(parts.model.sessions.len(), 75);
             assert!(parts.model.pending_post_indexing_batch.is_some());
         }
 

--- a/src/ui/session_list.rs
+++ b/src/ui/session_list.rs
@@ -910,6 +910,32 @@ impl SessionList {
                 guard.push_back(SessionRowInit { session });
             }
         }
+
+        // After the first batch's clear+push, the listbox is briefly without
+        // a focused row. GTK then auto-focuses the first row, which is
+        // visible to the user as a flicker before finalize restores the
+        // intended selection. If the previously selected row was in the
+        // first batch (or arrived in any subsequent batch before finalize),
+        // anchor focus on it now so the user never sees row 0.
+        if !self.sessions.widget().selected_row().is_some_and(|row| {
+            self.sessions.get(row.index() as usize).is_some_and(|sr| {
+                self.pending_post_indexing_batch
+                    .as_ref()
+                    .and_then(|b| b.previously_selected_id())
+                    == Some(sr.session_id())
+            })
+        }) && let Some(target_id) = self
+            .pending_post_indexing_batch
+            .as_ref()
+            .and_then(|b| b.previously_selected_id())
+            .map(str::to_string)
+            && self.select_session_by_id(&target_id)
+            && let Some(batch) = self.pending_post_indexing_batch.as_ref()
+            && batch.had_focus_before_reload()
+            && let Some(row) = self.sessions.widget().selected_row()
+        {
+            row.grab_focus();
+        }
         let batch_push_duration = batch_push_started_at
             .elapsed()
             .saturating_sub(deferred_clear_duration.unwrap_or(Duration::ZERO));

--- a/src/ui/session_list.rs
+++ b/src/ui/session_list.rs
@@ -33,6 +33,7 @@ pub struct SessionList {
     active_post_indexing_measurement: Option<ActivePostIndexingMeasurement>,
     pending_post_indexing_batch: Option<PendingPostIndexingBatch>,
     selection_signal_handler: Option<glib::SignalHandlerId>,
+    selection_signal_blocked_for_batch: bool,
 }
 
 #[derive(Debug)]
@@ -513,6 +514,7 @@ impl SimpleComponent for SessionList {
             active_post_indexing_measurement: None,
             pending_post_indexing_batch: None,
             selection_signal_handler: None,
+            selection_signal_blocked_for_batch: false,
         };
 
         // Populate initial data
@@ -813,6 +815,18 @@ impl SessionList {
         if let Some(active) = self.active_post_indexing_measurement.take() {
             active.token.invalidate();
         }
+
+        self.unblock_selection_signal_after_batch();
+    }
+
+    fn unblock_selection_signal_after_batch(&mut self) {
+        if !self.selection_signal_blocked_for_batch {
+            return;
+        }
+        if let Some(handler) = self.selection_signal_handler.as_ref() {
+            self.sessions.widget().unblock_signal(handler);
+        }
+        self.selection_signal_blocked_for_batch = false;
     }
 
     fn mark_post_indexing_selection_changed(&mut self) {
@@ -858,6 +872,7 @@ impl SessionList {
             active.user_selection_changed_during_batch = batch.user_selection_changed();
         }
 
+        self.unblock_selection_signal_after_batch();
         self.maybe_emit_post_indexing_measurement();
     }
 
@@ -876,10 +891,10 @@ impl SessionList {
         let batch_push_started_at = Instant::now();
         if batch.needs_clear {
             let list_box = self.sessions.widget().clone();
-            let blocked_handler = self.selection_signal_handler.as_ref();
-            if let Some(handler) = blocked_handler {
+            if let Some(handler) = self.selection_signal_handler.as_ref() {
                 list_box.block_signal(handler);
             }
+            self.selection_signal_blocked_for_batch = true;
             let mut guard = self.sessions.guard();
             let clear_started_at = Instant::now();
             guard.clear();
@@ -888,9 +903,6 @@ impl SessionList {
                 guard.push_back(SessionRowInit { session });
             }
             drop(guard);
-            if let Some(handler) = blocked_handler {
-                list_box.unblock_signal(handler);
-            }
             batch.needs_clear = false;
         } else {
             let mut guard = self.sessions.guard();

--- a/src/ui/session_list.rs
+++ b/src/ui/session_list.rs
@@ -3,9 +3,11 @@ use gtk::glib;
 use relm4::factory::FactoryVecDeque;
 use relm4::{ComponentParts, ComponentSender, SimpleComponent, adw, gtk};
 use std::{
+    cell::Cell,
     collections::VecDeque,
     fmt,
     path::{Path, PathBuf},
+    rc::Rc,
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
@@ -33,7 +35,7 @@ pub struct SessionList {
     active_post_indexing_measurement: Option<ActivePostIndexingMeasurement>,
     pending_post_indexing_batch: Option<PendingPostIndexingBatch>,
     selection_signal_handler: Option<glib::SignalHandlerId>,
-    selection_signal_blocked_for_batch: bool,
+    programmatic_selection: Rc<Cell<bool>>,
 }
 
 #[derive(Debug)]
@@ -311,6 +313,16 @@ impl PendingPostIndexingBatch {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+struct ProgrammaticSelectionGuard {
+    flag: Rc<Cell<bool>>,
+}
+
+impl Drop for ProgrammaticSelectionGuard {
+    fn drop(&mut self) {
+        self.flag.set(false);
+    }
+}
+
 struct EmptyStateViewModel {
     title: &'static str,
     description: &'static str,
@@ -514,7 +526,7 @@ impl SimpleComponent for SessionList {
             active_post_indexing_measurement: None,
             pending_post_indexing_batch: None,
             selection_signal_handler: None,
-            selection_signal_blocked_for_batch: false,
+            programmatic_selection: Rc::new(Cell::new(false)),
         };
 
         // Populate initial data
@@ -534,7 +546,11 @@ impl SimpleComponent for SessionList {
         });
 
         let selection_sender = sender.input_sender().clone();
+        let programmatic_flag = model.programmatic_selection.clone();
         let selection_signal_handler = session_list_box.connect_selected_rows_changed(move |_| {
+            if programmatic_flag.get() {
+                return;
+            }
             let _ = selection_sender.send(SessionListMsg::PostIndexingSelectionChanged);
         });
         model.selection_signal_handler = Some(selection_signal_handler);
@@ -815,18 +831,11 @@ impl SessionList {
         if let Some(active) = self.active_post_indexing_measurement.take() {
             active.token.invalidate();
         }
-
-        self.unblock_selection_signal_after_batch();
     }
 
-    fn unblock_selection_signal_after_batch(&mut self) {
-        if !self.selection_signal_blocked_for_batch {
-            return;
-        }
-        if let Some(handler) = self.selection_signal_handler.as_ref() {
-            self.sessions.widget().unblock_signal(handler);
-        }
-        self.selection_signal_blocked_for_batch = false;
+    fn enter_programmatic_selection(flag: &Rc<Cell<bool>>) -> ProgrammaticSelectionGuard {
+        flag.set(true);
+        ProgrammaticSelectionGuard { flag: flag.clone() }
     }
 
     fn mark_post_indexing_selection_changed(&mut self) {
@@ -844,6 +853,7 @@ impl SessionList {
         let mut ensure_selection_fallback_ran = false;
 
         if !batch.user_selection_changed() {
+            let _prog = Self::enter_programmatic_selection(&self.programmatic_selection);
             if let Some(session_id) = batch.previously_selected_id() {
                 selection_restore_attempted = true;
                 selection_restore_succeeded = self.select_session_by_id(session_id);
@@ -873,7 +883,6 @@ impl SessionList {
             active.user_selection_changed_during_batch = batch.user_selection_changed();
         }
 
-        self.unblock_selection_signal_after_batch();
         self.maybe_emit_post_indexing_measurement();
     }
 
@@ -891,11 +900,7 @@ impl SessionList {
 
         let batch_push_started_at = Instant::now();
         if batch.needs_clear {
-            let list_box = self.sessions.widget().clone();
-            if let Some(handler) = self.selection_signal_handler.as_ref() {
-                list_box.block_signal(handler);
-            }
-            self.selection_signal_blocked_for_batch = true;
+            let _prog = Self::enter_programmatic_selection(&self.programmatic_selection);
             let mut guard = self.sessions.guard();
             let clear_started_at = Instant::now();
             guard.clear();
@@ -918,25 +923,28 @@ impl SessionList {
         // intended selection. If the previously selected row was in the
         // first batch (or arrived in any subsequent batch before finalize),
         // anchor focus on it now so the user never sees row 0.
-        if !self.sessions.widget().selected_row().is_some_and(|row| {
-            self.sessions.get(row.index() as usize).is_some_and(|sr| {
-                self.pending_post_indexing_batch
-                    .as_ref()
-                    .and_then(|b| b.previously_selected_id())
-                    == Some(sr.session_id())
-            })
-        }) && let Some(target_id) = self
-            .pending_post_indexing_batch
-            .as_ref()
-            .and_then(|b| b.previously_selected_id())
-            .map(str::to_string)
-            && self.select_session_by_id(&target_id)
-            && let Some(batch) = self.pending_post_indexing_batch.as_ref()
-            && batch.had_focus_before_reload()
-            && let Some(row) = self.sessions.widget().selected_row()
         {
-            row.grab_focus();
-            Self::scroll_row_into_view(&row, self.sessions.widget());
+            let _prog = Self::enter_programmatic_selection(&self.programmatic_selection);
+            if !self.sessions.widget().selected_row().is_some_and(|row| {
+                self.sessions.get(row.index() as usize).is_some_and(|sr| {
+                    self.pending_post_indexing_batch
+                        .as_ref()
+                        .and_then(|b| b.previously_selected_id())
+                        == Some(sr.session_id())
+                })
+            }) && let Some(target_id) = self
+                .pending_post_indexing_batch
+                .as_ref()
+                .and_then(|b| b.previously_selected_id())
+                .map(str::to_string)
+                && self.select_session_by_id(&target_id)
+                && let Some(batch) = self.pending_post_indexing_batch.as_ref()
+                && batch.had_focus_before_reload()
+                && let Some(row) = self.sessions.widget().selected_row()
+            {
+                row.grab_focus();
+                Self::scroll_row_into_view(&row, self.sessions.widget());
+            }
         }
         let batch_push_duration = batch_push_started_at
             .elapsed()

--- a/src/ui/session_list.rs
+++ b/src/ui/session_list.rs
@@ -238,7 +238,6 @@ const POST_INDEXING_RELOAD_BATCH_SIZE: usize = 64;
 struct PendingPostIndexingBatch {
     token: MeasurementToken,
     remaining_sessions: VecDeque<Session>,
-    total_row_count: usize,
     previously_selected_id: Option<String>,
     user_selection_changed: bool,
 }
@@ -249,18 +248,12 @@ impl PendingPostIndexingBatch {
         sessions: Vec<Session>,
         previously_selected_id: Option<String>,
     ) -> Self {
-        let total_row_count = sessions.len();
         Self {
             token,
             remaining_sessions: sessions.into(),
-            total_row_count,
             previously_selected_id,
             user_selection_changed: false,
         }
-    }
-
-    fn token(&self) -> MeasurementToken {
-        self.token.clone()
     }
 
     fn token_matches(&self, token: &MeasurementToken) -> bool {
@@ -280,12 +273,9 @@ impl PendingPostIndexingBatch {
         self.remaining_sessions.is_empty()
     }
 
+    #[cfg(test)]
     fn remaining_row_count(&self) -> usize {
         self.remaining_sessions.len()
-    }
-
-    fn total_row_count(&self) -> usize {
-        self.total_row_count
     }
 
     fn previously_selected_id(&self) -> Option<&str> {
@@ -1655,7 +1645,6 @@ mod tests {
         let mut batch =
             PendingPostIndexingBatch::new(token.clone(), sessions, Some("batch-2".to_string()));
 
-        assert_eq!(batch.total_row_count(), 3);
         assert_eq!(batch.remaining_row_count(), 3);
         assert_eq!(batch.previously_selected_id(), Some("batch-2"));
         assert!(!batch.is_exhausted());

--- a/src/ui/session_list.rs
+++ b/src/ui/session_list.rs
@@ -860,6 +860,7 @@ impl SessionList {
                 && let Some(row) = self.sessions.widget().selected_row()
             {
                 row.grab_focus();
+                Self::scroll_row_into_view(&row, self.sessions.widget());
             }
         }
 
@@ -935,6 +936,7 @@ impl SessionList {
             && let Some(row) = self.sessions.widget().selected_row()
         {
             row.grab_focus();
+            Self::scroll_row_into_view(&row, self.sessions.widget());
         }
         let batch_push_duration = batch_push_started_at
             .elapsed()

--- a/src/ui/session_list.rs
+++ b/src/ui/session_list.rs
@@ -1357,6 +1357,15 @@ mod tests {
         }
     }
 
+    fn drain_main_context() {
+        let context = gtk::glib::MainContext::default();
+        for _ in 0..20 {
+            if !context.iteration(false) {
+                break;
+            }
+        }
+    }
+
     #[gtk::test]
     fn pump_main_context_waits_for_timeout_callbacks() {
         let done = Rc::new(RefCell::new(false));
@@ -1955,6 +1964,180 @@ mod tests {
         assert_eq!(ids[0], "alpha-claude-new");
         assert_eq!(ids[1], "alpha-claude-old");
         assert_eq!(ids.len(), 72);
+    }
+
+    #[gtk::test]
+    fn second_reload_after_indexing_invalidates_first_pending_batch() {
+        let temp_db = TempDatabase::new();
+        temp_db.seed_project_sidebar_fixture();
+        temp_db.seed_many_claude_sessions(130);
+
+        let controller = SessionList::builder().launch(temp_db.path.clone());
+
+        pump_main_context(|| {
+            let parts = controller.state().get();
+            parts.model.sessions.len() == 135
+        });
+
+        controller.emit(SessionListMsg::ReloadAfterIndexing {
+            assistants: vec![AiAssistant::ClaudeCode],
+            project_filter: ProjectFilter::Project(1),
+            context: IndexingReloadContext {
+                indexed: 130,
+                skipped: 0,
+                removed: 0,
+                pending_reindex_feedback: false,
+                errors_present: false,
+            },
+        });
+
+        pump_main_context(|| {
+            let parts = controller.state().get();
+            parts.model.sessions.len() == POST_INDEXING_RELOAD_BATCH_SIZE
+        });
+
+        controller.emit(SessionListMsg::ReloadAfterIndexing {
+            assistants: vec![AiAssistant::OpenCode],
+            project_filter: ProjectFilter::Project(1),
+            context: IndexingReloadContext {
+                indexed: 1,
+                skipped: 0,
+                removed: 0,
+                pending_reindex_feedback: false,
+                errors_present: false,
+            },
+        });
+
+        pump_main_context(|| {
+            let parts = controller.state().get();
+            parts.model.pending_post_indexing_batch.is_none() && parts.model.sessions.len() == 1
+        });
+
+        drain_main_context();
+
+        let ids: Vec<String> = {
+            let parts = controller.state().get();
+            (0..parts.model.sessions.len())
+                .filter_map(|index| parts.model.sessions.get(index))
+                .map(|row| row.session_id().to_string())
+                .collect()
+        };
+
+        assert_eq!(ids, vec!["alpha-opencode"]);
+    }
+
+    #[gtk::test]
+    fn ordinary_reload_cancels_active_post_indexing_batch() {
+        let temp_db = TempDatabase::new();
+        temp_db.seed_project_sidebar_fixture();
+        temp_db.seed_many_claude_sessions(130);
+
+        let controller = SessionList::builder().launch(temp_db.path.clone());
+
+        pump_main_context(|| {
+            let parts = controller.state().get();
+            parts.model.sessions.len() == 135
+        });
+
+        controller.emit(SessionListMsg::ReloadAfterIndexing {
+            assistants: vec![AiAssistant::ClaudeCode],
+            project_filter: ProjectFilter::Project(1),
+            context: IndexingReloadContext {
+                indexed: 130,
+                skipped: 0,
+                removed: 0,
+                pending_reindex_feedback: false,
+                errors_present: false,
+            },
+        });
+
+        pump_main_context(|| {
+            let parts = controller.state().get();
+            parts.model.sessions.len() == POST_INDEXING_RELOAD_BATCH_SIZE
+        });
+
+        controller.emit(SessionListMsg::SetSearchQuery(
+            "id:alpha-claude-new".to_string(),
+        ));
+
+        pump_main_context(|| {
+            let parts = controller.state().get();
+            parts.model.pending_post_indexing_batch.is_none() && parts.model.sessions.len() == 1
+        });
+
+        drain_main_context();
+
+        let ids: Vec<String> = {
+            let parts = controller.state().get();
+            (0..parts.model.sessions.len())
+                .filter_map(|index| parts.model.sessions.get(index))
+                .map(|row| row.session_id().to_string())
+                .collect()
+        };
+
+        assert_eq!(ids, vec!["alpha-claude-new"]);
+    }
+
+    #[gtk::test]
+    fn user_selection_during_batch_is_not_overwritten_by_final_restore() {
+        let temp_db = TempDatabase::new();
+        temp_db.seed_project_sidebar_fixture();
+        temp_db.seed_many_claude_sessions(130);
+
+        let controller = SessionList::builder().launch(temp_db.path.clone());
+
+        pump_main_context(|| {
+            let parts = controller.state().get();
+            parts.model.sessions.len() == 135
+        });
+
+        let root = controller.widget().clone().upcast::<gtk::Widget>();
+        let list_box = find_list_box(&root).expect("list box");
+        let old_row = list_box.row_at_index(1).expect("alpha old row");
+        list_box.select_row(Some(&old_row));
+        pump_main_context(|| list_box.selected_row().map(|row| row.index()) == Some(1));
+
+        controller.emit(SessionListMsg::ReloadAfterIndexing {
+            assistants: vec![AiAssistant::ClaudeCode],
+            project_filter: ProjectFilter::Project(1),
+            context: IndexingReloadContext {
+                indexed: 130,
+                skipped: 0,
+                removed: 0,
+                pending_reindex_feedback: false,
+                errors_present: false,
+            },
+        });
+
+        pump_main_context(|| {
+            let parts = controller.state().get();
+            parts.model.sessions.len() == POST_INDEXING_RELOAD_BATCH_SIZE
+        });
+
+        let new_row = list_box.row_at_index(0).expect("alpha new row");
+        list_box.select_row(Some(&new_row));
+        pump_main_context(|| list_box.selected_row().map(|row| row.index()) == Some(0));
+
+        pump_main_context(|| {
+            let parts = controller.state().get();
+            parts.model.pending_post_indexing_batch.is_none() && parts.model.sessions.len() == 132
+        });
+
+        let selected_session_id = {
+            let parts = controller.state().get();
+            let selected_index = list_box
+                .selected_row()
+                .map(|row| row.index() as usize)
+                .expect("selected row");
+            parts
+                .model
+                .sessions
+                .get(selected_index)
+                .map(|row| row.session_id().to_string())
+                .expect("selected session")
+        };
+
+        assert_eq!(selected_session_id, "alpha-claude-new");
     }
 
     #[gtk::test]

--- a/src/ui/session_list.rs
+++ b/src/ui/session_list.rs
@@ -1,7 +1,16 @@
 use adw::prelude::*;
+use gtk::glib;
 use relm4::factory::FactoryVecDeque;
 use relm4::{ComponentParts, ComponentSender, SimpleComponent, adw, gtk};
-use std::path::{Path, PathBuf};
+use std::{
+    fmt,
+    path::{Path, PathBuf},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::{Duration, Instant},
+};
 
 use crate::database::{
     load_session_by_id_for_filter, load_sessions_for_filter, search_sessions_for_filter,
@@ -20,6 +29,7 @@ pub struct SessionList {
     sessions: FactoryVecDeque<SessionRow>,
     source_results: Vec<PerSourceResult>,
     source_results_available: bool,
+    active_post_indexing_measurement: Option<ActivePostIndexingMeasurement>,
 }
 
 #[derive(Debug)]
@@ -30,6 +40,19 @@ pub enum SessionListMsg {
     },
     SetSearchQuery(String),
     Reload,
+    ReloadAfterIndexing {
+        assistants: Vec<AiAssistant>,
+        project_filter: ProjectFilter,
+        context: IndexingReloadContext,
+    },
+    PostIndexingReloadIdleMeasured {
+        token: MeasurementToken,
+        delay_ms: u128,
+    },
+    PostIndexingReloadFrameMeasured {
+        token: MeasurementToken,
+        delay_ms: u128,
+    },
     SetIndexing(bool),
     SetSourceResults(Vec<PerSourceResult>),
     SessionActivated(i32),
@@ -50,6 +73,143 @@ pub enum SessionListOutput {
     TogglePinRequested(String),
     SelectedSessionForPin(String),
     ResumeRequested(String, AiAssistant),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IndexingReloadContext {
+    pub indexed: usize,
+    pub skipped: usize,
+    pub removed: usize,
+    pub pending_reindex_feedback: bool,
+    pub errors_present: bool,
+}
+
+#[derive(Clone)]
+pub struct MeasurementToken {
+    valid: Arc<AtomicBool>,
+}
+
+impl MeasurementToken {
+    fn new() -> Self {
+        Self {
+            valid: Arc::new(AtomicBool::new(true)),
+        }
+    }
+
+    fn invalidate(&self) {
+        self.valid.store(false, Ordering::Relaxed);
+    }
+
+    fn is_valid(&self) -> bool {
+        self.valid.load(Ordering::Relaxed)
+    }
+
+    fn same_identity(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.valid, &other.valid)
+    }
+}
+
+impl fmt::Debug for MeasurementToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MeasurementToken")
+            .field("valid", &self.valid.load(Ordering::Relaxed))
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CallbackTiming {
+    Pending,
+    Available(u128),
+    Unavailable,
+}
+
+impl CallbackTiming {
+    fn is_pending(self) -> bool {
+        matches!(self, CallbackTiming::Pending)
+    }
+
+    fn as_option(self) -> Option<u128> {
+        match self {
+            CallbackTiming::Available(ms) => Some(ms),
+            CallbackTiming::Pending | CallbackTiming::Unavailable => None,
+        }
+    }
+
+    fn is_unavailable(self) -> bool {
+        matches!(self, CallbackTiming::Unavailable)
+    }
+}
+
+#[derive(Debug)]
+struct ActivePostIndexingMeasurement {
+    token: MeasurementToken,
+    started_at: Instant,
+    context: IndexingReloadContext,
+    assistant_filters: Vec<AiAssistant>,
+    project_filter: ProjectFilter,
+    search_query_present: bool,
+    search_query_len: usize,
+    previously_selected_id_present: bool,
+    fetch_duration: Duration,
+    clear_duration: Duration,
+    push_duration: Duration,
+    row_count: usize,
+    selection_restore_attempted: bool,
+    selection_restore_succeeded: bool,
+    ensure_selection_fallback_ran: bool,
+    next_idle_delay: CallbackTiming,
+    next_frame_delay: CallbackTiming,
+}
+
+impl ActivePostIndexingMeasurement {
+    fn new(
+        context: IndexingReloadContext,
+        assistant_filters: &[AiAssistant],
+        project_filter: &ProjectFilter,
+        search_query: &str,
+    ) -> Self {
+        Self {
+            token: MeasurementToken::new(),
+            started_at: Instant::now(),
+            context,
+            assistant_filters: assistant_filters.to_vec(),
+            project_filter: project_filter.clone(),
+            search_query_present: !search_query.trim().is_empty(),
+            search_query_len: search_query.len(),
+            previously_selected_id_present: false,
+            fetch_duration: Duration::ZERO,
+            clear_duration: Duration::ZERO,
+            push_duration: Duration::ZERO,
+            row_count: 0,
+            selection_restore_attempted: false,
+            selection_restore_succeeded: false,
+            ensure_selection_fallback_ran: false,
+            next_idle_delay: CallbackTiming::Pending,
+            next_frame_delay: CallbackTiming::Pending,
+        }
+    }
+
+    fn record_sync_phases(
+        &mut self,
+        previously_selected_id_present: bool,
+        fetch_duration: Duration,
+        clear_duration: Duration,
+        push_duration: Duration,
+        row_count: usize,
+    ) {
+        self.previously_selected_id_present = previously_selected_id_present;
+        self.fetch_duration = fetch_duration;
+        self.clear_duration = clear_duration;
+        self.push_duration = push_duration;
+        self.row_count = row_count;
+    }
+
+    fn record_selection(&mut self, attempted: bool, succeeded: bool, fallback_ran: bool) {
+        self.selection_restore_attempted = attempted;
+        self.selection_restore_succeeded = succeeded;
+        self.ensure_selection_fallback_ran = fallback_ran;
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -242,6 +402,7 @@ impl SimpleComponent for SessionList {
             sessions,
             source_results: vec![],
             source_results_available: false,
+            active_post_indexing_measurement: None,
         };
 
         // Populate initial data
@@ -293,7 +454,7 @@ impl SimpleComponent for SessionList {
                 self.active_tools = tools.clone();
                 self.project_filter = project_filter;
                 self.all_tools_selected = tools.len() == AiAssistant::ALL.len();
-                self.reload_sessions();
+                self.reload_sessions(&sender);
             }
             SessionListMsg::SetSearchQuery(query) => {
                 if !Self::search_query_changed(&self.search_query, &query) {
@@ -301,10 +462,27 @@ impl SimpleComponent for SessionList {
                 }
 
                 self.search_query = query;
-                self.reload_sessions();
+                self.reload_sessions(&sender);
             }
             SessionListMsg::Reload => {
-                self.reload_sessions();
+                self.reload_sessions(&sender);
+            }
+            SessionListMsg::ReloadAfterIndexing {
+                assistants,
+                project_filter,
+                context,
+            } => {
+                self.active_tools = assistants;
+                self.all_tools_selected = self.active_tools.len() == AiAssistant::ALL.len();
+                self.project_filter = project_filter;
+                self.start_post_indexing_measurement(context);
+                self.reload_sessions(&sender);
+            }
+            SessionListMsg::PostIndexingReloadIdleMeasured { token, delay_ms } => {
+                self.record_post_indexing_idle(token, delay_ms);
+            }
+            SessionListMsg::PostIndexingReloadFrameMeasured { token, delay_ms } => {
+                self.record_post_indexing_frame(token, delay_ms);
             }
             SessionListMsg::SetIndexing(indexing) => {
                 self.indexing = indexing;
@@ -494,27 +672,194 @@ impl SessionList {
         false
     }
 
-    fn reload_sessions(&mut self) {
+    fn start_post_indexing_measurement(&mut self, context: IndexingReloadContext) {
+        if let Some(active) = &self.active_post_indexing_measurement {
+            active.token.invalidate();
+        }
+
+        self.active_post_indexing_measurement = Some(ActivePostIndexingMeasurement::new(
+            context,
+            &self.active_tools,
+            &self.project_filter,
+            &self.search_query,
+        ));
+    }
+
+    fn current_post_indexing_measurement_mut(
+        &mut self,
+        token: &MeasurementToken,
+    ) -> Option<&mut ActivePostIndexingMeasurement> {
+        self.active_post_indexing_measurement
+            .as_mut()
+            .filter(|active| active.token.is_valid() && active.token.same_identity(token))
+    }
+
+    fn schedule_post_indexing_callbacks(
+        &mut self,
+        sender: &ComponentSender<Self>,
+        token: MeasurementToken,
+        after_drop_at: Instant,
+    ) {
+        let idle_sender = sender.input_sender().clone();
+        let idle_token = token.clone();
+        glib::idle_add_local_once(move || {
+            if idle_token.is_valid() {
+                let _ = idle_sender.send(SessionListMsg::PostIndexingReloadIdleMeasured {
+                    token: idle_token,
+                    delay_ms: after_drop_at.elapsed().as_millis(),
+                });
+            }
+        });
+
+        let list_widget = self.sessions.widget().clone();
+        if list_widget.root().is_none() {
+            self.mark_post_indexing_frame_unavailable(&token);
+            return;
+        }
+
+        let frame_sender = sender.input_sender().clone();
+        let frame_token = token;
+        list_widget.add_tick_callback(move |_, _| {
+            if frame_token.is_valid() {
+                let _ = frame_sender.send(SessionListMsg::PostIndexingReloadFrameMeasured {
+                    token: frame_token.clone(),
+                    delay_ms: after_drop_at.elapsed().as_millis(),
+                });
+            }
+            glib::ControlFlow::Break
+        });
+    }
+
+    fn record_post_indexing_idle(&mut self, token: MeasurementToken, delay_ms: u128) {
+        if let Some(active) = self.current_post_indexing_measurement_mut(&token) {
+            active.next_idle_delay = CallbackTiming::Available(delay_ms);
+        }
+        self.maybe_emit_post_indexing_measurement();
+    }
+
+    fn record_post_indexing_frame(&mut self, token: MeasurementToken, delay_ms: u128) {
+        if let Some(active) = self.current_post_indexing_measurement_mut(&token) {
+            active.next_frame_delay = CallbackTiming::Available(delay_ms);
+        }
+        self.maybe_emit_post_indexing_measurement();
+    }
+
+    fn mark_post_indexing_frame_unavailable(&mut self, token: &MeasurementToken) {
+        if let Some(active) = self.current_post_indexing_measurement_mut(token) {
+            active.next_frame_delay = CallbackTiming::Unavailable;
+        }
+    }
+
+    fn maybe_emit_post_indexing_measurement(&mut self) {
+        let Some(active) = &self.active_post_indexing_measurement else {
+            return;
+        };
+
+        if active.next_idle_delay.is_pending() || active.next_frame_delay.is_pending() {
+            return;
+        }
+
+        tracing::info!(
+            reason = "post_indexing_completion",
+            indexed = active.context.indexed,
+            skipped = active.context.skipped,
+            removed = active.context.removed,
+            pending_reindex_feedback = active.context.pending_reindex_feedback,
+            errors_present = active.context.errors_present,
+            assistant_filter_count = active.assistant_filters.len(),
+            assistant_filters = ?active.assistant_filters,
+            all_assistants_selected = active.assistant_filters.len() == AiAssistant::ALL.len(),
+            project_filter = ?active.project_filter,
+            project_filter_active = active.project_filter != ProjectFilter::AllSessions,
+            search_query_present = active.search_query_present,
+            search_query_len = active.search_query_len,
+            previously_selected_id_present = active.previously_selected_id_present,
+            fetch_ms = active.fetch_duration.as_millis(),
+            clear_ms = active.clear_duration.as_millis(),
+            push_ms = active.push_duration.as_millis(),
+            row_count = active.row_count,
+            selection_restore_attempted = active.selection_restore_attempted,
+            selection_restore_succeeded = active.selection_restore_succeeded,
+            ensure_selection_fallback_ran = active.ensure_selection_fallback_ran,
+            next_idle_delay_ms = active.next_idle_delay.as_option(),
+            next_idle_delay_unavailable = active.next_idle_delay.is_unavailable(),
+            next_frame_delay_ms = active.next_frame_delay.as_option(),
+            next_frame_delay_unavailable = active.next_frame_delay.is_unavailable(),
+            total_reload_ms = active.started_at.elapsed().as_millis(),
+            "sessionlist.post_indexing_reload.measured"
+        );
+
+        active.token.invalidate();
+        self.active_post_indexing_measurement = None;
+    }
+
+    fn reload_sessions(&mut self, sender: &ComponentSender<Self>) {
         let previously_selected_id = self.selected_session_id();
+
+        let fetch_started_at = Instant::now();
         let fetched = Self::fetch_sessions(
             &self.db_path,
             &self.active_tools,
             &self.project_filter,
             &self.search_query,
         );
+        let fetch_duration = fetch_started_at.elapsed();
+        let row_count = fetched.len();
+
         let mut guard = self.sessions.guard();
+
+        let clear_started_at = Instant::now();
         guard.clear();
+        let clear_duration = clear_started_at.elapsed();
+
+        let push_started_at = Instant::now();
         for session in fetched {
             guard.push_back(SessionRowInit { session });
         }
+        let push_duration = push_started_at.elapsed();
         drop(guard);
 
+        let maybe_token = self
+            .active_post_indexing_measurement
+            .as_ref()
+            .map(|active| active.token.clone());
+
+        if let Some(active) = self.active_post_indexing_measurement.as_mut() {
+            active.record_sync_phases(
+                previously_selected_id.is_some(),
+                fetch_duration,
+                clear_duration,
+                push_duration,
+                row_count,
+            );
+        }
+
+        if let Some(token) = maybe_token {
+            self.schedule_post_indexing_callbacks(sender, token, Instant::now());
+        }
+
+        let mut selection_restore_attempted = false;
+        let mut selection_restore_succeeded = false;
+        let mut ensure_selection_fallback_ran = false;
+
         if let Some(session_id) = previously_selected_id {
-            if !self.select_session_by_id(&session_id) {
+            selection_restore_attempted = true;
+            selection_restore_succeeded = self.select_session_by_id(&session_id);
+            if !selection_restore_succeeded {
+                ensure_selection_fallback_ran = true;
                 self.ensure_selection();
             }
         } else {
+            ensure_selection_fallback_ran = true;
             self.ensure_selection();
+        }
+
+        if let Some(active) = self.active_post_indexing_measurement.as_mut() {
+            active.record_selection(
+                selection_restore_attempted,
+                selection_restore_succeeded,
+                ensure_selection_fallback_ran,
+            );
         }
     }
 }
@@ -995,6 +1340,21 @@ mod tests {
         assert!(!state.show_source_results);
     }
 
+    #[test]
+    fn post_indexing_measurement_token_invalidates_stale_callbacks() {
+        let token = MeasurementToken::new();
+        let stale_callback_token = token.clone();
+
+        assert!(token.is_valid());
+        assert!(stale_callback_token.is_valid());
+        assert!(token.same_identity(&stale_callback_token));
+
+        token.invalidate();
+
+        assert!(!token.is_valid());
+        assert!(!stale_callback_token.is_valid());
+    }
+
     #[gtk::test]
     fn explicit_reload_refreshes_even_when_filters_are_unchanged() {
         let temp_db = TempDatabase::new();
@@ -1042,6 +1402,46 @@ mod tests {
         };
 
         assert_eq!(first_session_id.as_deref(), Some("fresh-claude"));
+    }
+
+    #[gtk::test]
+    fn reload_after_indexing_applies_filters_and_refreshes_sessions() {
+        let temp_db = TempDatabase::new();
+        temp_db.seed_project_sidebar_fixture();
+
+        let controller = SessionList::builder().launch(temp_db.path.clone());
+
+        pump_main_context(|| {
+            let parts = controller.state().get();
+            parts.model.sessions.len() == 5
+        });
+
+        controller.emit(SessionListMsg::ReloadAfterIndexing {
+            assistants: vec![AiAssistant::OpenCode],
+            project_filter: ProjectFilter::Project(1),
+            context: IndexingReloadContext {
+                indexed: 1,
+                skipped: 2,
+                removed: 3,
+                pending_reindex_feedback: true,
+                errors_present: false,
+            },
+        });
+
+        pump_main_context(|| {
+            let parts = controller.state().get();
+            parts.model.sessions.len() == 1
+        });
+
+        let ids: Vec<String> = {
+            let parts = controller.state().get();
+            (0..parts.model.sessions.len())
+                .filter_map(|index| parts.model.sessions.get(index))
+                .map(|row| row.session_id().to_string())
+                .collect()
+        };
+
+        assert_eq!(ids, vec!["alpha-opencode"]);
     }
 
     #[gtk::test]

--- a/src/ui/session_list.rs
+++ b/src/ui/session_list.rs
@@ -161,6 +161,9 @@ struct ActivePostIndexingMeasurement {
     clear_duration: Duration,
     push_duration: Duration,
     row_count: usize,
+    batch_count: usize,
+    batch_size: usize,
+    max_batch_push_duration: Duration,
     selection_restore_attempted: bool,
     selection_restore_succeeded: bool,
     ensure_selection_fallback_ran: bool,
@@ -189,6 +192,9 @@ impl ActivePostIndexingMeasurement {
             clear_duration: Duration::ZERO,
             push_duration: Duration::ZERO,
             row_count: 0,
+            batch_count: 0,
+            batch_size: POST_INDEXING_RELOAD_BATCH_SIZE,
+            max_batch_push_duration: Duration::ZERO,
             selection_restore_attempted: false,
             selection_restore_succeeded: false,
             ensure_selection_fallback_ran: false,
@@ -220,7 +226,9 @@ impl ActivePostIndexingMeasurement {
     }
 
     fn record_batch_push(&mut self, duration: Duration) {
+        self.batch_count += 1;
         self.push_duration += duration;
+        self.max_batch_push_duration = self.max_batch_push_duration.max(duration);
     }
 }
 
@@ -972,9 +980,14 @@ impl SessionList {
             clear_ms = active.clear_duration.as_millis(),
             push_ms = active.push_duration.as_millis(),
             row_count = active.row_count,
+            batch_count = active.batch_count,
+            batch_size = active.batch_size,
+            max_batch_push_ms = active.max_batch_push_duration.as_millis(),
+            total_batch_push_ms = active.push_duration.as_millis(),
             selection_restore_attempted = active.selection_restore_attempted,
             selection_restore_succeeded = active.selection_restore_succeeded,
             ensure_selection_fallback_ran = active.ensure_selection_fallback_ran,
+            user_selection_changed_during_batch = active.user_selection_changed_during_batch,
             next_idle_delay_ms = active.next_idle_delay.as_option(),
             next_idle_delay_unavailable = active.next_idle_delay.is_unavailable(),
             next_frame_delay_ms = active.next_frame_delay.as_option(),
@@ -1672,6 +1685,35 @@ mod tests {
         batch.invalidate();
         assert!(!callback_token.is_valid());
         assert!(!batch.token_matches(&callback_token));
+    }
+
+    #[test]
+    fn post_indexing_measurement_accumulates_batch_push_metrics() {
+        let context = IndexingReloadContext {
+            indexed: 3,
+            skipped: 0,
+            removed: 0,
+            pending_reindex_feedback: false,
+            errors_present: false,
+        };
+        let mut measurement = ActivePostIndexingMeasurement::new(
+            context,
+            &[AiAssistant::ClaudeCode],
+            &ProjectFilter::AllSessions,
+            "",
+        );
+
+        measurement.record_batch_push(Duration::from_millis(2));
+        measurement.record_batch_push(Duration::from_millis(5));
+        measurement.record_batch_push(Duration::from_millis(3));
+
+        assert_eq!(measurement.batch_count, 3);
+        assert_eq!(measurement.batch_size, POST_INDEXING_RELOAD_BATCH_SIZE);
+        assert_eq!(measurement.push_duration, Duration::from_millis(10));
+        assert_eq!(
+            measurement.max_batch_push_duration,
+            Duration::from_millis(5)
+        );
     }
 
     #[gtk::test]

--- a/src/ui/session_list.rs
+++ b/src/ui/session_list.rs
@@ -218,6 +218,10 @@ impl ActivePostIndexingMeasurement {
         self.selection_restore_succeeded = succeeded;
         self.ensure_selection_fallback_ran = fallback_ran;
     }
+
+    fn record_batch_push(&mut self, duration: Duration) {
+        self.push_duration += duration;
+    }
 }
 
 const POST_INDEXING_RELOAD_BATCH_SIZE: usize = 64;
@@ -559,7 +563,7 @@ impl SimpleComponent for SessionList {
                 self.all_tools_selected = self.active_tools.len() == AiAssistant::ALL.len();
                 self.project_filter = project_filter;
                 self.start_post_indexing_measurement(context);
-                self.reload_sessions(&sender);
+                self.reload_sessions_after_indexing(&sender);
             }
             SessionListMsg::PostIndexingReloadIdleMeasured { token, delay_ms } => {
                 self.record_post_indexing_idle(token, delay_ms);
@@ -791,11 +795,72 @@ impl SessionList {
         }
     }
 
-    fn run_post_indexing_batch(
-        &mut self,
-        _sender: &ComponentSender<Self>,
-        _token: MeasurementToken,
-    ) {
+    fn finalize_post_indexing_batch(&mut self, batch: PendingPostIndexingBatch) {
+        let mut selection_restore_attempted = false;
+        let mut selection_restore_succeeded = false;
+        let mut ensure_selection_fallback_ran = false;
+
+        if !batch.user_selection_changed() {
+            if let Some(session_id) = batch.previously_selected_id() {
+                selection_restore_attempted = true;
+                selection_restore_succeeded = self.select_session_by_id(session_id);
+                if !selection_restore_succeeded {
+                    ensure_selection_fallback_ran = true;
+                    self.ensure_selection();
+                }
+            } else {
+                ensure_selection_fallback_ran = true;
+                self.ensure_selection();
+            }
+        }
+
+        if let Some(active) = self.active_post_indexing_measurement.as_mut() {
+            active.record_selection(
+                selection_restore_attempted,
+                selection_restore_succeeded,
+                ensure_selection_fallback_ran,
+            );
+            active.user_selection_changed_during_batch = batch.user_selection_changed();
+        }
+
+        self.maybe_emit_post_indexing_measurement();
+    }
+
+    fn run_post_indexing_batch(&mut self, sender: &ComponentSender<Self>, token: MeasurementToken) {
+        let Some(batch) = self.pending_post_indexing_batch.as_mut() else {
+            return;
+        };
+
+        if !batch.token_matches(&token) {
+            return;
+        }
+
+        let rows = batch.take_next_rows(POST_INDEXING_RELOAD_BATCH_SIZE);
+        let batch_push_started_at = Instant::now();
+        {
+            let mut guard = self.sessions.guard();
+            for session in rows {
+                guard.push_back(SessionRowInit { session });
+            }
+        }
+        let batch_push_duration = batch_push_started_at.elapsed();
+
+        if let Some(active) = self.current_post_indexing_measurement_mut(&token) {
+            active.record_batch_push(batch_push_duration);
+        }
+
+        let exhausted = self
+            .pending_post_indexing_batch
+            .as_ref()
+            .is_some_and(PendingPostIndexingBatch::is_exhausted);
+
+        if exhausted {
+            if let Some(batch) = self.pending_post_indexing_batch.take() {
+                self.finalize_post_indexing_batch(batch);
+            }
+        } else {
+            self.schedule_post_indexing_batch(sender, token);
+        }
     }
 
     fn current_post_indexing_measurement_mut(
@@ -843,6 +908,19 @@ impl SessionList {
         });
     }
 
+    fn schedule_post_indexing_batch(
+        &self,
+        sender: &ComponentSender<Self>,
+        token: MeasurementToken,
+    ) {
+        let batch_sender = sender.input_sender().clone();
+        glib::idle_add_local_once(move || {
+            if token.is_valid() {
+                let _ = batch_sender.send(SessionListMsg::PostIndexingReloadBatch { token });
+            }
+        });
+    }
+
     fn record_post_indexing_idle(&mut self, token: MeasurementToken, delay_ms: u128) {
         if let Some(active) = self.current_post_indexing_measurement_mut(&token) {
             active.next_idle_delay = CallbackTiming::Available(delay_ms);
@@ -868,7 +946,10 @@ impl SessionList {
             return;
         };
 
-        if active.next_idle_delay.is_pending() || active.next_frame_delay.is_pending() {
+        if active.next_idle_delay.is_pending()
+            || active.next_frame_delay.is_pending()
+            || self.pending_post_indexing_batch.is_some()
+        {
             return;
         }
 
@@ -906,7 +987,57 @@ impl SessionList {
         self.active_post_indexing_measurement = None;
     }
 
+    fn reload_sessions_after_indexing(&mut self, sender: &ComponentSender<Self>) {
+        let previously_selected_id = self.selected_session_id();
+
+        let fetch_started_at = Instant::now();
+        let fetched = Self::fetch_sessions(
+            &self.db_path,
+            &self.active_tools,
+            &self.project_filter,
+            &self.search_query,
+        );
+        let fetch_duration = fetch_started_at.elapsed();
+        let row_count = fetched.len();
+
+        let mut guard = self.sessions.guard();
+        let clear_started_at = Instant::now();
+        guard.clear();
+        let clear_duration = clear_started_at.elapsed();
+        drop(guard);
+
+        let Some(token) = self
+            .active_post_indexing_measurement
+            .as_ref()
+            .map(|active| active.token.clone())
+        else {
+            return;
+        };
+
+        if let Some(active) = self.active_post_indexing_measurement.as_mut() {
+            active.record_sync_phases(
+                previously_selected_id.is_some(),
+                fetch_duration,
+                clear_duration,
+                Duration::ZERO,
+                row_count,
+            );
+        }
+
+        self.pending_post_indexing_batch = Some(PendingPostIndexingBatch::new(
+            token.clone(),
+            fetched,
+            previously_selected_id,
+        ));
+
+        let after_setup_at = Instant::now();
+        self.schedule_post_indexing_callbacks(sender, token.clone(), after_setup_at);
+        self.schedule_post_indexing_batch(sender, token);
+    }
+
     fn reload_sessions(&mut self, sender: &ComponentSender<Self>) {
+        self.cancel_post_indexing_batch();
+
         let previously_selected_id = self.selected_session_id();
 
         let fetch_started_at = Instant::now();
@@ -1116,6 +1247,29 @@ mod tests {
                     ],
                 )
                 .expect("Failed to insert beta claude session");
+        }
+
+        fn seed_many_claude_sessions(&self, count: usize) {
+            for index in 0..count {
+                let id = format!("bulk-claude-{index:03}");
+                let file_path = format!("/tmp/{id}.jsonl");
+                self.connection
+                    .execute(
+                        "INSERT INTO sessions (id, tool, project_path, project_id, start_time, message_count, file_path, last_updated)
+                         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                        rusqlite::params![
+                            id,
+                            "claude_code",
+                            Some("/projects/alpha"),
+                            Some(1_i64),
+                            index as i64,
+                            1_i64,
+                            file_path,
+                            index as i64,
+                        ],
+                    )
+                    .expect("Failed to insert bulk claude session");
+            }
         }
     }
 
@@ -1700,6 +1854,65 @@ mod tests {
         };
 
         assert_eq!(ids, vec!["alpha-opencode"]);
+    }
+
+    #[gtk::test]
+    fn reload_after_indexing_finishes_batched_reload_with_expected_rows() {
+        let temp_db = TempDatabase::new();
+        temp_db.seed_project_sidebar_fixture();
+        temp_db.seed_many_claude_sessions(70);
+
+        let controller = SessionList::builder().launch(temp_db.path.clone());
+
+        pump_main_context(|| {
+            let parts = controller.state().get();
+            parts.model.sessions.len() == 75
+        });
+
+        controller.emit(SessionListMsg::ReloadAfterIndexing {
+            assistants: vec![AiAssistant::ClaudeCode],
+            project_filter: ProjectFilter::Project(1),
+            context: IndexingReloadContext {
+                indexed: 70,
+                skipped: 0,
+                removed: 0,
+                pending_reindex_feedback: false,
+                errors_present: false,
+            },
+        });
+
+        pump_main_context(|| {
+            let parts = controller.state().get();
+            parts.model.sessions.len() == 0 && parts.model.pending_post_indexing_batch.is_some()
+        });
+
+        {
+            let parts = controller.state().get();
+            assert_eq!(parts.model.sessions.len(), 0);
+            assert!(parts.model.pending_post_indexing_batch.is_some());
+        }
+
+        pump_main_context(|| {
+            let parts = controller.state().get();
+            parts.model.sessions.len() == POST_INDEXING_RELOAD_BATCH_SIZE
+        });
+
+        pump_main_context(|| {
+            let parts = controller.state().get();
+            parts.model.pending_post_indexing_batch.is_none() && parts.model.sessions.len() == 72
+        });
+
+        let ids: Vec<String> = {
+            let parts = controller.state().get();
+            (0..parts.model.sessions.len())
+                .filter_map(|index| parts.model.sessions.get(index))
+                .map(|row| row.session_id().to_string())
+                .collect()
+        };
+
+        assert_eq!(ids[0], "alpha-claude-new");
+        assert_eq!(ids[1], "alpha-claude-old");
+        assert_eq!(ids.len(), 72);
     }
 
     #[gtk::test]

--- a/src/ui/session_list.rs
+++ b/src/ui/session_list.rs
@@ -3,6 +3,7 @@ use gtk::glib;
 use relm4::factory::FactoryVecDeque;
 use relm4::{ComponentParts, ComponentSender, SimpleComponent, adw, gtk};
 use std::{
+    collections::VecDeque,
     fmt,
     path::{Path, PathBuf},
     sync::{
@@ -209,6 +210,75 @@ impl ActivePostIndexingMeasurement {
         self.selection_restore_attempted = attempted;
         self.selection_restore_succeeded = succeeded;
         self.ensure_selection_fallback_ran = fallback_ran;
+    }
+}
+
+const POST_INDEXING_RELOAD_BATCH_SIZE: usize = 64;
+
+#[derive(Debug)]
+struct PendingPostIndexingBatch {
+    token: MeasurementToken,
+    remaining_sessions: VecDeque<Session>,
+    total_row_count: usize,
+    previously_selected_id: Option<String>,
+    user_selection_changed: bool,
+}
+
+impl PendingPostIndexingBatch {
+    fn new(
+        token: MeasurementToken,
+        sessions: Vec<Session>,
+        previously_selected_id: Option<String>,
+    ) -> Self {
+        let total_row_count = sessions.len();
+        Self {
+            token,
+            remaining_sessions: sessions.into(),
+            total_row_count,
+            previously_selected_id,
+            user_selection_changed: false,
+        }
+    }
+
+    fn token(&self) -> MeasurementToken {
+        self.token.clone()
+    }
+
+    fn token_matches(&self, token: &MeasurementToken) -> bool {
+        self.token.is_valid() && self.token.same_identity(token)
+    }
+
+    fn invalidate(&self) {
+        self.token.invalidate();
+    }
+
+    fn take_next_rows(&mut self, batch_size: usize) -> Vec<Session> {
+        let take_count = batch_size.min(self.remaining_sessions.len());
+        self.remaining_sessions.drain(..take_count).collect()
+    }
+
+    fn is_exhausted(&self) -> bool {
+        self.remaining_sessions.is_empty()
+    }
+
+    fn remaining_row_count(&self) -> usize {
+        self.remaining_sessions.len()
+    }
+
+    fn total_row_count(&self) -> usize {
+        self.total_row_count
+    }
+
+    fn previously_selected_id(&self) -> Option<&str> {
+        self.previously_selected_id.as_deref()
+    }
+
+    fn user_selection_changed(&self) -> bool {
+        self.user_selection_changed
+    }
+
+    fn mark_user_selection_changed(&mut self) {
+        self.user_selection_changed = true;
     }
 }
 
@@ -1353,6 +1423,58 @@ mod tests {
 
         assert!(!token.is_valid());
         assert!(!stale_callback_token.is_valid());
+    }
+
+    #[test]
+    fn pending_post_indexing_batch_takes_bounded_rows_and_tracks_progress() {
+        let token = MeasurementToken::new();
+        let sessions = vec![
+            make_test_session("batch-1"),
+            make_test_session("batch-2"),
+            make_test_session("batch-3"),
+        ];
+        let mut batch =
+            PendingPostIndexingBatch::new(token.clone(), sessions, Some("batch-2".to_string()));
+
+        assert_eq!(batch.total_row_count(), 3);
+        assert_eq!(batch.remaining_row_count(), 3);
+        assert_eq!(batch.previously_selected_id(), Some("batch-2"));
+        assert!(!batch.is_exhausted());
+
+        let first = batch.take_next_rows(2);
+        assert_eq!(first.len(), 2);
+        assert_eq!(first[0].id, "batch-1");
+        assert_eq!(first[1].id, "batch-2");
+        assert_eq!(batch.remaining_row_count(), 1);
+        assert!(!batch.is_exhausted());
+
+        let second = batch.take_next_rows(2);
+        assert_eq!(second.len(), 1);
+        assert_eq!(second[0].id, "batch-3");
+        assert_eq!(batch.remaining_row_count(), 0);
+        assert!(batch.is_exhausted());
+    }
+
+    #[test]
+    fn pending_post_indexing_batch_invalidates_token_and_records_user_selection_change() {
+        let token = MeasurementToken::new();
+        let callback_token = token.clone();
+        let mut batch = PendingPostIndexingBatch::new(
+            token,
+            vec![make_test_session("batch-1")],
+            Some("batch-1".to_string()),
+        );
+
+        assert!(callback_token.is_valid());
+        assert!(batch.token_matches(&callback_token));
+        assert!(!batch.user_selection_changed());
+
+        batch.mark_user_selection_changed();
+        assert!(batch.user_selection_changed());
+
+        batch.invalidate();
+        assert!(!callback_token.is_valid());
+        assert!(!batch.token_matches(&callback_token));
     }
 
     #[gtk::test]


### PR DESCRIPTION
## Summary

Closes #145 

- Replace the post-indexing immediate insertion pass with fixed-size (64-row) idle batches in `SessionList`, while keeping ordinary reloads (filters, search, pin, explicit reload) on the existing synchronous path.
- Add a `PendingPostIndexingBatch` state object guarded by the existing `MeasurementToken` so stale idle/frame/batch callbacks no-op when a newer reload starts. Ordinary reloads explicitly cancel the active batch + measurement; user selection during batching is preserved instead of being clobbered by the final restore.
- Extend the `sessionlist.post_indexing_reload.measured` event with `batch_count`, `batch_size`, `max_batch_push_ms`, `total_batch_push_ms`, and `user_selection_changed_during_batch`. `push_ms` continues to report the cumulative batch push time so existing dashboards stay valid.

## Measurements

Acceptance baseline (from `docs/reports/2026-05-06-session-list-post-indexing-reload-instrumentation-report.md`): median `next_idle_delay_ms` = 469 ms, median `total_reload_ms` = 1301 ms.

| Run | row_count | batch_count | next_idle_delay_ms | total_reload_ms | total_batch_push_ms |
|-----|-----------|-------------|--------------------|------------------|---------------------|
| 1   | 890       | 14          | **23**             | 1251             | 528                 |
| 2   | 890       | 14          | **25**             | 1437             | 537                 |

`next_idle_delay_ms` drops ~95% (target was 40% reduction or <250 ms); `total_reload_ms` stays under the 1626 ms guardrail.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test --all --no-fail-fast` (new tests: deterministic batch state, cancellation invalidation, batched reload contents, second-reload invalidation, ordinary-reload cancellation, user-selection preservation, batch metric accumulation)
- [x] Manual measurement runs (logged to `/tmp/sessions-chronicle-issue-145-batched-run{1,2}.log`) confirm acceptance thresholds