### PR TITLE
chore: archive issue 146 post-drop investigation instrumentation

### DIFF
--- a/docs/reports/2026-05-10-session-detail-issue-146-post-drop-investigation.md
+++ b/docs/reports/2026-05-10-session-detail-issue-146-post-drop-investigation.md
@@ -1,0 +1,72 @@
+# Session Detail Issue 146 Post-Drop Investigation Report
+
+## Protocol
+
+- Reference session: `019dc51a-f0cd-79c1-ba79-45fedac889c2`
+- Build profile: `release`
+- Run mode: `native ~/.local/bin/sessions-chronicle`
+- Display backend: `wayland`
+- GNOME Shell version: `49.6`
+- Search before open: none
+- Probe targets: `AppMsg::SessionSelected`, `App::handle_session_selected`, `SessionDetailMsg::SetSession`, `NavigationView::push`, `SessionDetail::render_next_transcript_batch`, `App::handle_search_query_changed`, `App::handle_toggle_inspector`, `App::handle_inspector_visibility_changed`, `SidebarMsg::ProjectsLoaded`, `SidebarMsg::ProjectSelected`, `SidebarMsg::AiAssistantToggled`
+- Runs captured: one cold run after cache drop attempt, two warm runs, one focused Sysprof capture with `sysprof-cli --gtk --gnome-shell --use-trace-fd`
+
+## Runs
+
+| run | cache_state | reproduced | max_schedule_gap_ms | max_post_drop_residual_ms | default_idle_ms | high_idle_ms | first_frame_ms | second_frame_ms | largest_frame_phase_us | notes |
+| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| cold | cold | yes | 1327 | 1327 | 3246 | 0.0 | 9 | 1330 | 1325982 | `load_session=0 ms`; row build total `1 ms`; repeated `update_to_layout_us` spikes around `640k-1326k us` |
+| warm-1 | warm | yes | 1330 | 1330 | 4001 | 664 | 12 | 1335 | 1322549 | `load_session=0 ms`; row build total `1 ms`; repeated `update_to_layout_us` spikes around `1.31M us` and `5k-8k us` |
+| warm-2 | warm | yes | 1307 | 1307 | 3966 | 0.0 | 7 | 1310 | 1305530 | `load_session=0 ms`; row build total `3 ms`; repeated `update_to_layout_us` spikes around `1.30M us` and `21k-28k us` |
+
+## Largest Stall Timeline
+
+The cold run produced the clearest largest stall.
+
+1. `AppMsg::SessionSelected`, `App::handle_session_selected`, `load_session`, `SessionDetailMsg::SetSession`, and `NavigationView::push` all happened back-to-back at `22:05:37.148-22:05:37.149`, with `load_session_ms=0`.
+2. The first render batch completed its factory push immediately: `push_duration_ms=0`, `high-idle=0 ms`, `default-idle=1 ms`, and `first_frame_ms=7` for batch 1.
+3. The first long stall appeared inside frame-clock work, not before it: frame `550` logged `update_to_layout_us=1280408`, `before_paint_to_after_paint_us=1281924`, and the heartbeat logged `heartbeat_gap_ms=1286`.
+4. The next batch inherited the same wall-clock loss: batch 4 logged `schedule_gap_ms=1286`, `max_schedule_gap_ms=1286`, and batch 3's second-frame callback landed at `after_drop_to_second_frame_ms=1288`.
+5. The page completed with `total_duration_ms=7272`, `max_schedule_gap_ms=1327`, `max_post_drop_residual_ms=1327`, and `total_row_build_duration_ms=1`.
+
+The warm runs repeated the same pattern with nearly identical residual gaps: `1307-1330 ms` schedule gaps, `1310-1335 ms` second-frame delays, and `1305530-1322549 us` largest frame spans while Rust row-build work stayed at `1-3 ms`.
+
+## Owner Decision
+
+`GTK update/layout/paint`
+
+The first matching interpretation rule is the one where the post-drop stall is owned by GTK frame processing because the lost time shows up inside frame phases rather than in Rust batch push, neighboring handlers, or pre-frame scheduling. All three runs reached `load_session=0 ms`, `total_row_build_duration_ms=1-3 ms`, and immediate or near-immediate first high-idle callbacks, but then spent `1305530-1325982 us` in frame-clock spans dominated by `update_to_layout_us`, with matching `1307-1330 ms` heartbeat and schedule gaps. Sysprof matched that measurement window with stacks dominated by GTK update/layout/paint and only secondary Pango presence.
+
+## Suspects Ruled Out
+
+- `neighboring app path`: the only neighboring logs during open were `AppMsg::SessionSelected`, `App::handle_session_selected`, `load_session`, `SessionDetailMsg::SetSession`, and `NavigationView::push`; `load_session` was `0 ms`, and no search or inspector handlers fired in the measured open path.
+- `GLib/Relm4 main-loop scheduling`: the earliest high-idle callbacks landed at `0-664 ms`, but the decisive lost time was inside frame-phase measurements, especially `update_to_layout_us`, not before GTK started processing the frame.
+- `compositor/swap`: the long spans sat before or during layout, while `paint_to_after_paint_us` stayed tiny and Sysprof did not point to swap/compositor-dominant stacks.
+- Rust transcript row construction: `push_duration_ms` stayed `0`, `total_row_build_duration_ms` stayed `1-3 ms`, and the worst row build stayed `1 ms`, far below the `1307-1330 ms` residual stalls.
+
+## What Not To Try Next
+
+- Do not spend the next iteration on database loading, sidebar noise, search handlers, or inspector toggles; the logs already show those are not the owner of the stall window.
+- Do not focus on Rust-side row-build micro-optimizations first; the measurement gap is overwhelmingly in GTK frame work after rows have already been pushed.
+- Do not treat Pango as the sole owner from this capture; text shaping appears contributory, but the dominant bucket is still broader GTK update/layout/paint.
+
+## Recommended Next Issue
+
+`tune batching against post-drop GTK cost`
+
+The next issue should reduce how much GTK layout/paint work is triggered per post-drop batch, because the current batching pattern creates repeated `~1.3 s` frame-layout stalls even though Rust-side work is negligible.
+
+## Sysprof
+
+`sysprof-cli` was available and produced `target/issue146.syscap`.
+
+The focused capture lined up with the measured stall window and showed stacks dominated by GTK update/layout/paint activity, with some Pango work present but not leading. That matches the frame-clock probes, where the largest spans were in `update_to_layout_us` and not in `paint_to_after_paint_us` or neighboring application handlers.
+
+## Validation
+
+- Environment header recorded in `target/issue146-environment.txt`
+- Native release binary installed at `~/.local/bin/sessions-chronicle`
+- Log summary extracted into `target/issue146-summary.log`
+- Placeholder scan completed with no unresolved authoring markers remaining.
+- `cargo fmt --all -- --check` passed after report authoring.
+- `cargo test --all --no-fail-fast` passed after report authoring.

--- a/src/app/handlers/navigation.rs
+++ b/src/app/handlers/navigation.rs
@@ -51,6 +51,11 @@ impl App {
     }
 
     pub(crate) fn handle_toggle_inspector(&mut self) {
+        tracing::debug!(
+            method = "App::handle_toggle_inspector",
+            detail_visible = self.detail_visible,
+            "Session detail issue146 neighboring owner event"
+        );
         if !self.detail_visible {
             return;
         }
@@ -72,10 +77,21 @@ impl App {
     }
 
     pub(crate) fn handle_inspector_visibility_changed(&mut self, visible: bool) {
+        tracing::debug!(
+            method = "App::handle_inspector_visibility_changed",
+            visible,
+            "Session detail issue146 neighboring owner event"
+        );
         self.inspector_open = visible;
     }
 
     pub(crate) fn handle_search_query_changed(&mut self, query: String) {
+        tracing::debug!(
+            method = "App::handle_search_query_changed",
+            query_len = query.len(),
+            detail_visible = self.detail_visible,
+            "Session detail issue146 neighboring owner event"
+        );
         self.search_query = query.clone();
         let (list_msg, detail_msg) = search_query_update_messages(query);
         self.session_list.emit(list_msg);

--- a/src/app/handlers/sessions.rs
+++ b/src/app/handlers/sessions.rs
@@ -24,6 +24,8 @@ impl App {
 
     fn set_active_session_and_detail(&mut self, session: Session, search_query: Option<String>) {
         let project_name = Self::project_name_from_session(&session);
+        let session_id = session.id.clone();
+        let has_search_query = search_query.is_some();
 
         self.active_session = Some(ActiveSessionRef {
             id: session.id.clone(),
@@ -32,6 +34,12 @@ impl App {
             pinned: session.pinned_at.is_some(),
         });
 
+        tracing::debug!(
+            message_variant = "SessionDetailMsg::SetSession",
+            session_id = session_id.as_str(),
+            has_search_query,
+            "Session detail issue146 neighboring owner event"
+        );
         self.session_detail.emit(SessionDetailMsg::SetSession {
             session: Box::new(session),
             search_query,
@@ -39,13 +47,24 @@ impl App {
     }
 
     pub(crate) fn handle_session_selected(&mut self, id: String) {
-        tracing::debug!("Session selected: {}", id);
+        tracing::debug!(
+            method = "App::handle_session_selected",
+            session_id = id.as_str(),
+            "Session detail issue146 neighboring owner event"
+        );
 
         self.session_detail.widget().set_visible(true);
         let search_query = active_search_query(&self.search_query);
+        let load_started_at = std::time::Instant::now();
 
         match load_session(&self.db_path, &id) {
             Ok(Some(session)) => {
+                tracing::debug!(
+                    method = "load_session",
+                    session_id = id.as_str(),
+                    load_duration_ms = load_started_at.elapsed().as_millis(),
+                    "Session detail issue146 neighboring owner event"
+                );
                 self.set_active_session_and_detail(session, search_query);
             }
             Ok(None) => {
@@ -63,6 +82,12 @@ impl App {
         if !self.detail_visible {
             self.filters_open_before_detail = self.filters_open;
             self.filters_open = false;
+            tracing::debug!(
+                method = "NavigationView::push",
+                page_tag = "detail",
+                session_id = id.as_str(),
+                "Session detail issue146 neighboring owner event"
+            );
             self.nav_view.push(&self.detail_page);
             self.detail_visible = true;
             self.banner.set_revealed(false);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -548,7 +548,14 @@ impl SimpleComponent for App {
                 self.refresh_sidebar_projects();
                 self.emit_session_list_filters();
             }
-            AppMsg::SessionSelected(id) => self.handle_session_selected(id),
+            AppMsg::SessionSelected(id) => {
+                tracing::debug!(
+                    message_variant = "AppMsg::SessionSelected",
+                    session_id = id.as_str(),
+                    "Session detail issue146 neighboring owner event"
+                );
+                self.handle_session_selected(id)
+            }
             AppMsg::RequestNavigateBack => self.handle_request_navigate_back(),
             AppMsg::NavigateBack => self.handle_navigate_back(),
             AppMsg::ShowPreferences => {

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -1105,6 +1105,7 @@ impl Component for SessionDetail {
                 self.session = Some(session);
                 self.start_first_page_load(&sender, &session_id, true, "open");
                 self.start_probe_window(self.transcript_request_id, session_id.clone());
+                self.start_probe_heartbeat();
                 tracing::info!(
                     request_id = self.transcript_request_id,
                     session_id = session_id.as_str(),
@@ -1918,6 +1919,178 @@ impl SessionDetail {
         });
     }
 
+    fn scrolled_window_for_probe(&self) -> Option<gtk::ScrolledWindow> {
+        self.messages
+            .widget()
+            .ancestor(gtk::ScrolledWindow::static_type())
+            .and_then(|w| w.downcast::<gtk::ScrolledWindow>().ok())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn schedule_post_drop_probes(
+        &mut self,
+        request_id: u64,
+        offset: usize,
+        render_batch_index: usize,
+        rendered_this_batch: usize,
+        rendered_items: usize,
+        remaining_items: usize,
+        display_item_count: usize,
+        push_duration: Duration,
+        schedule_gap: Duration,
+        max_schedule_gap: Duration,
+        after_drop_at: Instant,
+    ) {
+        let Some(probe_window) = self.probe_window.as_mut() else {
+            return;
+        };
+        if probe_window.request_id != request_id {
+            return;
+        }
+
+        probe_window.record_latest_batch(render_batch_index, rendered_items);
+        let session_id = probe_window.session_id.clone();
+        let frame_probe_session_id = probe_window.session_id.clone();
+
+        let default_idle_source = ProbePendingSource::new();
+        let default_idle_source_for_callback = default_idle_source.clone();
+        let default_idle_id = glib::idle_add_local_once(move || {
+            default_idle_source_for_callback.clear();
+            tracing::debug!(
+                request_id,
+                session_id = session_id.as_deref(),
+                offset,
+                render_batch_index,
+                rendered_this_batch,
+                rendered_items,
+                remaining_items,
+                display_item_count,
+                push_duration_ms = push_duration.as_millis(),
+                schedule_gap_ms = schedule_gap.as_millis(),
+                max_schedule_gap_ms = max_schedule_gap.as_millis(),
+                after_drop_to_idle_ms = after_drop_at.elapsed().as_millis(),
+                idle_priority = "default-idle",
+                "Session detail issue146 post-drop idle measured"
+            );
+        });
+        default_idle_source.set(default_idle_id);
+        probe_window.pending_sources.push(default_idle_source);
+
+        let high_idle_source = ProbePendingSource::new();
+        let high_idle_source_for_callback = high_idle_source.clone();
+        let high_idle_session_id = probe_window.session_id.clone();
+        let high_idle_id = glib::idle_add_local_full(glib::Priority::HIGH_IDLE, move || {
+            high_idle_source_for_callback.clear();
+            tracing::debug!(
+                request_id,
+                session_id = high_idle_session_id.as_deref(),
+                offset,
+                render_batch_index,
+                rendered_this_batch,
+                rendered_items,
+                remaining_items,
+                display_item_count,
+                push_duration_ms = push_duration.as_millis(),
+                schedule_gap_ms = schedule_gap.as_millis(),
+                max_schedule_gap_ms = max_schedule_gap.as_millis(),
+                after_drop_to_idle_ms = after_drop_at.elapsed().as_millis(),
+                idle_priority = "high-idle",
+                "Session detail issue146 post-drop idle measured"
+            );
+            glib::ControlFlow::Break
+        });
+        high_idle_source.set(high_idle_id);
+        probe_window.pending_sources.push(high_idle_source);
+
+        let frame_probe_request_id = probe_window.request_id;
+        let rooted_session_id = frame_probe_session_id.clone();
+
+        let Some(scrolled_window) = self.scrolled_window_for_probe() else {
+            tracing::debug!(
+                request_id = frame_probe_request_id,
+                session_id = rooted_session_id.as_deref(),
+                offset,
+                render_batch_index,
+                "Session detail issue146 frame probe unavailable because scrolled window is not rooted"
+            );
+            return;
+        };
+
+        let first_tick_scrolled_window = scrolled_window.clone();
+        let first_tick_session_id = frame_probe_session_id;
+        let first_tick_id = scrolled_window.add_tick_callback(move |widget, _clock| {
+            let vadjustment = first_tick_scrolled_window.vadjustment();
+            tracing::debug!(
+                request_id,
+                session_id = first_tick_session_id.as_deref(),
+                offset,
+                render_batch_index,
+                rendered_this_batch,
+                rendered_items,
+                remaining_items,
+                display_item_count,
+                after_drop_to_first_frame_ms = after_drop_at.elapsed().as_millis(),
+                vadjustment_value = vadjustment.value(),
+                vadjustment_upper = vadjustment.upper(),
+                "Session detail issue146 post-drop first frame measured"
+            );
+            let second_tick_session_id = first_tick_session_id.clone();
+            let second_tick_scrolled_window = first_tick_scrolled_window.clone();
+            widget.add_tick_callback(move |_, _| {
+                let vadjustment = second_tick_scrolled_window.vadjustment();
+                tracing::debug!(
+                    request_id,
+                    session_id = second_tick_session_id.as_deref(),
+                    offset,
+                    render_batch_index,
+                    rendered_items,
+                    remaining_items,
+                    after_drop_to_second_frame_ms = after_drop_at.elapsed().as_millis(),
+                    vadjustment_value = vadjustment.value(),
+                    vadjustment_upper = vadjustment.upper(),
+                    "Session detail issue146 post-drop second frame measured"
+                );
+                glib::ControlFlow::Break
+            });
+            glib::ControlFlow::Break
+        });
+        if let Some(probe_window) = self.probe_window.as_mut()
+            && probe_window.request_id == request_id
+        {
+            probe_window.tick_callbacks.push(first_tick_id);
+        }
+    }
+
+    fn start_probe_heartbeat(&mut self) {
+        let Some(probe_window) = self.probe_window.as_mut() else {
+            return;
+        };
+        if probe_window.heartbeat_source.is_some() {
+            return;
+        }
+
+        let request_id = probe_window.request_id;
+        let session_id = probe_window.session_id.clone();
+        let last_tick = Rc::new(RefCell::new(Instant::now()));
+        let last_tick_for_callback = last_tick.clone();
+        let heartbeat_source = glib::timeout_add_local(Duration::from_millis(16), move || {
+            let now = Instant::now();
+            let mut previous = last_tick_for_callback.borrow_mut();
+            let gap = now.duration_since(*previous);
+            *previous = now;
+            if gap >= Duration::from_millis(50) {
+                tracing::debug!(
+                    request_id,
+                    session_id = session_id.as_deref(),
+                    heartbeat_gap_ms = gap.as_millis(),
+                    "Session detail issue146 heartbeat gap"
+                );
+            }
+            glib::ControlFlow::Continue
+        });
+        probe_window.heartbeat_source = Some(heartbeat_source);
+    }
+
     fn prepare_for_navigation_back(&mut self, sender: &ComponentSender<Self>) {
         self.invalidate_transcript_requests();
         self.loading_first_page = false;
@@ -2052,7 +2225,8 @@ impl SessionDetail {
         let source_row_count = batch.source_row_count;
         let total_push_duration_ms = batch.total_push_duration.as_millis();
         let max_push_duration_ms = batch.max_push_duration.as_millis();
-        let max_schedule_gap_ms = batch.max_schedule_gap.as_millis();
+        let max_schedule_gap = batch.max_schedule_gap;
+        let max_schedule_gap_ms = max_schedule_gap.as_millis();
         let total_duration_ms = batch.queued_at.elapsed().as_millis();
         batch.batch_breakdowns.push(RenderBatchBreakdown {
             render_batch_index,
@@ -2064,6 +2238,30 @@ impl SessionDetail {
         });
         batch.last_batch_completed_at = Some(Instant::now());
         drop(guard);
+        let should_complete_render = !has_more_items;
+        let first_page_load_to_factory_push_ms = if offset == 0 && should_complete_render {
+            first_page_load_started_at.map(|started_at| started_at.elapsed().as_millis())
+        } else {
+            None
+        };
+        if should_complete_render && let Some(batch) = self.pending_render_batch.as_mut() {
+            batch.first_page_load_to_factory_push_ms = first_page_load_to_factory_push_ms;
+            batch.push_complete = true;
+        }
+        let after_drop_at = Instant::now();
+        self.schedule_post_drop_probes(
+            request_id,
+            offset,
+            render_batch_index,
+            rendered_this_batch,
+            rendered_items,
+            remaining_items,
+            total_items,
+            push_duration,
+            schedule_gap,
+            max_schedule_gap,
+            after_drop_at,
+        );
 
         if has_more_items {
             tracing::debug!(
@@ -2080,11 +2278,6 @@ impl SessionDetail {
             );
             self.schedule_transcript_render_batch(sender, request_id);
         } else {
-            let first_page_load_to_factory_push_ms = if offset == 0 {
-                first_page_load_started_at.map(|started_at| started_at.elapsed().as_millis())
-            } else {
-                None
-            };
             if offset == 0 {
                 tracing::info!(
                     request_id,
@@ -2099,10 +2292,6 @@ impl SessionDetail {
                     first_page_load_to_factory_push_ms,
                     "First transcript page factory push complete"
                 );
-            }
-            if let Some(batch) = self.pending_render_batch.as_mut() {
-                batch.first_page_load_to_factory_push_ms = first_page_load_to_factory_push_ms;
-                batch.push_complete = true;
             }
             self.complete_transcript_render_push(sender);
         }

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -5,8 +5,8 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use gtk::glib;
 use gtk::prelude::*;
+use gtk::{gdk, glib};
 use relm4::factory::FactoryVecDeque;
 use relm4::{
     Component, ComponentController, ComponentParts, ComponentSender, Controller, RelmWidgetExt,
@@ -66,6 +66,7 @@ pub struct SessionDetail {
     search_request_id: u64,
     scroll_to_item: Cell<Option<ScrollTarget>>,
     pending_toast: Cell<bool>,
+    probe_window: Option<SessionDetailProbeWindow>,
     inspector: Controller<ToolInspectorPane>,
     inspector_open: bool,
 }
@@ -206,6 +207,95 @@ impl FramePhaseSample {
             ),
             update_to_after_paint_us: Self::delta_us(self.update_at, self.after_paint_at),
         })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ProbePendingSource {
+    id: Rc<RefCell<Option<glib::SourceId>>>,
+}
+
+impl ProbePendingSource {
+    fn new() -> Self {
+        Self {
+            id: Rc::new(RefCell::new(None)),
+        }
+    }
+
+    fn set(&self, source_id: glib::SourceId) {
+        *self.id.borrow_mut() = Some(source_id);
+    }
+
+    fn clear(&self) {
+        *self.id.borrow_mut() = None;
+    }
+
+    fn remove_if_pending(&self) {
+        if let Some(source_id) = self.id.borrow_mut().take() {
+            source_id.remove();
+        }
+    }
+}
+
+struct SessionDetailProbeWindow {
+    request_id: u64,
+    session_id: Option<String>,
+    started_at: Instant,
+    latest_render_batch_index: Option<usize>,
+    latest_rendered_items: Option<usize>,
+    heartbeat_source: Option<glib::SourceId>,
+    pending_sources: Vec<ProbePendingSource>,
+    tick_callbacks: Vec<gtk::TickCallbackId>,
+    frame_signal_handlers: Vec<(gdk::FrameClock, glib::SignalHandlerId)>,
+    frame_samples: Rc<RefCell<BTreeMap<i64, FramePhaseSample>>>,
+}
+
+impl std::fmt::Debug for SessionDetailProbeWindow {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SessionDetailProbeWindow")
+            .field("request_id", &self.request_id)
+            .field("session_id", &self.session_id)
+            .field("latest_render_batch_index", &self.latest_render_batch_index)
+            .field("latest_rendered_items", &self.latest_rendered_items)
+            .finish()
+    }
+}
+
+impl SessionDetailProbeWindow {
+    fn new(request_id: u64, session_id: String) -> Self {
+        Self {
+            request_id,
+            session_id: Some(session_id),
+            started_at: Instant::now(),
+            latest_render_batch_index: None,
+            latest_rendered_items: None,
+            heartbeat_source: None,
+            pending_sources: Vec::new(),
+            tick_callbacks: Vec::new(),
+            frame_signal_handlers: Vec::new(),
+            frame_samples: Rc::new(RefCell::new(BTreeMap::new())),
+        }
+    }
+
+    fn record_latest_batch(&mut self, render_batch_index: usize, rendered_items: usize) {
+        self.latest_render_batch_index = Some(render_batch_index);
+        self.latest_rendered_items = Some(rendered_items);
+    }
+
+    fn teardown(&mut self) {
+        if let Some(source_id) = self.heartbeat_source.take() {
+            source_id.remove();
+        }
+        for source in self.pending_sources.drain(..) {
+            source.remove_if_pending();
+        }
+        for tick_callback in self.tick_callbacks.drain(..) {
+            tick_callback.remove();
+        }
+        for (frame_clock, handler_id) in self.frame_signal_handlers.drain(..) {
+            frame_clock.disconnect(handler_id);
+        }
+        self.frame_samples.borrow_mut().clear();
     }
 }
 
@@ -963,6 +1053,7 @@ impl Component for SessionDetail {
             search_request_id: 0,
             scroll_to_item: Cell::new(None),
             pending_toast: Cell::new(false),
+            probe_window: None,
             inspector,
             inspector_open: false,
         };
@@ -1013,6 +1104,7 @@ impl Component for SessionDetail {
                 let query_len = normalized.as_ref().map(|query| query.len()).unwrap_or(0);
                 self.session = Some(session);
                 self.start_first_page_load(&sender, &session_id, true, "open");
+                self.start_probe_window(self.transcript_request_id, session_id.clone());
                 tracing::info!(
                     request_id = self.transcript_request_id,
                     session_id = session_id.as_str(),
@@ -1165,6 +1257,7 @@ impl Component for SessionDetail {
                 self.reload_current_session(&sender, "clear_search");
             }
             SessionDetailMsg::Clear => {
+                self.finish_probe_window("component_clear");
                 self.invalidate_transcript_requests();
                 self.invalidate_search_requests();
                 self.session = None;
@@ -1709,6 +1802,30 @@ impl SessionDetail {
             .ok();
     }
 
+    fn start_probe_window(&mut self, request_id: u64, session_id: String) {
+        self.finish_probe_window("replaced");
+        tracing::info!(
+            request_id,
+            session_id = session_id.as_str(),
+            "Session detail issue146 probe window started"
+        );
+        self.probe_window = Some(SessionDetailProbeWindow::new(request_id, session_id));
+    }
+
+    fn finish_probe_window(&mut self, reason: &'static str) {
+        if let Some(mut probe_window) = self.probe_window.take() {
+            let elapsed_ms = probe_window.started_at.elapsed().as_millis();
+            probe_window.teardown();
+            tracing::info!(
+                request_id = probe_window.request_id,
+                session_id = probe_window.session_id.as_deref(),
+                reason,
+                elapsed_ms,
+                "Session detail issue146 probe window finished"
+            );
+        }
+    }
+
     /// Reset transcript state and trigger the first-page load.
     ///
     /// Pass `defer = true` only when a fresh session is being opened: the load
@@ -1815,6 +1932,7 @@ impl SessionDetail {
     }
 
     fn clear_for_navigation_back(&mut self) {
+        self.finish_probe_window("navigation_back");
         self.invalidate_search_requests();
         self.session = None;
         self.first_page_load_started_at = None;
@@ -2708,6 +2826,19 @@ mod tests {
         assert_eq!(deltas.layout_to_paint_us, Some(30));
         assert_eq!(deltas.paint_to_after_paint_us, Some(15));
         assert_eq!(deltas.update_to_after_paint_us, Some(60));
+    }
+
+    #[test]
+    fn session_detail_probe_window_starts_active_and_records_batch_context() {
+        let mut window = SessionDetailProbeWindow::new(5, "session-5".to_string());
+
+        window.record_latest_batch(3, 9);
+
+        assert_eq!(window.request_id, 5);
+        assert_eq!(window.session_id.as_deref(), Some("session-5"));
+        assert_eq!(window.latest_render_batch_index, Some(3));
+        assert_eq!(window.latest_rendered_items, Some(9));
+        assert!(window.started_at.elapsed() < Duration::from_secs(5));
     }
 
     fn build_test_session(

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -2016,6 +2016,8 @@ impl SessionDetail {
             return;
         };
 
+        self.connect_frame_clock_phase_probes();
+
         let first_tick_scrolled_window = scrolled_window.clone();
         let first_tick_session_id = frame_probe_session_id;
         let first_tick_id = scrolled_window.add_tick_callback(move |widget, _clock| {
@@ -2058,6 +2060,135 @@ impl SessionDetail {
             && probe_window.request_id == request_id
         {
             probe_window.tick_callbacks.push(first_tick_id);
+        }
+    }
+
+    fn connect_frame_clock_phase_probes(&mut self) {
+        let Some(probe_window) = self.probe_window.as_ref() else {
+            return;
+        };
+        if !probe_window.frame_signal_handlers.is_empty() {
+            return;
+        }
+
+        let probe_request_id = probe_window.request_id;
+        let probe_session_id = probe_window.session_id.clone();
+        let latest_render_batch_index = probe_window.latest_render_batch_index.unwrap_or(0);
+        let samples = probe_window.frame_samples.clone();
+
+        let Some(scrolled_window) = self.scrolled_window_for_probe() else {
+            tracing::debug!(
+                request_id = probe_request_id,
+                session_id = probe_session_id.as_deref(),
+                "Session detail issue146 frame clock unavailable because scrolled window is not rooted"
+            );
+            return;
+        };
+        let Some(frame_clock) = scrolled_window.frame_clock() else {
+            tracing::debug!(
+                request_id = probe_request_id,
+                session_id = probe_session_id.as_deref(),
+                "Session detail issue146 frame clock unavailable on active backend"
+            );
+            return;
+        };
+
+        let request_id = probe_request_id;
+        let session_id = probe_session_id;
+
+        let before_samples = samples.clone();
+        let before_handler = frame_clock.connect_before_paint(move |clock| {
+            let frame_counter = clock.frame_counter();
+            before_samples.borrow_mut().insert(
+                frame_counter,
+                FramePhaseSample::new(request_id, latest_render_batch_index, frame_counter),
+            );
+            if let Some(sample) = before_samples.borrow_mut().get_mut(&frame_counter) {
+                sample.before_paint_at = Some(Instant::now());
+            }
+        });
+
+        let update_samples = samples.clone();
+        let update_handler = frame_clock.connect_update(move |clock| {
+            let frame_counter = clock.frame_counter();
+            update_samples
+                .borrow_mut()
+                .entry(frame_counter)
+                .or_insert_with(|| {
+                    FramePhaseSample::new(request_id, latest_render_batch_index, frame_counter)
+                })
+                .update_at = Some(Instant::now());
+        });
+
+        let layout_samples = samples.clone();
+        let layout_handler = frame_clock.connect_layout(move |clock| {
+            let frame_counter = clock.frame_counter();
+            layout_samples
+                .borrow_mut()
+                .entry(frame_counter)
+                .or_insert_with(|| {
+                    FramePhaseSample::new(request_id, latest_render_batch_index, frame_counter)
+                })
+                .layout_at = Some(Instant::now());
+        });
+
+        let paint_samples = samples.clone();
+        let paint_handler = frame_clock.connect_paint(move |clock| {
+            let frame_counter = clock.frame_counter();
+            paint_samples
+                .borrow_mut()
+                .entry(frame_counter)
+                .or_insert_with(|| {
+                    FramePhaseSample::new(request_id, latest_render_batch_index, frame_counter)
+                })
+                .paint_at = Some(Instant::now());
+        });
+
+        let after_samples = samples.clone();
+        let after_session_id = session_id.clone();
+        let after_handler = frame_clock.connect_after_paint(move |clock| {
+            let frame_counter = clock.frame_counter();
+            let mut samples = after_samples.borrow_mut();
+            let sample = samples.entry(frame_counter).or_insert_with(|| {
+                FramePhaseSample::new(request_id, latest_render_batch_index, frame_counter)
+            });
+            sample.after_paint_at = Some(Instant::now());
+            if let Some(deltas) = sample.deltas() {
+                tracing::debug!(
+                    request_id = deltas.request_id,
+                    session_id = after_session_id.as_deref(),
+                    render_batch_index = deltas.render_batch_index,
+                    frame_counter = deltas.frame_counter,
+                    before_paint_to_update_us = deltas.before_paint_to_update_us,
+                    update_to_layout_us = deltas.update_to_layout_us,
+                    layout_to_paint_us = deltas.layout_to_paint_us,
+                    paint_to_after_paint_us = deltas.paint_to_after_paint_us,
+                    before_paint_to_after_paint_us = deltas.before_paint_to_after_paint_us,
+                    update_to_after_paint_us = deltas.update_to_after_paint_us,
+                    "Session detail issue146 frame clock phase measured"
+                );
+            }
+            samples.remove(&(frame_counter - 120));
+        });
+
+        if let Some(probe_window) = self.probe_window.as_mut()
+            && probe_window.request_id == request_id
+        {
+            probe_window
+                .frame_signal_handlers
+                .push((frame_clock.clone(), before_handler));
+            probe_window
+                .frame_signal_handlers
+                .push((frame_clock.clone(), update_handler));
+            probe_window
+                .frame_signal_handlers
+                .push((frame_clock.clone(), layout_handler));
+            probe_window
+                .frame_signal_handlers
+                .push((frame_clock.clone(), paint_handler));
+            probe_window
+                .frame_signal_handlers
+                .push((frame_clock, after_handler));
         }
     }
 

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -1,6 +1,7 @@
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::path::PathBuf;
+use std::rc::Rc;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -138,6 +139,74 @@ struct RenderBatchBreakdown {
     schedule_gap: Duration,
     row_build_duration: Duration,
     logged: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FramePhaseDeltas {
+    request_id: u64,
+    render_batch_index: usize,
+    frame_counter: i64,
+    before_paint_to_update_us: Option<u128>,
+    update_to_layout_us: Option<u128>,
+    layout_to_paint_us: Option<u128>,
+    paint_to_after_paint_us: Option<u128>,
+    before_paint_to_after_paint_us: Option<u128>,
+    update_to_after_paint_us: Option<u128>,
+}
+
+#[derive(Debug, Clone)]
+struct FramePhaseSample {
+    request_id: u64,
+    render_batch_index: usize,
+    frame_counter: i64,
+    before_paint_at: Option<Instant>,
+    update_at: Option<Instant>,
+    layout_at: Option<Instant>,
+    paint_at: Option<Instant>,
+    after_paint_at: Option<Instant>,
+}
+
+impl FramePhaseSample {
+    fn new(request_id: u64, render_batch_index: usize, frame_counter: i64) -> Self {
+        Self {
+            request_id,
+            render_batch_index,
+            frame_counter,
+            before_paint_at: None,
+            update_at: None,
+            layout_at: None,
+            paint_at: None,
+            after_paint_at: None,
+        }
+    }
+
+    fn delta_us(start: Option<Instant>, end: Option<Instant>) -> Option<u128> {
+        match (start, end) {
+            (Some(start), Some(end)) => Some(end.duration_since(start).as_micros()),
+            _ => None,
+        }
+    }
+
+    fn deltas(&self) -> Option<FramePhaseDeltas> {
+        if self.after_paint_at.is_none() {
+            return None;
+        }
+
+        Some(FramePhaseDeltas {
+            request_id: self.request_id,
+            render_batch_index: self.render_batch_index,
+            frame_counter: self.frame_counter,
+            before_paint_to_update_us: Self::delta_us(self.before_paint_at, self.update_at),
+            update_to_layout_us: Self::delta_us(self.update_at, self.layout_at),
+            layout_to_paint_us: Self::delta_us(self.layout_at, self.paint_at),
+            paint_to_after_paint_us: Self::delta_us(self.paint_at, self.after_paint_at),
+            before_paint_to_after_paint_us: Self::delta_us(
+                self.before_paint_at,
+                self.after_paint_at,
+            ),
+            update_to_after_paint_us: Self::delta_us(self.update_at, self.after_paint_at),
+        })
+    }
 }
 
 impl RenderRowBuildTotals {
@@ -2587,6 +2656,59 @@ mod tests {
 
     use relm4::{Component, ComponentController};
     use rusqlite::{Connection, params};
+
+    #[test]
+    fn frame_phase_sample_reports_all_deltas_when_all_phases_exist() {
+        let mut sample = FramePhaseSample::new(42, 7, 3);
+        sample.before_paint_at = Some(Instant::now());
+        sample.update_at = sample
+            .before_paint_at
+            .map(|t| t + Duration::from_micros(10));
+        sample.layout_at = sample
+            .before_paint_at
+            .map(|t| t + Duration::from_micros(30));
+        sample.paint_at = sample
+            .before_paint_at
+            .map(|t| t + Duration::from_micros(70));
+        sample.after_paint_at = sample
+            .before_paint_at
+            .map(|t| t + Duration::from_micros(100));
+
+        let deltas = sample
+            .deltas()
+            .expect("all phase timestamps should produce deltas");
+
+        assert_eq!(deltas.request_id, 42);
+        assert_eq!(deltas.render_batch_index, 7);
+        assert_eq!(deltas.frame_counter, 3);
+        assert_eq!(deltas.before_paint_to_update_us, Some(10));
+        assert_eq!(deltas.update_to_layout_us, Some(20));
+        assert_eq!(deltas.layout_to_paint_us, Some(40));
+        assert_eq!(deltas.paint_to_after_paint_us, Some(30));
+        assert_eq!(deltas.before_paint_to_after_paint_us, Some(100));
+        assert_eq!(deltas.update_to_after_paint_us, Some(90));
+    }
+
+    #[test]
+    fn frame_phase_sample_reports_fallback_delta_without_before_paint() {
+        let mut sample = FramePhaseSample::new(11, 2, 9);
+        let started_at = Instant::now();
+        sample.update_at = Some(started_at);
+        sample.layout_at = Some(started_at + Duration::from_micros(15));
+        sample.paint_at = Some(started_at + Duration::from_micros(45));
+        sample.after_paint_at = Some(started_at + Duration::from_micros(60));
+
+        let deltas = sample
+            .deltas()
+            .expect("update through after-paint should produce fallback deltas");
+
+        assert_eq!(deltas.before_paint_to_update_us, None);
+        assert_eq!(deltas.before_paint_to_after_paint_us, None);
+        assert_eq!(deltas.update_to_layout_us, Some(15));
+        assert_eq!(deltas.layout_to_paint_us, Some(30));
+        assert_eq!(deltas.paint_to_after_paint_us, Some(15));
+        assert_eq!(deltas.update_to_after_paint_us, Some(60));
+    }
 
     fn build_test_session(
         first_prompt: Option<&str>,

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -161,6 +161,13 @@ impl SimpleComponent for Sidebar {
                 }
             }
             SidebarMsg::AiAssistantToggled(tool, active) => {
+                tracing::debug!(
+                    component = "Sidebar",
+                    message_variant = "SidebarMsg::AiAssistantToggled",
+                    tool = ?tool,
+                    active,
+                    "Session detail issue146 neighboring owner event"
+                );
                 match tool {
                     AiAssistant::ClaudeCode => self.claude_enabled = active,
                     AiAssistant::OpenCode => self.opencode_enabled = active,
@@ -171,6 +178,12 @@ impl SimpleComponent for Sidebar {
                 self.emit_filters_changed(&sender);
             }
             SidebarMsg::ProjectSelected(project_filter) => {
+                tracing::debug!(
+                    component = "Sidebar",
+                    message_variant = "SidebarMsg::ProjectSelected",
+                    project_filter = ?project_filter,
+                    "Session detail issue146 neighboring owner event"
+                );
                 if self.selected_project_filter != project_filter {
                     self.selected_project_filter = project_filter;
                     if !self.rebuilding_projects {
@@ -186,6 +199,17 @@ impl SimpleComponent for Sidebar {
                 show_unassigned,
                 selected_filter,
             } => {
+                tracing::debug!(
+                    component = "Sidebar",
+                    message_variant = "SidebarMsg::ProjectsLoaded",
+                    project_count = projects.len(),
+                    all_sessions_count,
+                    unassigned_count,
+                    pinned_count,
+                    show_unassigned,
+                    selected_filter = ?selected_filter,
+                    "Session detail issue146 neighboring owner event"
+                );
                 self.selected_project_filter = selected_filter;
                 self.rebuilding_projects = true;
                 self.rebuild_project_rows(


### PR DESCRIPTION
## Summary
- add temporary instrumentation used to identify the owner of the issue 146 session-detail freeze
- include the measured investigation report in `docs/reports/2026-05-10-session-detail-issue-146-post-drop-investigation.md`
- keep this PR for archive/reference only; it is not intended to be merged as-is

## Verification
- `cargo test --all --no-fail-fast`
- native release measurement runs captured in `target/issue146-*.log`
- focused Sysprof capture recorded in `target/issue146.syscap`