### PR TITLE
fix: tune session detail transcript batching

### DIFF
--- a/docs/reports/2026-05-13-session-detail-issue-132-batching-verification.md
+++ b/docs/reports/2026-05-13-session-detail-issue-132-batching-verification.md
@@ -8,34 +8,34 @@
 - Patch configuration: `RENDER_BATCH_SIZE = 1`, GTK tick callback scheduling, `RENDER_BATCH_WATCHDOG_MS = 100`
 - Baseline: `docs/reports/2026-05-10-session-detail-issue-146-post-drop-investigation.md` reported largest frame spans of `1 305 530–1 325 982 us` and schedule gaps of `1 307–1 330 ms` with `RENDER_BATCH_SIZE = 3`.
 - Runs captured: 3 cold app restarts against the same reference session.
-- Probe origin: temporary instrumentation re-derived from PR #150 (`SessionDetailProbeWindow`, frame-clock `before/update/layout/paint/after_paint` handlers, idle/tick post-drop logging, 16 ms heartbeat). Removed in the follow-up commit after this report was committed.
-- Capture command per run: `RUST_LOG=sessions_chronicle=debug ~/.local/bin/sessions-chronicle 2>&1 | tee target/issue132-run-N.log`
-- Aggregation: `update_to_layout_us` extracted from every `Session detail issue132 frame clock phase measured` line during the probe window; `max_schedule_gap_ms` and `heartbeat_gap_ms` extracted from the matching probe lines.
+- Probe origin: corrected temporary rerun probe added locally for this measurement pass. Unlike the superseded report revision, it logs exactly one frame-clock phase sample per render batch: the first frame after each post-drop batch.
+- Capture command per run: `SC_ISSUE132_PROBE=1 SC_OPEN_SESSION_ID=019dc51a-f0cd-79c1-ba79-45fedac889c2 RUST_LOG=sessions_chronicle=debug ~/.local/bin/sessions-chronicle > target/issue132-rerun-fixed-N.log 2>&1`
+- Aggregation: `update_to_layout_us` extracted only from `Session detail issue132 next frame phase measured` lines. Each such line is one batch sample, so the median and p95 are now truly `per batch`, matching the issue #132 design AC.
+- Secondary-signal scope: this corrected rerun targets the AC metric (`update_to_layout_us` per batch) and `max_schedule_gap_ms`. The earlier `heartbeat_gap_ms` side signal was not re-collected in this rerun.
 
 ## Results
 
-| run | frames | median_update_to_layout_us | p95_update_to_layout_us | max_update_to_layout_us | max_schedule_gap_ms | heartbeat_gap_samples_over_200_ms | max_heartbeat_gap_ms | notes |
-| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
-| 1 | 142 | 331 | 648 000 | 690 201 | 706 | 12 | 707 | First cold open after install. |
-| 2 | 87 | 41 546 | 654 632 | 687 314 | 698 | 12 | 694 | Median raised by fewer total frames captured before close. |
-| 3 | 144 | 767 | 645 911 | 683 109 | 695 | 12 | 695 | Matches run 1 shape. |
+| run | batches | median_update_to_layout_us | p95_update_to_layout_us | max_update_to_layout_us | max_schedule_gap_ms | notes |
+| --- | ---: | ---: | ---: | ---: | ---: | --- |
+| 1 | 33 | 7 734 | 709 025 | 716 665 | 730 | Corrected rerun using one next-frame sample per batch. |
+| 2 | 33 | 7 943 | 723 520 | 726 530 | 741 | Same shape as run 1, slightly higher p95 and max gap. |
+| 3 | 33 | 7 738 | 721 154 | 742 687 | 754 | Same median band; largest max gap of the three reruns. |
 
 ## Decision
 
-The measured medians meet the issue #132 acceptance criterion:
+This corrected rerun supersedes the earlier report revision that aggregated every frame inside the probe window. With one `update_to_layout_us` sample per render batch, the measured medians meet the issue #132 acceptance criterion:
 
-- All three medians of `update_to_layout_us` are well below `100 000 us` (0.3 ms / 41.5 ms / 0.8 ms vs. 100 ms target).
-- `max_schedule_gap_ms` collapsed from the `1 307–1 330 ms` baseline to `695–706 ms`, a measurable reduction.
-- `heartbeat_gap_ms` no longer reaches the baseline `1 307–1 330 ms` range; the largest sample is now `694–707 ms`. Spikes above 200 ms still occur (12 per run) but are clearly reduced in both magnitude and likely cause: they cluster around the same `~700 ms` frame stall that the p95 of `update_to_layout_us` also captures.
+- All three medians of `update_to_layout_us` are well below `100 000 us` (7.7 ms / 7.9 ms / 7.7 ms vs. 100 ms target).
+- `max_schedule_gap_ms` still improves materially versus the `1 307–1 330 ms` baseline, landing at `730–754 ms` across the corrected reruns.
+- The residual stall is still visible in the tail: p95 `update_to_layout_us` remains `709 025–723 520 us`, and max per-batch samples remain `716 665–742 687 us`.
 
 **Outcome:** AC met. Merge PR #151 and close #132.
 
-The remaining `~700 ms` p95 layout stall is the next floor; it is the expected residual from non-virtualised `gtk::ListBox` doing full layout passes as rows continue to mount. Issue #134 (virtualisation / `TypedListView` migration) is the natural follow-up and should be updated with this measured floor so the virtualisation work picks up from a quantified baseline.
+The remaining `~0.71–0.74 s` p95 / max next-frame layout stall is the next floor. It is still consistent with non-virtualised `gtk::ListBox` doing expensive full layout passes as rows continue to mount. Issue #134 (virtualisation / `TypedListView` migration) remains the natural follow-up and should use this corrected floor, not the earlier all-frames aggregation, as its baseline.
 
 ## Validation
 
 - `cargo fmt --all -- --check` passed.
-- `cargo clippy --all -- -D warnings` passed.
-- `cargo test --all --no-fail-fast` passed.
+- `cargo check --bin sessions-chronicle` passed.
 - `meson install -C builddir` passed.
-- Probe instrumentation will be reverted in the commit that follows this report; PR #151 stays at the production patch without the temporary probes.
+- Corrected rerun logs captured in `target/issue132-rerun-fixed-{1,2,3}.log`.

--- a/docs/reports/2026-05-13-session-detail-issue-132-batching-verification.md
+++ b/docs/reports/2026-05-13-session-detail-issue-132-batching-verification.md
@@ -1,0 +1,41 @@
+# Session Detail Issue 132 Batching Verification Report
+
+## Protocol
+
+- Reference session: `019dc51a-f0cd-79c1-ba79-45fedac889c2`
+- Build profile: `release`
+- Run mode: `native ~/.local/bin/sessions-chronicle`
+- Patch configuration: `RENDER_BATCH_SIZE = 1`, GTK tick callback scheduling, `RENDER_BATCH_WATCHDOG_MS = 100`
+- Baseline: `docs/reports/2026-05-10-session-detail-issue-146-post-drop-investigation.md` reported largest frame spans of `1 305 530–1 325 982 us` and schedule gaps of `1 307–1 330 ms` with `RENDER_BATCH_SIZE = 3`.
+- Runs captured: 3 cold app restarts against the same reference session.
+- Probe origin: temporary instrumentation re-derived from PR #150 (`SessionDetailProbeWindow`, frame-clock `before/update/layout/paint/after_paint` handlers, idle/tick post-drop logging, 16 ms heartbeat). Removed in the follow-up commit after this report was committed.
+- Capture command per run: `RUST_LOG=sessions_chronicle=debug ~/.local/bin/sessions-chronicle 2>&1 | tee target/issue132-run-N.log`
+- Aggregation: `update_to_layout_us` extracted from every `Session detail issue132 frame clock phase measured` line during the probe window; `max_schedule_gap_ms` and `heartbeat_gap_ms` extracted from the matching probe lines.
+
+## Results
+
+| run | frames | median_update_to_layout_us | p95_update_to_layout_us | max_update_to_layout_us | max_schedule_gap_ms | heartbeat_gap_samples_over_200_ms | max_heartbeat_gap_ms | notes |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| 1 | 142 | 331 | 648 000 | 690 201 | 706 | 12 | 707 | First cold open after install. |
+| 2 | 87 | 41 546 | 654 632 | 687 314 | 698 | 12 | 694 | Median raised by fewer total frames captured before close. |
+| 3 | 144 | 767 | 645 911 | 683 109 | 695 | 12 | 695 | Matches run 1 shape. |
+
+## Decision
+
+The measured medians meet the issue #132 acceptance criterion:
+
+- All three medians of `update_to_layout_us` are well below `100 000 us` (0.3 ms / 41.5 ms / 0.8 ms vs. 100 ms target).
+- `max_schedule_gap_ms` collapsed from the `1 307–1 330 ms` baseline to `695–706 ms`, a measurable reduction.
+- `heartbeat_gap_ms` no longer reaches the baseline `1 307–1 330 ms` range; the largest sample is now `694–707 ms`. Spikes above 200 ms still occur (12 per run) but are clearly reduced in both magnitude and likely cause: they cluster around the same `~700 ms` frame stall that the p95 of `update_to_layout_us` also captures.
+
+**Outcome:** AC met. Merge PR #151 and close #132.
+
+The remaining `~700 ms` p95 layout stall is the next floor; it is the expected residual from non-virtualised `gtk::ListBox` doing full layout passes as rows continue to mount. Issue #134 (virtualisation / `TypedListView` migration) is the natural follow-up and should be updated with this measured floor so the virtualisation work picks up from a quantified baseline.
+
+## Validation
+
+- `cargo fmt --all -- --check` passed.
+- `cargo clippy --all -- -D warnings` passed.
+- `cargo test --all --no-fail-fast` passed.
+- `meson install -C builddir` passed.
+- Probe instrumentation will be reverted in the commit that follows this report; PR #151 stays at the production patch without the temporary probes.

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -2611,6 +2611,8 @@ mod tests {
     use relm4::{Component, ComponentController};
     use rusqlite::{Connection, params};
 
+    const TRANSCRIPT_BATCH_TEST_GRACE: Duration = Duration::from_millis(125);
+
     fn build_test_session(
         first_prompt: Option<&str>,
         token_usage: Option<crate::models::TokenUsage>,
@@ -2662,20 +2664,38 @@ mod tests {
     ) {
         let context = gtk::glib::MainContext::default();
         let deadline = std::time::Instant::now() + timeout;
+        let mut pending_batch_seen_at: Option<(u64, std::time::Instant)> = None;
         while std::time::Instant::now() < deadline {
             if condition() {
                 return;
             }
 
-            let pending_request_id = controller
-                .state()
-                .get()
-                .model
-                .pending_render_batch
-                .as_ref()
-                .map(|batch| batch.request_id);
-            if let Some(request_id) = pending_request_id {
-                controller.emit(SessionDetailMsg::RenderNextTranscriptBatch { request_id });
+            let pending_request_id = {
+                let parts = controller.state().get();
+                parts
+                    .model
+                    .pending_render_batch
+                    .as_ref()
+                    .map(|batch| batch.request_id)
+            };
+            match pending_request_id {
+                Some(request_id) => {
+                    let now = std::time::Instant::now();
+                    let observed_at = match pending_batch_seen_at {
+                        Some((seen_request_id, observed_at)) if seen_request_id == request_id => {
+                            observed_at
+                        }
+                        _ => {
+                            pending_batch_seen_at = Some((request_id, now));
+                            now
+                        }
+                    };
+
+                    if now.duration_since(observed_at) >= TRANSCRIPT_BATCH_TEST_GRACE {
+                        controller.emit(SessionDetailMsg::RenderNextTranscriptBatch { request_id });
+                    }
+                }
+                None => pending_batch_seen_at = None,
             }
 
             if !context.iteration(false) {
@@ -3207,6 +3227,17 @@ fn synthetic_measurement(input: &str) -> String {\n\
             session: Box::new(build_test_session(None, None, 0, 0, 0)),
             search_query: None,
         });
+
+        pump_main_context(|| {
+            let parts = controller.state().get();
+            parts.model.messages.len() > 0
+        });
+
+        {
+            let parts = controller.state().get();
+            assert!(parts.model.pending_render_batch.is_some());
+            assert!(parts.model.messages.len() < INITIAL_PAGE_SIZE);
+        }
 
         pump_main_context_draining_transcript_batches(&controller, Duration::from_secs(5), || {
             let parts = controller.state().get();

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -1,6 +1,7 @@
 use std::cell::Cell;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::path::PathBuf;
+use std::rc::Rc;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -30,8 +31,10 @@ use crate::ui::transcript_row::{
 const INITIAL_PAGE_SIZE: usize = 75;
 const NEXT_PAGE_SIZE: usize = 100;
 const PREVIEW_LEN: usize = 2000;
-const RENDER_BATCH_SIZE: usize = 3;
-const RENDER_BATCH_DELAY_MS: u64 = 16;
+// Every mounted row participates in transcript container Layout, so per-batch
+// row count directly scales the next frame's GTK layout cost.
+const RENDER_BATCH_SIZE: usize = 1;
+const RENDER_BATCH_WATCHDOG_MS: u64 = 100;
 const DEFERRED_FIRST_PAGE_LOAD_DELAY_MS: u64 = 250;
 const DEFERRED_CLEAR_DELAY_MS: u64 = 250;
 
@@ -45,6 +48,7 @@ pub struct SessionDetail {
     session: Option<Session>,
     first_page_load_started_at: Option<Instant>,
     messages: FactoryVecDeque<TranscriptRow>,
+    transcript_render_widget: gtk::Widget,
     initial_page_size: usize,
     page_size: usize,
     preview_len: usize,
@@ -860,6 +864,7 @@ impl Component for SessionDetail {
                 },
             });
 
+        let transcript_render_widget = messages.widget().clone().upcast::<gtk::Widget>();
         let db_path = Arc::new(db_path);
         let inspector = ToolInspectorPane::builder()
             .launch(db_path.clone())
@@ -874,6 +879,7 @@ impl Component for SessionDetail {
             session: None,
             first_page_load_started_at: None,
             messages,
+            transcript_render_widget,
             initial_page_size: INITIAL_PAGE_SIZE,
             page_size: NEXT_PAGE_SIZE,
             preview_len: PREVIEW_LEN,
@@ -1727,8 +1733,25 @@ impl SessionDetail {
 
     fn schedule_transcript_render_batch(&self, sender: &ComponentSender<Self>, request_id: u64) {
         let input_sender = sender.input_sender().clone();
-        glib::timeout_add_local_once(Duration::from_millis(RENDER_BATCH_DELAY_MS), move || {
-            let _ = input_sender.send(SessionDetailMsg::RenderNextTranscriptBatch { request_id });
+        let fired = Rc::new(Cell::new(false));
+
+        let fired_tick = fired.clone();
+        let input_tick = input_sender.clone();
+        self.transcript_render_widget
+            .add_tick_callback(move |_, _| {
+                if !fired_tick.replace(true) {
+                    let _ =
+                        input_tick.send(SessionDetailMsg::RenderNextTranscriptBatch { request_id });
+                }
+                glib::ControlFlow::Break
+            });
+
+        let fired_watchdog = fired.clone();
+        glib::timeout_add_local_once(Duration::from_millis(RENDER_BATCH_WATCHDOG_MS), move || {
+            if !fired_watchdog.replace(true) {
+                let _ =
+                    input_sender.send(SessionDetailMsg::RenderNextTranscriptBatch { request_id });
+            }
         });
     }
 
@@ -2632,12 +2655,27 @@ mod tests {
         }
     }
 
-    fn pump_main_context_for(timeout: Duration, condition: impl Fn() -> bool) {
+    fn pump_main_context_draining_transcript_batches(
+        controller: &impl ComponentController<SessionDetail>,
+        timeout: Duration,
+        condition: impl Fn() -> bool,
+    ) {
         let context = gtk::glib::MainContext::default();
         let deadline = std::time::Instant::now() + timeout;
         while std::time::Instant::now() < deadline {
             if condition() {
                 return;
+            }
+
+            let pending_request_id = controller
+                .state()
+                .get()
+                .model
+                .pending_render_batch
+                .as_ref()
+                .map(|batch| batch.request_id);
+            if let Some(request_id) = pending_request_id {
+                controller.emit(SessionDetailMsg::RenderNextTranscriptBatch { request_id });
             }
 
             if !context.iteration(false) {
@@ -2784,7 +2822,7 @@ fn synthetic_measurement(input: &str) -> String {\n\
             search_query: search_query.map(str::to_string),
         });
 
-        pump_main_context(|| {
+        pump_main_context_draining_transcript_batches(&controller, Duration::from_secs(5), || {
             let parts = controller.state().get();
             parts.model.pending_render_batch.is_none() && parts.model.last_render_metrics.is_some()
         });
@@ -2807,7 +2845,7 @@ fn synthetic_measurement(input: &str) -> String {\n\
             search_query: None,
         });
 
-        pump_main_context_for(Duration::from_secs(30), || {
+        pump_main_context_draining_transcript_batches(&controller, Duration::from_secs(30), || {
             let parts = controller.state().get();
             parts.model.pending_render_batch.is_none() && parts.model.last_render_metrics.is_some()
         });
@@ -3075,7 +3113,7 @@ fn synthetic_measurement(input: &str) -> String {\n\
             search_query: None,
         });
 
-        pump_main_context(|| {
+        pump_main_context_draining_transcript_batches(&controller, Duration::from_secs(5), || {
             let parts = controller.state().get();
             parts.model.pending_render_batch.is_none()
                 && parts.model.messages.len() == INITIAL_PAGE_SIZE
@@ -3130,7 +3168,7 @@ fn synthetic_measurement(input: &str) -> String {\n\
             assert!(parts.model.has_more_messages);
         }
 
-        pump_main_context(|| {
+        pump_main_context_draining_transcript_batches(&controller, Duration::from_secs(5), || {
             let parts = controller.state().get();
             parts.model.pending_render_batch.is_none()
                 && parts.model.messages.len() == INITIAL_PAGE_SIZE
@@ -3149,7 +3187,7 @@ fn synthetic_measurement(input: &str) -> String {\n\
             assert!(parts.model.messages.len() < INITIAL_PAGE_SIZE + 5);
         }
 
-        pump_main_context(|| {
+        pump_main_context_draining_transcript_batches(&controller, Duration::from_secs(5), || {
             let parts = controller.state().get();
             parts.model.pending_render_batch.is_none()
                 && parts.model.messages.len() == INITIAL_PAGE_SIZE + 5
@@ -3170,7 +3208,7 @@ fn synthetic_measurement(input: &str) -> String {\n\
             search_query: None,
         });
 
-        pump_main_context(|| {
+        pump_main_context_draining_transcript_batches(&controller, Duration::from_secs(5), || {
             let parts = controller.state().get();
             parts.model.pending_render_batch.is_none()
                 && parts.model.messages.len() == INITIAL_PAGE_SIZE
@@ -3552,7 +3590,7 @@ fn synthetic_measurement(input: &str) -> String {\n\
             session: Box::new(build_test_session(None, None, 0, 0, 0)),
             search_query: None,
         });
-        pump_main_context(|| {
+        pump_main_context_draining_transcript_batches(&controller, Duration::from_secs(5), || {
             let parts = controller.state().get();
             parts.model.pending_render_batch.is_none()
                 && parts.model.loaded_count == INITIAL_PAGE_SIZE
@@ -3561,7 +3599,7 @@ fn synthetic_measurement(input: &str) -> String {\n\
         controller.emit(SessionDetailMsg::UpdateSearchQuery(Some(
             "needle".to_string(),
         )));
-        pump_main_context(|| {
+        pump_main_context_draining_transcript_batches(&controller, Duration::from_secs(5), || {
             let parts = controller.state().get();
             parts.model.match_positions.len() == 2
                 && parts.model.pending_render_batch.is_none()
@@ -3629,7 +3667,7 @@ fn synthetic_measurement(input: &str) -> String {\n\
             session: Box::new(build_test_session(None, None, 0, 0, 0)),
             search_query: None,
         });
-        pump_main_context(|| {
+        pump_main_context_draining_transcript_batches(&controller, Duration::from_secs(5), || {
             let parts = controller.state().get();
             parts.model.pending_render_batch.is_none()
                 && parts.model.loaded_count == INITIAL_PAGE_SIZE
@@ -3678,7 +3716,7 @@ fn synthetic_measurement(input: &str) -> String {\n\
             positions: vec![MatchPosition { item_index: 70 }],
         });
 
-        pump_main_context(|| {
+        pump_main_context_draining_transcript_batches(&controller, Duration::from_secs(5), || {
             let parts = controller.state().get();
             parts.model.pending_render_batch.is_none() && !parts.model.loading_jump
         });
@@ -3703,13 +3741,17 @@ fn synthetic_measurement(input: &str) -> String {\n\
             session: Box::new(build_test_session(None, None, 0, 0, 0)),
             search_query: Some("needle".to_string()),
         });
-        pump_main_context(|| {
+        pump_main_context_draining_transcript_batches(&controller, Duration::from_secs(5), || {
             let parts = controller.state().get();
-            parts.model.match_positions.len() == 2 && !parts.model.loading_jump
+            parts.model.match_positions.len() == 2
+                && parts.model.pending_render_batch.is_none()
+                && !parts.model.loading_jump
+                && parts.model.current_match == 0
+                && parts.model.display_targets_by_item_index.contains_key(&10)
         });
 
         controller.emit(SessionDetailMsg::NextMatch);
-        pump_main_context(|| {
+        pump_main_context_draining_transcript_batches(&controller, Duration::from_secs(5), || {
             let parts = controller.state().get();
             parts.model.loaded_count == INITIAL_PAGE_SIZE + NEXT_PAGE_SIZE
                 && parts.model.pending_render_batch.is_none()

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -2657,6 +2657,11 @@ mod tests {
         }
     }
 
+    // Headless tests have no frame clock, so `add_tick_callback` never fires;
+    // the production watchdog still does. We let the watchdog drive the first
+    // ~100 ms (preserving real scheduler coverage), then once
+    // `TRANSCRIPT_BATCH_TEST_GRACE` elapses for the same `request_id` we drive
+    // remaining items on every loop iteration so the batch drains quickly.
     fn pump_main_context_draining_transcript_batches(
         controller: &impl ComponentController<SessionDetail>,
         timeout: Duration,


### PR DESCRIPTION
## Summary
- reduce `SessionDetail` transcript render batches from 3 rows to 1 row and schedule follow-up batches from the GTK frame clock
- add a 100 ms watchdog fallback so rendering still progresses when the frame clock is inactive
- update headless GTK tests so batching stays deterministic without masking the new scheduler path

Closes #132 

## Test Plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test --all --no-fail-fast`
- [x] `meson install -C builddir`
- [x] Manual real-session verification/report for issue #132