### PR TITLE
Migrate session detail transcript to typed ListView

### DIFF
--- a/data/resources/style.css
+++ b/data/resources/style.css
@@ -177,12 +177,6 @@
   min-height: 0;
 }
 
-.tool-call-group-header > flowboxchild {
-  padding: 0;
-  min-width: 0;
-  min-height: 0;
-}
-
 .tool-call-group-arrow {
   margin-top: 4px;
 }

--- a/data/resources/style.css
+++ b/data/resources/style.css
@@ -15,6 +15,15 @@
   margin-bottom: 8px;
 }
 
+/* Transcript list blends into the window background so the gaps between
+   message rows match the message-row backdrop in light and dark mode.
+   A plain ListView otherwise paints @view_bg_color, which is darker than
+   the window background in dark mode. */
+.transcript-list,
+.transcript-list > row {
+  background-color: transparent;
+}
+
 /* Role-specific accent colors */
 .role-user {
   border-left-color: #3584e4;

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -988,6 +988,15 @@ pub fn load_transcript_items(
     Ok(items)
 }
 
+/// Load all ordered transcript items for a session with preview truncation.
+pub fn load_all_transcript_items(
+    db_path: &Path,
+    session_id: &str,
+    preview_len: i64,
+) -> Result<Vec<TranscriptItemRow>> {
+    load_transcript_items(db_path, session_id, i64::MAX, 0, preview_len)
+}
+
 /// Insert a tool call record (upsert by session_id + id).
 pub fn insert_tool_call(conn: &Connection, tc: &ToolCall, session_id: &str) -> Result<()> {
     conn.execute(

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -291,8 +291,8 @@ pub fn find_session_match_positions(
         return Ok(Vec::new());
     }
 
-    match find_session_match_positions_with_query(db, session_id, query) {
-        Ok(positions) => Ok(positions),
+    let matched_messages = match find_session_matched_messages(db, session_id, query) {
+        Ok(messages) => messages,
         Err(err) => {
             if let Some(sanitized) = sanitize_search_query(query) {
                 tracing::warn!(
@@ -300,15 +300,15 @@ pub fn find_session_match_positions(
                     sanitized,
                     err
                 );
-                match find_session_match_positions_with_query(db, session_id, &sanitized) {
-                    Ok(positions) => Ok(positions),
+                match find_session_matched_messages(db, session_id, &sanitized) {
+                    Ok(messages) => messages,
                     Err(retry_err) => {
                         tracing::warn!(
                             "Sanitized session detail search query failed '{}': {}",
                             sanitized,
                             retry_err
                         );
-                        Ok(Vec::new())
+                        return Ok(Vec::new());
                     }
                 }
             } else {
@@ -316,19 +316,44 @@ pub fn find_session_match_positions(
                     "Session detail search query failed and could not be sanitized: {}",
                     err
                 );
-                Ok(Vec::new())
+                return Ok(Vec::new());
             }
         }
+    };
+
+    // Expand each matching message into one position per highlighted
+    // occurrence, so the `X / Y` counter and Next/Previous step in lockstep
+    // with the spans the user sees. Occurrences are counted with the original
+    // query (never the sanitized FTS variant) to match the transcript
+    // highlighter exactly; a message that matches FTS but contains no literal
+    // occurrence contributes nothing, just as it shows no highlight.
+    let mut positions = Vec::new();
+    for message in matched_messages {
+        let occurrences =
+            crate::utils::text_match::count_case_insensitive_matches(&message.content, query);
+        for _ in 0..occurrences {
+            positions.push(MatchPosition {
+                item_index: message.item_index,
+            });
+        }
     }
+
+    Ok(positions)
 }
 
-fn find_session_match_positions_with_query(
+/// A transcript message item whose content matched the FTS query.
+struct MatchedMessage {
+    item_index: i64,
+    content: String,
+}
+
+fn find_session_matched_messages(
     db: &Connection,
     session_id: &str,
-    query: &str,
-) -> Result<Vec<MatchPosition>> {
+    fts_query: &str,
+) -> Result<Vec<MatchedMessage>> {
     let mut stmt = db.prepare(
-        "SELECT ti.item_index
+        "SELECT ti.item_index, m.content
          FROM messages_fts
          JOIN messages m ON m.id = messages_fts.rowid
          JOIN transcript_items ti
@@ -340,18 +365,19 @@ fn find_session_match_positions_with_query(
          ORDER BY ti.item_index ASC",
     )?;
 
-    let rows = stmt.query_map(rusqlite::params![query, session_id], |row| {
-        Ok(MatchPosition {
+    let rows = stmt.query_map(rusqlite::params![fts_query, session_id], |row| {
+        Ok(MatchedMessage {
             item_index: row.get(0)?,
+            content: row.get(1)?,
         })
     })?;
 
-    let mut positions = Vec::new();
+    let mut messages = Vec::new();
     for row in rows {
-        positions.push(row?);
+        messages.push(row?);
     }
 
-    Ok(positions)
+    Ok(messages)
 }
 
 fn search_sessions_with_query(

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -818,7 +818,6 @@ pub fn load_message_full_content(
 }
 
 /// Load message previews for a session with pagination and truncation.
-#[allow(dead_code)]
 pub fn load_message_previews_for_session(
     db_path: &Path,
     session_id: &str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod config;
 pub mod database;
-pub mod icon_names {
+mod icon_names {
     pub use shipped::*;
     include!(concat!(env!("OUT_DIR"), "/icon_names.rs"));
 }
@@ -8,7 +8,7 @@ pub mod models;
 pub mod parsers;
 pub mod project_resolver;
 pub mod session_sources;
-pub mod ui;
+mod ui;
 pub mod utils;
 
 // Re-export commonly used types

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,14 @@
 pub mod config;
 pub mod database;
+pub mod icon_names {
+    pub use shipped::*;
+    include!(concat!(env!("OUT_DIR"), "/icon_names.rs"));
+}
 pub mod models;
 pub mod parsers;
 pub mod project_resolver;
 pub mod session_sources;
+pub mod ui;
 pub mod utils;
 
 // Re-export commonly used types

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod config;
 pub mod database;
+#[allow(dead_code)]
 mod icon_names {
     pub use shipped::*;
     include!(concat!(env!("OUT_DIR"), "/icon_names.rs"));
@@ -8,6 +9,7 @@ pub mod models;
 pub mod parsers;
 pub mod project_resolver;
 pub mod session_sources;
+#[allow(dead_code)]
 mod ui;
 pub mod utils;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,16 +2,20 @@
 mod config;
 mod analytics_worker;
 mod app;
+#[allow(dead_code)]
 mod database;
+#[allow(dead_code)]
 mod icon_names {
     pub use shipped::*;
     include!(concat!(env!("OUT_DIR"), "/icon_names.rs"));
 }
 mod indexing_worker;
+#[allow(dead_code)]
 mod models;
 mod parsers;
 mod project_resolver;
 mod session_sources;
+#[allow(dead_code)]
 mod ui;
 mod utils;
 

--- a/src/ui/highlight.rs
+++ b/src/ui/highlight.rs
@@ -13,7 +13,7 @@ pub fn highlight_text(text: &str, query: &str) -> (String, usize) {
         return (pango_escape(text), 0);
     }
 
-    let matches = find_case_insensitive_matches_in_text(text, query);
+    let matches = crate::utils::text_match::find_case_insensitive_matches(text, query);
     let mut result = String::with_capacity(text.len() * 2);
     let mut pos = 0usize;
 
@@ -37,52 +37,6 @@ pub fn highlight_text(text: &str, query: &str) -> (String, usize) {
     result.push_str(&pango_escape(&text[pos..]));
 
     (result, matches.len())
-}
-
-fn fold_query_chars(query: &str) -> Vec<char> {
-    query.chars().flat_map(char::to_lowercase).collect()
-}
-
-pub fn find_case_insensitive_matches_in_text(text: &str, query: &str) -> Vec<(usize, usize)> {
-    let mut folded_units: Vec<(char, usize, usize)> = Vec::new();
-    for (start, ch) in text.char_indices() {
-        let end = start + ch.len_utf8();
-        for lower in ch.to_lowercase() {
-            folded_units.push((lower, start, end));
-        }
-    }
-
-    let query_chars = fold_query_chars(query);
-    find_case_insensitive_matches_in_folded_units(&folded_units, &query_chars)
-}
-
-fn find_case_insensitive_matches_in_folded_units(
-    folded_units: &[(char, usize, usize)],
-    query_chars: &[char],
-) -> Vec<(usize, usize)> {
-    if query_chars.is_empty() || folded_units.is_empty() || query_chars.len() > folded_units.len() {
-        return Vec::new();
-    }
-
-    let mut matches = Vec::new();
-    let mut i = 0usize;
-    while i + query_chars.len() <= folded_units.len() {
-        let is_match = folded_units[i..i + query_chars.len()]
-            .iter()
-            .zip(query_chars.iter())
-            .all(|((ch, _, _), q)| ch == q);
-
-        if is_match {
-            let start = folded_units[i].1;
-            let end = folded_units[i + query_chars.len() - 1].2;
-            matches.push((start, end));
-            i += query_chars.len();
-        } else {
-            i += 1;
-        }
-    }
-
-    matches
 }
 
 #[cfg(test)]

--- a/src/ui/markdown.rs
+++ b/src/ui/markdown.rs
@@ -950,7 +950,7 @@ fn apply_search_highlight(buffer: &impl IsA<gtk::TextBuffer>, query: &str) -> us
     let text = buffer.slice(&start, &end, false);
     let text_str = text.as_str();
 
-    let matches = crate::ui::highlight::find_case_insensitive_matches_in_text(text_str, query);
+    let matches = crate::utils::text_match::find_case_insensitive_matches(text_str, query);
     let count = matches.len();
 
     if count == 0 {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -13,4 +13,5 @@ pub mod tool_inspector_pane;
 pub mod tool_preview;
 pub mod tool_renderers;
 pub mod transcript_display;
+pub mod transcript_item_data;
 pub mod transcript_row;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -15,3 +15,4 @@ pub mod tool_renderers;
 pub mod transcript_display;
 pub mod transcript_item_data;
 pub mod transcript_row;
+pub mod typed_transcript_row;

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -2113,7 +2113,6 @@ impl SessionDetail {
         sender: &ComponentSender<Self>,
         request_id: u64,
         session_id: &str,
-        limit: usize,
         rows: Vec<crate::database::TranscriptItemRow>,
     ) {
         self.loading_first_page = false;
@@ -2228,7 +2227,7 @@ impl SessionDetail {
                     load_duration_ms,
                     "Loaded first transcript page"
                 );
-                self.apply_first_page_rows(sender, request_id, &session_id, limit, rows)
+                self.apply_first_page_rows(sender, request_id, &session_id, rows)
             }
             Ok(rows) => {
                 tracing::info!(

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -74,15 +74,6 @@ pub struct SessionDetail {
     inspector_open: bool,
 }
 
-fn toggle_typed_message_expanded(items: &[TranscriptItemData], item_index: usize) -> bool {
-    let Some(item) = items.iter().find(|item| item.item_index == item_index) else {
-        return false;
-    };
-
-    item.expanded.set(!item.expanded.get());
-    true
-}
-
 /// Resolved scroll destination for global search navigation.
 ///
 /// `display_index` addresses a top-level transcript row in the factory. When
@@ -2648,42 +2639,6 @@ mod tests {
             command_count,
             ending_status: crate::models::SessionEndingStatus::Clean,
         }
-    }
-
-    #[test]
-    fn toggle_typed_message_expanded_flips_matching_item_binding() {
-        let (sender, _receiver) = relm4::channel::<SessionDetailMsg>();
-        let item = TranscriptItemData::from_init(
-            TranscriptItemInit::Message(crate::ui::transcript_row::MessageItemInit {
-                item_index: 7,
-                transcript_item_index: 11,
-                preview: crate::models::MessagePreview {
-                    session_id: "session-1".to_string(),
-                    message_index: 4,
-                    role: crate::models::Role::Assistant,
-                    content_preview: "preview".to_string(),
-                    content_len: 42,
-                    timestamp: chrono::Utc::now(),
-                    model: Some("gpt-5.4".to_string()),
-                    reasoning_preview: crate::models::ReasoningPreview::default(),
-                },
-                highlight_query: None,
-                db_path: Arc::new(PathBuf::from("/tmp/session-detail-toggle.db")),
-            }),
-            sender,
-        );
-
-        assert!(!item.expanded.get());
-        assert!(toggle_typed_message_expanded(
-            std::slice::from_ref(&item),
-            7
-        ));
-        assert!(item.expanded.get());
-        assert!(!toggle_typed_message_expanded(
-            std::slice::from_ref(&item),
-            8
-        ));
-        assert!(item.expanded.get());
     }
 
     fn pump_main_context(condition: impl Fn() -> bool) {

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -40,7 +40,6 @@ pub struct SessionDetail {
     first_page_load_started_at: Option<Instant>,
     messages: TypedListView<TranscriptItemData, gtk::NoSelection>,
     transcript_render_widget: gtk::Widget,
-    initial_page_size: usize,
     preview_len: usize,
     loaded_count: usize,
     loading_first_page: bool,
@@ -153,8 +152,6 @@ pub enum SessionDetailCmd {
     TranscriptPageLoaded {
         request_id: u64,
         session_id: String,
-        offset: usize,
-        limit: usize,
         load_duration_ms: u128,
         result: Result<Vec<crate::database::TranscriptItemRow>, String>,
     },
@@ -172,8 +169,6 @@ impl std::fmt::Debug for SessionDetailCmd {
             Self::TranscriptPageLoaded {
                 request_id,
                 session_id,
-                offset,
-                limit,
                 load_duration_ms,
                 result,
             } => {
@@ -185,8 +180,6 @@ impl std::fmt::Debug for SessionDetailCmd {
                 f.debug_struct("TranscriptPageLoaded")
                     .field("request_id", request_id)
                     .field("session_id", session_id)
-                    .field("offset", offset)
-                    .field("limit", limit)
                     .field("load_duration_ms", load_duration_ms)
                     .field("result", &result_summary)
                     .finish()
@@ -675,7 +668,6 @@ impl Component for SessionDetail {
             first_page_load_started_at: None,
             messages,
             transcript_render_widget,
-            initial_page_size: 0,
             preview_len: PREVIEW_LEN,
             loaded_count: 0,
             loading_first_page: false,
@@ -857,13 +849,7 @@ impl Component for SessionDetail {
                         configured_delay_ms = DEFERRED_FIRST_PAGE_LOAD_DELAY_MS,
                         "Session detail deferred first page load started"
                     );
-                    self.spawn_transcript_page_load(
-                        &sender,
-                        request_id,
-                        session_id,
-                        0,
-                        self.initial_page_size,
-                    );
+                    self.spawn_transcript_page_load(&sender, request_id, session_id);
                 }
             }
             SessionDetailMsg::PrepareForNavigationBack => {
@@ -1396,21 +1382,6 @@ impl SessionDetail {
         targets
     }
 
-    fn remove_display_targets_for_items(&mut self, items: &[DisplayTranscriptItem]) {
-        for item in items {
-            match item {
-                DisplayTranscriptItem::Single(row) => {
-                    self.display_targets_by_item_index.remove(&row.item_index);
-                }
-                DisplayTranscriptItem::ToolBurst(burst) => {
-                    for row in &burst.rows {
-                        self.display_targets_by_item_index.remove(&row.item_index);
-                    }
-                }
-            }
-        }
-    }
-
     fn extend_display_targets(&mut self, targets: BTreeMap<i64, ScrollTarget>) {
         self.display_targets_by_item_index.extend(targets);
     }
@@ -1549,13 +1520,7 @@ impl SessionDetail {
                 },
             );
         } else {
-            self.spawn_transcript_page_load(
-                sender,
-                request_id,
-                session_id,
-                0,
-                self.initial_page_size,
-            );
+            self.spawn_transcript_page_load(sender, request_id, session_id);
         }
     }
 
@@ -1564,8 +1529,6 @@ impl SessionDetail {
         sender: &ComponentSender<Self>,
         request_id: u64,
         session_id: String,
-        offset: usize,
-        limit: usize,
     ) {
         let db_path = self.db_path.clone();
         let preview_len = self.preview_len as i64;
@@ -1579,8 +1542,6 @@ impl SessionDetail {
             SessionDetailCmd::TranscriptPageLoaded {
                 request_id,
                 session_id,
-                offset,
-                limit,
                 load_duration_ms,
                 result,
             }
@@ -1631,19 +1592,14 @@ impl SessionDetail {
         self.continue_pending_jump(sender);
     }
 
-    fn handle_transcript_page_error(&mut self, session_id: &str, offset: usize, err: String) {
+    fn handle_transcript_page_error(&mut self, session_id: &str, err: String) {
         tracing::error!(
-            "Failed to load transcript items for {} at offset {}: {}",
+            "Failed to load transcript items for {}: {}",
             session_id,
-            offset,
             err
         );
-
-        if offset == 0 {
-            self.clear_messages_safely_with_metrics("transcript_error");
-            self.loaded_count = 0;
-        }
-
+        self.clear_messages_safely_with_metrics("transcript_error");
+        self.loaded_count = 0;
         self.loading_first_page = false;
         self.pending_jump = None;
         self.loading_jump = false;
@@ -1657,7 +1613,6 @@ impl SessionDetail {
         let SessionDetailCmd::TranscriptPageLoaded {
             request_id,
             session_id,
-            offset,
             load_duration_ms,
             result,
             ..
@@ -1667,11 +1622,7 @@ impl SessionDetail {
         };
 
         if request_id != self.transcript_request_id {
-            tracing::debug!(
-                "Ignoring stale transcript page for session {} at offset {}",
-                session_id,
-                offset
-            );
+            tracing::debug!("Ignoring stale transcript page for session {}", session_id,);
             return;
         }
 
@@ -1681,9 +1632,8 @@ impl SessionDetail {
             .is_some_and(|session| session.id == session_id);
         if !active_session_matches {
             tracing::debug!(
-                "Ignoring transcript page for inactive session {} at offset {}",
+                "Ignoring transcript page for inactive session {}",
                 session_id,
-                offset
             );
             return;
         }
@@ -1699,7 +1649,7 @@ impl SessionDetail {
                 );
                 self.apply_first_page_rows(sender, request_id, &session_id, rows)
             }
-            Err(err) => self.handle_transcript_page_error(&session_id, offset, err),
+            Err(err) => self.handle_transcript_page_error(&session_id, err),
         }
     }
 

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -1,7 +1,6 @@
 use std::cell::Cell;
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
-use std::rc::Rc;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -20,22 +19,13 @@ use crate::ui::activity_bar::SessionActivityBar;
 use crate::ui::tool_inspector_pane::{
     ToolInspectorPane, ToolInspectorPaneMsg, ToolInspectorPaneOutput,
 };
-use crate::ui::transcript_display::{
-    DisplayTranscriptItem, group_transcript_rows, regroup_boundary, trailing_tool_call_rows,
-    trailing_tool_rows_from_display,
-};
+use crate::ui::transcript_display::{DisplayTranscriptItem, group_transcript_rows};
 use crate::ui::transcript_item_data::TranscriptItemData;
 use crate::ui::transcript_row::{
     TranscriptItemInit, TranscriptRowBuildKind, transcript_item_init_from_display_item,
 };
 
-const INITIAL_PAGE_SIZE: usize = 75;
-const NEXT_PAGE_SIZE: usize = 100;
 const PREVIEW_LEN: usize = 2000;
-// Every mounted row participates in transcript container Layout, so per-batch
-// row count directly scales the next frame's GTK layout cost.
-const RENDER_BATCH_SIZE: usize = 1;
-const RENDER_BATCH_WATCHDOG_MS: u64 = 100;
 const DEFERRED_FIRST_PAGE_LOAD_DELAY_MS: u64 = 250;
 const DEFERRED_CLEAR_DELAY_MS: u64 = 250;
 
@@ -51,16 +41,10 @@ pub struct SessionDetail {
     messages: TypedListView<TranscriptItemData, gtk::NoSelection>,
     transcript_render_widget: gtk::Widget,
     initial_page_size: usize,
-    page_size: usize,
     preview_len: usize,
     loaded_count: usize,
-    has_more_messages: bool,
     loading_first_page: bool,
-    loading_next_page: bool,
     transcript_request_id: u64,
-    pending_render_batch: Option<PendingRenderBatch>,
-    last_render_metrics: Option<RenderMetrics>,
-    pending_boundary_tool_rows: Vec<crate::database::TranscriptItemRow>,
     search_query: Option<String>,
     match_positions: Vec<crate::database::MatchPosition>,
     display_targets_by_item_index: BTreeMap<i64, ScrollTarget>,
@@ -90,158 +74,10 @@ struct PreparedTranscriptItems {
     display_targets_by_item_index: BTreeMap<i64, ScrollTarget>,
 }
 
-struct BoundaryAppendPlan {
-    replacement_items: Vec<DisplayTranscriptItem>,
-    rows: Vec<crate::database::TranscriptItemRow>,
-}
-
-struct PendingRenderBatch {
-    request_id: u64,
-    offset: usize,
-    source_row_count: usize,
-    total_items: usize,
-    rendered_items: usize,
-    batch_count: usize,
-    queued_at: Instant,
-    last_batch_completed_at: Option<Instant>,
-    total_push_duration: Duration,
-    max_push_duration: Duration,
-    max_schedule_gap: Duration,
-    row_build_totals: RenderRowBuildTotals,
-    row_build_count: usize,
-    worst_row_kind: Option<TranscriptRowBuildKind>,
-    worst_row_duration: Duration,
-    batch_breakdowns: Vec<RenderBatchBreakdown>,
-    item_render_batch_indices: std::collections::HashMap<usize, usize>,
-    row_kind_counts: RenderRowKindCounts,
-    items: VecDeque<TranscriptItemInit>,
-    first_page_load_to_factory_push_ms: Option<u128>,
-    push_complete: bool,
-}
-
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-struct RenderRowKindCounts {
-    message_count: usize,
-    tool_call_count: usize,
-    tool_burst_count: usize,
-    subagent_count: usize,
-}
-
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-struct RenderRowBuildTotals {
-    message_duration: Duration,
-    tool_call_duration: Duration,
-    tool_burst_duration: Duration,
-    subagent_duration: Duration,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct RenderBatchBreakdown {
-    render_batch_index: usize,
-    pushed_row_count: usize,
-    row_build_count: usize,
-    schedule_gap: Duration,
-    row_build_duration: Duration,
-    logged: bool,
-}
-
-impl RenderRowBuildTotals {
-    fn add(&mut self, kind: TranscriptRowBuildKind, duration: Duration) {
-        match kind {
-            TranscriptRowBuildKind::Message => self.message_duration += duration,
-            TranscriptRowBuildKind::ToolCall => self.tool_call_duration += duration,
-            TranscriptRowBuildKind::ToolBurst => self.tool_burst_duration += duration,
-            TranscriptRowBuildKind::Subagent => self.subagent_duration += duration,
-        }
-    }
-
-    fn total(&self) -> Duration {
-        self.message_duration
-            + self.tool_call_duration
-            + self.tool_burst_duration
-            + self.subagent_duration
-    }
-}
-
-fn render_metrics_for_batch(batch: &PendingRenderBatch, total_duration_ms: u128) -> RenderMetrics {
-    let total_row_build_duration_ms = batch.row_build_totals.total().as_millis();
-    let max_post_drop_residual_ms = batch
-        .batch_breakdowns
-        .iter()
-        .map(|b| b.schedule_gap.saturating_sub(b.row_build_duration))
-        .max()
-        .unwrap_or(Duration::ZERO)
-        .as_millis();
-
-    RenderMetrics {
-        offset: batch.offset,
-        source_row_count: batch.source_row_count,
-        display_item_count: batch.total_items,
-        batch_count: batch.batch_count,
-        total_duration_ms,
-        total_push_duration_ms: batch.total_push_duration.as_millis(),
-        max_push_duration_ms: batch.max_push_duration.as_millis(),
-        max_schedule_gap_ms: batch.max_schedule_gap.as_millis(),
-        message_build_duration_ms: batch.row_build_totals.message_duration.as_millis(),
-        tool_call_build_duration_ms: batch.row_build_totals.tool_call_duration.as_millis(),
-        tool_burst_build_duration_ms: batch.row_build_totals.tool_burst_duration.as_millis(),
-        subagent_build_duration_ms: batch.row_build_totals.subagent_duration.as_millis(),
-        total_row_build_duration_ms,
-        worst_row_kind: batch.worst_row_kind,
-        worst_row_build_duration_ms: batch.worst_row_duration.as_millis(),
-        max_post_drop_residual_ms,
-        first_page_load_to_factory_push_ms: batch.first_page_load_to_factory_push_ms,
-        message_count: batch.row_kind_counts.message_count,
-        tool_call_count: batch.row_kind_counts.tool_call_count,
-        tool_burst_count: batch.row_kind_counts.tool_burst_count,
-        subagent_count: batch.row_kind_counts.subagent_count,
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct RenderMetrics {
-    offset: usize,
-    source_row_count: usize,
-    display_item_count: usize,
-    batch_count: usize,
-    total_duration_ms: u128,
-    total_push_duration_ms: u128,
-    max_push_duration_ms: u128,
-    max_schedule_gap_ms: u128,
-    message_build_duration_ms: u128,
-    tool_call_build_duration_ms: u128,
-    tool_burst_build_duration_ms: u128,
-    subagent_build_duration_ms: u128,
-    total_row_build_duration_ms: u128,
-    worst_row_kind: Option<TranscriptRowBuildKind>,
-    worst_row_build_duration_ms: u128,
-    max_post_drop_residual_ms: u128,
-    first_page_load_to_factory_push_ms: Option<u128>,
-    message_count: usize,
-    tool_call_count: usize,
-    tool_burst_count: usize,
-    subagent_count: usize,
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct ClearMessagesMetrics {
     row_count_before: usize,
-    had_pending_render: bool,
     duration_ms: u128,
-}
-
-impl std::fmt::Debug for PendingRenderBatch {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("PendingRenderBatch")
-            .field("request_id", &self.request_id)
-            .field("offset", &self.offset)
-            .field("source_row_count", &self.source_row_count)
-            .field("total_items", &self.total_items)
-            .field("rendered_items", &self.rendered_items)
-            .field("batch_count", &self.batch_count)
-            .field("remaining_items", &self.items.len())
-            .finish()
-    }
 }
 
 /// Parent-facing actions emitted by [`SessionDetail`].
@@ -274,13 +110,9 @@ pub enum SessionDetailMsg {
         session_id: String,
         positions: Vec<MatchPosition>,
     },
-    LoadMore,
     PrevMatch,
     NextMatch,
     ClearSearch,
-    RenderNextTranscriptBatch {
-        request_id: u64,
-    },
     StartDeferredFirstPageLoad {
         request_id: u64,
         session_id: String,
@@ -730,22 +562,6 @@ impl Component for SessionDetail {
 
                             #[local_ref]
                             messages_box -> gtk::ListView {},
-
-                            #[name = "load_more_button"]
-                            gtk::Button {
-                                set_halign: gtk::Align::Center,
-                                set_margin_top: 12,
-                                set_margin_bottom: 12,
-                                #[watch]
-                                set_visible: model.has_more_messages,
-                                #[watch]
-                                set_sensitive: !model.loading_next_page
-                                    && !model.loading_first_page
-                                    && model.pending_render_batch.is_none(),
-                                #[watch]
-                                set_label: if model.loading_next_page { "Loading..." } else { "Load more" },
-                                connect_clicked => SessionDetailMsg::LoadMore,
-                            },
                         },
                     },
                     }, // close inspector_split (adw::OverlaySplitView)
@@ -859,17 +675,11 @@ impl Component for SessionDetail {
             first_page_load_started_at: None,
             messages,
             transcript_render_widget,
-            initial_page_size: INITIAL_PAGE_SIZE,
-            page_size: NEXT_PAGE_SIZE,
+            initial_page_size: 0,
             preview_len: PREVIEW_LEN,
             loaded_count: 0,
-            has_more_messages: false,
             loading_first_page: false,
-            loading_next_page: false,
             transcript_request_id: 0,
-            pending_render_batch: None,
-            last_render_metrics: None,
-            pending_boundary_tool_rows: Vec::new(),
             search_query: None,
             match_positions: Vec::new(),
             display_targets_by_item_index: BTreeMap::new(),
@@ -1017,9 +827,6 @@ impl Component for SessionDetail {
                     self.jump_to(0, &sender);
                 }
             }
-            SessionDetailMsg::LoadMore => {
-                self.load_next_page(&sender);
-            }
             SessionDetailMsg::PrevMatch => {
                 if !self.match_positions.is_empty() && !self.loading_jump {
                     let target = match self.current_match {
@@ -1034,9 +841,6 @@ impl Component for SessionDetail {
                     let target = (self.current_match + 1) % self.match_positions.len();
                     self.jump_to(target, &sender);
                 }
-            }
-            SessionDetailMsg::RenderNextTranscriptBatch { request_id } => {
-                self.render_next_transcript_batch(&sender, request_id);
             }
             SessionDetailMsg::StartDeferredFirstPageLoad {
                 request_id,
@@ -1096,11 +900,11 @@ impl Component for SessionDetail {
                 tracing::debug!(item_index, toggled, "Typed message expand requested");
             }
             SessionDetailMsg::RowBuilt {
-                item_index,
-                kind,
-                build_duration_ms,
+                item_index: _,
+                kind: _,
+                build_duration_ms: _,
             } => {
-                self.record_transcript_row_build(sender, item_index, kind, build_duration_ms);
+                tracing::trace!("Transcript row built (no-op in typed path)");
             }
             SessionDetailMsg::ClearSearch => {
                 self.search_query = None;
@@ -1120,13 +924,9 @@ impl Component for SessionDetail {
                 self.first_page_load_started_at = None;
                 self.clear_messages_safely_with_metrics("component_clear");
                 self.loaded_count = 0;
-                self.has_more_messages = false;
                 self.loading_first_page = false;
-                self.loading_next_page = false;
-                self.pending_render_batch = None;
                 self.search_query = None;
                 self.reset_search_matches();
-                self.clear_pending_boundary_tool_rows();
                 self.inspector.emit(ToolInspectorPaneMsg::Clear);
                 self.set_inspector_open(false, &sender);
             }
@@ -1658,8 +1458,6 @@ impl SessionDetail {
 
     fn invalidate_transcript_requests(&mut self) {
         self.transcript_request_id = self.transcript_request_id.wrapping_add(1);
-        self.pending_render_batch = None;
-        self.last_render_metrics = None;
     }
 
     fn invalidate_search_requests(&mut self) {
@@ -1675,11 +1473,6 @@ impl SessionDetail {
     /// finish rendering.
     fn is_transcript_loading(&self) -> bool {
         self.loading_first_page
-            || self.loading_next_page
-            || self
-                .pending_render_batch
-                .as_ref()
-                .is_some_and(|b| !b.push_complete)
     }
 
     fn spawn_match_positions_load(
@@ -1737,10 +1530,7 @@ impl SessionDetail {
     ) {
         self.invalidate_transcript_requests();
         self.loading_first_page = true;
-        self.loading_next_page = false;
         self.loaded_count = 0;
-        self.has_more_messages = false;
-        self.clear_pending_boundary_tool_rows();
         self.clear_messages_safely_with_metrics(clear_reason);
         self.first_page_load_started_at = Some(Instant::now());
 
@@ -1797,388 +1587,6 @@ impl SessionDetail {
         });
     }
 
-    fn schedule_transcript_render_batch(&self, sender: &ComponentSender<Self>, request_id: u64) {
-        let input_sender = sender.input_sender().clone();
-        let fired = Rc::new(Cell::new(false));
-
-        let fired_tick = fired.clone();
-        let input_tick = input_sender.clone();
-        self.transcript_render_widget
-            .add_tick_callback(move |_, _| {
-                if !fired_tick.replace(true) {
-                    let _ =
-                        input_tick.send(SessionDetailMsg::RenderNextTranscriptBatch { request_id });
-                }
-                glib::ControlFlow::Break
-            });
-
-        let fired_watchdog = fired.clone();
-        glib::timeout_add_local_once(Duration::from_millis(RENDER_BATCH_WATCHDOG_MS), move || {
-            if !fired_watchdog.replace(true) {
-                let _ =
-                    input_sender.send(SessionDetailMsg::RenderNextTranscriptBatch { request_id });
-            }
-        });
-    }
-
-    fn prepare_for_navigation_back(&mut self, sender: &ComponentSender<Self>) {
-        self.invalidate_transcript_requests();
-        self.loading_first_page = false;
-        self.loading_next_page = false;
-        self.clear_pending_boundary_tool_rows();
-
-        let request_id = self.transcript_request_id;
-        let input_sender = sender.input_sender().clone();
-        glib::timeout_add_local_once(Duration::from_millis(DEFERRED_CLEAR_DELAY_MS), move || {
-            let _ = input_sender.send(SessionDetailMsg::DeferredClear { request_id });
-        });
-    }
-
-    fn clear_for_navigation_back(&mut self) {
-        self.invalidate_search_requests();
-        self.session = None;
-        self.first_page_load_started_at = None;
-        self.clear_messages_safely_with_metrics("navigation_back");
-        self.loaded_count = 0;
-        self.has_more_messages = false;
-        self.search_query = None;
-        self.reset_search_matches();
-    }
-
-    fn queue_transcript_items_for_render(
-        &mut self,
-        sender: &ComponentSender<Self>,
-        request_id: u64,
-        offset: usize,
-        source_row_count: usize,
-        items: Vec<TranscriptItemInit>,
-    ) {
-        let total_items = items.len();
-        let row_kind_counts = Self::count_render_item_kinds(&items);
-        tracing::info!(
-            request_id,
-            offset,
-            source_row_count,
-            display_item_count = total_items,
-            message_count = row_kind_counts.message_count,
-            tool_call_count = row_kind_counts.tool_call_count,
-            tool_burst_count = row_kind_counts.tool_burst_count,
-            subagent_count = row_kind_counts.subagent_count,
-            "Queued transcript render batch"
-        );
-        self.last_render_metrics = None;
-        self.pending_render_batch = Some(PendingRenderBatch {
-            request_id,
-            offset,
-            source_row_count,
-            total_items,
-            rendered_items: 0,
-            batch_count: 0,
-            queued_at: Instant::now(),
-            last_batch_completed_at: None,
-            total_push_duration: Duration::ZERO,
-            max_push_duration: Duration::ZERO,
-            max_schedule_gap: Duration::ZERO,
-            row_build_totals: RenderRowBuildTotals::default(),
-            row_build_count: 0,
-            worst_row_kind: None,
-            worst_row_duration: Duration::ZERO,
-            batch_breakdowns: Vec::new(),
-            item_render_batch_indices: std::collections::HashMap::new(),
-            row_kind_counts,
-            items: items.into(),
-            first_page_load_to_factory_push_ms: None,
-            push_complete: false,
-        });
-        self.schedule_transcript_render_batch(sender, request_id);
-    }
-
-    fn count_render_item_kinds(items: &[TranscriptItemInit]) -> RenderRowKindCounts {
-        let mut counts = RenderRowKindCounts::default();
-        for item in items {
-            match item {
-                TranscriptItemInit::Message(_) => counts.message_count += 1,
-                TranscriptItemInit::ToolCall(_) => counts.tool_call_count += 1,
-                TranscriptItemInit::ToolBurst(_) => counts.tool_burst_count += 1,
-                TranscriptItemInit::Subagent(_) => counts.subagent_count += 1,
-            }
-        }
-        counts
-    }
-
-    fn render_next_transcript_batch(&mut self, sender: &ComponentSender<Self>, request_id: u64) {
-        if request_id != self.transcript_request_id {
-            return;
-        }
-
-        let first_page_load_started_at = self.first_page_load_started_at;
-
-        let Some(batch) = &mut self.pending_render_batch else {
-            return;
-        };
-        if batch.request_id != request_id {
-            return;
-        }
-
-        let schedule_gap = batch
-            .last_batch_completed_at
-            .map(|completed_at| completed_at.elapsed())
-            .unwrap_or(Duration::ZERO);
-        batch.max_schedule_gap = batch.max_schedule_gap.max(schedule_gap);
-
-        let push_started_at = Instant::now();
-        let mut rendered_this_batch = 0usize;
-        let render_batch_index = batch.batch_count + 1;
-        let input_sender = sender.input_sender().clone();
-        for _ in 0..RENDER_BATCH_SIZE {
-            let Some(item) = batch.items.pop_front() else {
-                break;
-            };
-            batch
-                .item_render_batch_indices
-                .insert(item.item_index(), render_batch_index);
-            self.messages
-                .append(TranscriptItemData::from_init(item, input_sender.clone()));
-            rendered_this_batch += 1;
-        }
-        let push_duration = push_started_at.elapsed();
-        let has_more_items = !batch.items.is_empty();
-        batch.rendered_items += rendered_this_batch;
-        batch.batch_count += 1;
-        batch.total_push_duration += push_duration;
-        batch.max_push_duration = batch.max_push_duration.max(push_duration);
-        let remaining_items = batch.items.len();
-        let rendered_items = batch.rendered_items;
-        let total_items = batch.total_items;
-        let batch_count = batch.batch_count;
-        let offset = batch.offset;
-        let source_row_count = batch.source_row_count;
-        let total_push_duration_ms = batch.total_push_duration.as_millis();
-        let max_push_duration_ms = batch.max_push_duration.as_millis();
-        let max_schedule_gap_ms = batch.max_schedule_gap.as_millis();
-        let total_duration_ms = batch.queued_at.elapsed().as_millis();
-        batch.batch_breakdowns.push(RenderBatchBreakdown {
-            render_batch_index,
-            pushed_row_count: rendered_this_batch,
-            row_build_count: 0,
-            schedule_gap,
-            row_build_duration: Duration::ZERO,
-            logged: false,
-        });
-        batch.last_batch_completed_at = Some(Instant::now());
-
-        if has_more_items {
-            tracing::debug!(
-                request_id,
-                offset,
-                rendered_this_batch,
-                rendered_items,
-                total_items,
-                remaining_items,
-                push_duration_ms = push_duration.as_millis(),
-                schedule_gap_ms = schedule_gap.as_millis(),
-                max_schedule_gap_ms,
-                "Rendered transcript batch"
-            );
-            self.schedule_transcript_render_batch(sender, request_id);
-        } else {
-            let first_page_load_to_factory_push_ms = if offset == 0 {
-                first_page_load_started_at.map(|started_at| started_at.elapsed().as_millis())
-            } else {
-                None
-            };
-            if offset == 0 {
-                tracing::info!(
-                    request_id,
-                    offset,
-                    source_row_count,
-                    display_item_count = total_items,
-                    batch_count,
-                    total_push_duration_ms,
-                    max_push_duration_ms,
-                    total_duration_ms,
-                    max_schedule_gap_ms,
-                    first_page_load_to_factory_push_ms,
-                    "First transcript page factory push complete"
-                );
-            }
-            if let Some(batch) = self.pending_render_batch.as_mut() {
-                batch.first_page_load_to_factory_push_ms = first_page_load_to_factory_push_ms;
-                batch.push_complete = true;
-            }
-            self.complete_transcript_render_push(sender);
-        }
-    }
-
-    fn record_transcript_row_build(
-        &mut self,
-        sender: ComponentSender<Self>,
-        item_index: usize,
-        kind: TranscriptRowBuildKind,
-        build_duration_ms: u128,
-    ) {
-        let Some(batch) = &mut self.pending_render_batch else {
-            return;
-        };
-
-        let render_batch_index = match batch.item_render_batch_indices.get(&item_index) {
-            Some(&idx) => idx,
-            None => {
-                tracing::debug!(
-                    item_index,
-                    kind = ?kind,
-                    build_duration_ms,
-                    "Ignoring transcript row build metric without batch mapping"
-                );
-                return;
-            }
-        };
-
-        let duration = Duration::from_millis(build_duration_ms as u64);
-        batch.row_build_totals.add(kind, duration);
-        batch.row_build_count += 1;
-        if batch.worst_row_kind.is_none() || duration > batch.worst_row_duration {
-            batch.worst_row_duration = duration;
-            batch.worst_row_kind = Some(kind);
-        }
-
-        let request_id = batch.request_id;
-        let offset = batch.offset;
-        if let Some(breakdown) = batch
-            .batch_breakdowns
-            .iter_mut()
-            .find(|b| b.render_batch_index == render_batch_index)
-        {
-            breakdown.row_build_count += 1;
-            breakdown.row_build_duration += duration;
-            if !breakdown.logged && breakdown.row_build_count >= breakdown.pushed_row_count {
-                breakdown.logged = true;
-                let post_drop_residual = breakdown
-                    .schedule_gap
-                    .saturating_sub(breakdown.row_build_duration);
-                tracing::debug!(
-                    request_id,
-                    offset,
-                    render_batch_index,
-                    pushed_row_count = breakdown.pushed_row_count,
-                    row_build_count = breakdown.row_build_count,
-                    measured_row_build_ms = breakdown.row_build_duration.as_millis(),
-                    schedule_gap_ms = breakdown.schedule_gap.as_millis(),
-                    post_drop_residual_ms = post_drop_residual.as_millis(),
-                    "Measured transcript render batch breakdown"
-                );
-            }
-        }
-
-        self.maybe_log_row_build_breakdown(&sender);
-    }
-
-    fn maybe_log_row_build_breakdown(&mut self, _sender: &ComponentSender<Self>) {
-        let Some(batch) = &self.pending_render_batch else {
-            return;
-        };
-        if !batch.push_complete {
-            return;
-        }
-        if batch.row_build_count < batch.rendered_items {
-            return;
-        }
-
-        let batch = self
-            .pending_render_batch
-            .take()
-            .expect("pending batch checked above");
-        let total_row_build_duration_ms = batch.row_build_totals.total().as_millis();
-        let max_post_drop_residual_ms = batch
-            .batch_breakdowns
-            .iter()
-            .map(|b| b.schedule_gap.saturating_sub(b.row_build_duration))
-            .max()
-            .unwrap_or(Duration::ZERO)
-            .as_millis();
-        tracing::debug!(
-            request_id = batch.request_id,
-            offset = batch.offset,
-            row_build_count = batch.row_build_count,
-            message_build_duration_ms = batch.row_build_totals.message_duration.as_millis(),
-            tool_call_build_duration_ms =
-                batch.row_build_totals.tool_call_duration.as_millis(),
-            tool_burst_build_duration_ms =
-                batch.row_build_totals.tool_burst_duration.as_millis(),
-            subagent_build_duration_ms = batch.row_build_totals.subagent_duration.as_millis(),
-            total_row_build_duration_ms,
-            worst_row_kind = ?batch.worst_row_kind,
-            worst_row_build_duration_ms = batch.worst_row_duration.as_millis(),
-            max_post_drop_residual_ms,
-            "Transcript page row-build breakdown"
-        );
-
-        self.last_render_metrics = Some(render_metrics_for_batch(
-            &batch,
-            batch.queued_at.elapsed().as_millis(),
-        ));
-    }
-
-    fn complete_transcript_render_push(&mut self, sender: &ComponentSender<Self>) {
-        let (
-            total_push_duration_ms,
-            max_push_duration_ms,
-            max_schedule_gap_ms,
-            total_duration_ms,
-            request_id,
-            offset,
-            source_row_count,
-            total_items,
-            rendered_items,
-            batch_count,
-            message_count,
-            tool_call_count,
-            tool_burst_count,
-            subagent_count,
-        ) = {
-            let Some(batch) = &self.pending_render_batch else {
-                return;
-            };
-            (
-                batch.total_push_duration.as_millis(),
-                batch.max_push_duration.as_millis(),
-                batch.max_schedule_gap.as_millis(),
-                batch.queued_at.elapsed().as_millis(),
-                batch.request_id,
-                batch.offset,
-                batch.source_row_count,
-                batch.total_items,
-                batch.rendered_items,
-                batch.batch_count,
-                batch.row_kind_counts.message_count,
-                batch.row_kind_counts.tool_call_count,
-                batch.row_kind_counts.tool_burst_count,
-                batch.row_kind_counts.subagent_count,
-            )
-        };
-        tracing::info!(
-            request_id,
-            offset,
-            source_row_count,
-            display_item_count = total_items,
-            rendered_items,
-            batch_count,
-            total_push_duration_ms,
-            max_push_duration_ms,
-            total_duration_ms,
-            message_count,
-            tool_call_count,
-            tool_burst_count,
-            subagent_count,
-            max_schedule_gap_ms,
-            "Finished rendering transcript page"
-        );
-        if let Some(batch) = self.pending_render_batch.as_ref() {
-            self.last_render_metrics = Some(render_metrics_for_batch(batch, total_duration_ms));
-        }
-        self.continue_pending_jump(sender);
-    }
-
     fn apply_first_page_rows(
         &mut self,
         sender: &ComponentSender<Self>,
@@ -2187,12 +1595,9 @@ impl SessionDetail {
         rows: Vec<crate::database::TranscriptItemRow>,
     ) {
         self.loading_first_page = false;
-        self.loading_next_page = false;
-        self.has_more_messages = false;
         self.loaded_count = rows.len();
         let highlight = self.search_query.clone();
         let db_path = self.db_path.clone();
-        self.clear_pending_boundary_tool_rows();
         self.clear_messages_safely_with_metrics("first_page_apply");
         let build_started_at = Instant::now();
         let source_row_count = rows.len();
@@ -2210,11 +1615,10 @@ impl SessionDetail {
         tracing::info!(
             request_id,
             session_id,
-            offset = 0usize,
             source_row_count,
             display_item_count,
             build_duration_ms = build_started_at.elapsed().as_millis(),
-            "Prepared first transcript page"
+            "Prepared transcript"
         );
 
         let input_sender = sender.input_sender().clone();
@@ -2238,12 +1642,9 @@ impl SessionDetail {
         if offset == 0 {
             self.clear_messages_safely_with_metrics("transcript_error");
             self.loaded_count = 0;
-            self.has_more_messages = false;
-            self.clear_pending_boundary_tool_rows();
         }
 
         self.loading_first_page = false;
-        self.loading_next_page = false;
         self.pending_jump = None;
         self.loading_jump = false;
     }
@@ -2257,9 +1658,9 @@ impl SessionDetail {
             request_id,
             session_id,
             offset,
-            limit,
             load_duration_ms,
             result,
+            ..
         } = message
         else {
             return;
@@ -2288,29 +1689,15 @@ impl SessionDetail {
         }
 
         match result {
-            Ok(rows) if offset == 0 => {
-                tracing::info!(
-                    request_id,
-                    session_id = session_id.as_str(),
-                    offset,
-                    limit,
-                    source_row_count = rows.len(),
-                    load_duration_ms,
-                    "Loaded first transcript page"
-                );
-                self.apply_first_page_rows(sender, request_id, &session_id, rows)
-            }
             Ok(rows) => {
                 tracing::info!(
                     request_id,
                     session_id = session_id.as_str(),
-                    offset,
-                    limit,
                     source_row_count = rows.len(),
                     load_duration_ms,
-                    "Loaded next transcript page"
+                    "Loaded transcript"
                 );
-                self.apply_next_page_rows(sender, request_id, offset, &session_id, rows)
+                self.apply_first_page_rows(sender, request_id, &session_id, rows)
             }
             Err(err) => self.handle_transcript_page_error(&session_id, offset, err),
         }
@@ -2352,7 +1739,7 @@ impl SessionDetail {
         self.continue_pending_jump(sender);
     }
 
-    fn continue_pending_jump(&mut self, sender: &ComponentSender<Self>) {
+    fn continue_pending_jump(&mut self, _sender: &ComponentSender<Self>) {
         let Some(target) = self.pending_jump else {
             return;
         };
@@ -2375,9 +1762,7 @@ impl SessionDetail {
             self.pending_jump = None;
             self.loading_jump = false;
             self.scroll_to_item.set(Some(scroll_target));
-        } else if (position.item_index as usize) >= self.loaded_count && self.has_more_messages {
-            self.load_next_page(sender);
-        } else if !self.has_more_messages && (position.item_index as usize) >= self.loaded_count {
+        } else if (position.item_index as usize) >= self.loaded_count {
             tracing::warn!(
                 item_index = position.item_index,
                 loaded_count = self.loaded_count,
@@ -2401,179 +1786,25 @@ impl SessionDetail {
         }
     }
 
-    fn clear_pending_boundary_tool_rows(&mut self) {
-        self.pending_boundary_tool_rows.clear();
-    }
+    fn prepare_for_navigation_back(&mut self, sender: &ComponentSender<Self>) {
+        self.invalidate_transcript_requests();
+        self.loading_first_page = false;
 
-    fn track_pending_boundary_tool_rows(&mut self, rows: &[crate::database::TranscriptItemRow]) {
-        self.pending_boundary_tool_rows = if self.has_more_messages {
-            trailing_tool_call_rows(rows)
-        } else {
-            Vec::new()
-        };
-    }
-
-    fn regroup_next_page_boundary(
-        &mut self,
-        rows: Vec<crate::database::TranscriptItemRow>,
-    ) -> BoundaryAppendPlan {
-        if self.pending_boundary_tool_rows.is_empty() {
-            self.track_pending_boundary_tool_rows(&rows);
-            return BoundaryAppendPlan {
-                replacement_items: Vec::new(),
-                rows,
-            };
-        }
-
-        let regrouped =
-            regroup_boundary(std::mem::take(&mut self.pending_boundary_tool_rows), rows);
-        let replacement_items = regrouped.replacement_items;
-        let rows = regrouped.remaining_rows;
-
-        self.pending_boundary_tool_rows = if !self.has_more_messages {
-            Vec::new()
-        } else if rows.is_empty() {
-            trailing_tool_rows_from_display(&replacement_items)
-        } else {
-            trailing_tool_call_rows(&rows)
-        };
-
-        BoundaryAppendPlan {
-            replacement_items,
-            rows,
-        }
-    }
-
-    /// Loads the next transcript page and repairs any tool-burst grouping that
-    /// straddles the previous page boundary.
-    ///
-    /// The last rows of a loaded page may be trailing tool calls that cannot be
-    /// grouped correctly until the next page is available. When that happens,
-    /// the component replaces the affected tail items before appending the new
-    /// page so display rows and their search indexes stay stable.
-    fn load_next_page(&mut self, sender: &ComponentSender<Self>) {
-        let Some(session) = &self.session else {
-            return;
-        };
-
-        if self.is_transcript_loading() || !self.has_more_messages {
-            return;
-        }
-
-        let session_id = session.id.clone();
-        let offset = self.loaded_count;
-        self.loading_next_page = true;
-        self.spawn_transcript_page_load(
-            sender,
-            self.transcript_request_id,
-            session_id,
-            offset,
-            self.page_size,
-        );
-    }
-
-    fn apply_next_page_rows(
-        &mut self,
-        sender: &ComponentSender<Self>,
-        request_id: u64,
-        offset: usize,
-        session_id: &str,
-        rows: Vec<crate::database::TranscriptItemRow>,
-    ) {
-        let apply_started_at = Instant::now();
-        self.loading_next_page = false;
-        let source_len = rows.len();
-        self.has_more_messages = source_len == self.page_size;
-        self.loaded_count += source_len;
-
-        let highlight = self.search_query.clone();
-        let db_path = self.db_path.clone();
-        // Boundary regrouping must run before borrowing `self.messages` since it
-        // mutates `self.pending_boundary_tool_rows`.
-        let BoundaryAppendPlan {
-            replacement_items,
-            rows,
-        } = self.regroup_next_page_boundary(rows);
-        let replacement_item_count = replacement_items.len();
-
-        let need_replacement = !replacement_items.is_empty();
-        if need_replacement {
-            self.remove_display_targets_for_items(&replacement_items);
-        }
-        let matched_item_indexes = self.current_match_item_indexes();
-
-        let pre_replacement_len = self.messages.len() as usize;
-        let pre_replacement_len = pre_replacement_len - if need_replacement { 1 } else { 0 };
-
-        let mut replacement_targets = BTreeMap::new();
-        let mut replacement_inits = Vec::new();
-        if need_replacement {
-            for (offset, item) in replacement_items.iter().enumerate() {
-                let display_index = pre_replacement_len + offset;
-                replacement_targets.extend(Self::display_targets_for_item(display_index, item));
-                let item_highlight = match item {
-                    DisplayTranscriptItem::Single(row)
-                        if row.kind == crate::models::TranscriptItemKind::Message
-                            && matched_item_indexes.contains(&row.item_index) =>
-                    {
-                        highlight.clone()
-                    }
-                    _ => None,
-                };
-                replacement_inits.push(transcript_item_init_from_display_item(
-                    display_index,
-                    item,
-                    session_id,
-                    item_highlight,
-                    db_path.clone(),
-                ));
-            }
-        }
-
-        let page_start = pre_replacement_len + replacement_inits.len();
-        let prepared = Self::build_display_items(
-            rows,
-            session_id,
-            highlight,
-            &matched_item_indexes,
-            db_path,
-            page_start,
-        );
-        let display_item_count = prepared.items.len();
-
+        let request_id = self.transcript_request_id;
         let input_sender = sender.input_sender().clone();
-        if need_replacement {
-            self.messages.remove(self.messages.len() - 1);
-            for item in replacement_inits {
-                self.messages
-                    .append(TranscriptItemData::from_init(item, input_sender.clone()));
-            }
-        }
+        glib::timeout_add_local_once(Duration::from_millis(DEFERRED_CLEAR_DELAY_MS), move || {
+            let _ = input_sender.send(SessionDetailMsg::DeferredClear { request_id });
+        });
+    }
 
-        self.extend_display_targets(replacement_targets);
-        self.extend_display_targets(prepared.display_targets_by_item_index);
-        tracing::info!(
-            request_id,
-            session_id,
-            offset,
-            source_row_count = source_len,
-            replacement_item_count,
-            display_item_count,
-            prepare_duration_ms = apply_started_at.elapsed().as_millis(),
-            "Prepared next transcript page"
-        );
-        self.queue_transcript_items_for_render(
-            sender,
-            request_id,
-            offset,
-            source_len,
-            prepared.items,
-        );
-
-        if !self.has_more_messages {
-            self.clear_pending_boundary_tool_rows();
-        }
-        self.continue_pending_jump(sender);
+    fn clear_for_navigation_back(&mut self) {
+        self.invalidate_search_requests();
+        self.session = None;
+        self.first_page_load_started_at = None;
+        self.clear_messages_safely_with_metrics("navigation_back");
+        self.loaded_count = 0;
+        self.search_query = None;
+        self.reset_search_matches();
     }
 
     /// Clear transcript rows after releasing focus from any currently-focused row widget.
@@ -2585,20 +1816,17 @@ impl SessionDetail {
 
     fn clear_messages_safely_with_metrics(&mut self, reason: &'static str) -> ClearMessagesMetrics {
         let row_count_before = self.messages.len() as usize;
-        let had_pending_render = self.pending_render_batch.is_some();
         let started_at = Instant::now();
         self.clear_messages_safely();
         let duration_ms = started_at.elapsed().as_millis();
         tracing::info!(
             reason,
             row_count_before,
-            had_pending_render,
             duration_ms,
             "Cleared session detail transcript rows"
         );
         ClearMessagesMetrics {
             row_count_before,
-            had_pending_render,
             duration_ms,
         }
     }
@@ -2703,11 +1931,8 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
-    use relm4::binding::Binding;
     use relm4::{Component, ComponentController};
     use rusqlite::{Connection, params};
-
-    const TRANSCRIPT_BATCH_TEST_GRACE: Duration = Duration::from_millis(125);
 
     fn build_test_session(
         first_prompt: Option<&str>,
@@ -2745,58 +1970,6 @@ mod tests {
         while std::time::Instant::now() < deadline {
             if condition() {
                 return;
-            }
-
-            if !context.iteration(false) {
-                std::thread::sleep(Duration::from_millis(2));
-            }
-        }
-    }
-
-    // Headless tests have no frame clock, so `add_tick_callback` never fires;
-    // the production watchdog still does. We let the watchdog drive the first
-    // ~100 ms (preserving real scheduler coverage), then once
-    // `TRANSCRIPT_BATCH_TEST_GRACE` elapses for the same `request_id` we drive
-    // remaining items on every loop iteration so the batch drains quickly.
-    fn pump_main_context_draining_transcript_batches(
-        controller: &impl ComponentController<SessionDetail>,
-        timeout: Duration,
-        condition: impl Fn() -> bool,
-    ) {
-        let context = gtk::glib::MainContext::default();
-        let deadline = std::time::Instant::now() + timeout;
-        let mut pending_batch_seen_at: Option<(u64, std::time::Instant)> = None;
-        while std::time::Instant::now() < deadline {
-            if condition() {
-                return;
-            }
-
-            let pending_request_id = {
-                let parts = controller.state().get();
-                parts
-                    .model
-                    .pending_render_batch
-                    .as_ref()
-                    .map(|batch| batch.request_id)
-            };
-            match pending_request_id {
-                Some(request_id) => {
-                    let now = std::time::Instant::now();
-                    let observed_at = match pending_batch_seen_at {
-                        Some((seen_request_id, observed_at)) if seen_request_id == request_id => {
-                            observed_at
-                        }
-                        _ => {
-                            pending_batch_seen_at = Some((request_id, now));
-                            now
-                        }
-                    };
-
-                    if now.duration_since(observed_at) >= TRANSCRIPT_BATCH_TEST_GRACE {
-                        controller.emit(SessionDetailMsg::RenderNextTranscriptBatch { request_id });
-                    }
-                }
-                None => pending_batch_seen_at = None,
             }
 
             if !context.iteration(false) {
@@ -2858,125 +2031,6 @@ mod tests {
             )
             .expect("insert search transcript item");
         }
-    }
-
-    fn seed_tool_burst_transcript(db_path: &std::path::Path, session_id: &str, count: usize) {
-        let conn = Connection::open(db_path).expect("open temp db");
-        crate::database::schema::initialize_database(&conn).expect("initialize db");
-
-        for index in 0..count {
-            let tool_call_id = format!("call-{index}");
-            conn.execute(
-                "INSERT INTO tool_calls (
-                    id, session_id, tool_name, status, summary, input_json, output_text, duration_ms
-                 ) VALUES (?1, ?2, ?3, 'completed', ?4, ?5, ?6, ?7)",
-                params![
-                    tool_call_id,
-                    session_id,
-                    if index % 2 == 0 { "Read" } else { "Edit" },
-                    format!("tool summary {index}"),
-                    format!(r#"{{"path":"/tmp/file-{index}.rs"}}"#),
-                    format!("tool output line {index}"),
-                    index as i64,
-                ],
-            )
-            .expect("insert tool call");
-            conn.execute(
-                "INSERT INTO transcript_items (session_id, item_index, kind, tool_call_id)
-                 VALUES (?1, ?2, 'tool_call', ?3)",
-                params![session_id, index as i64, tool_call_id],
-            )
-            .expect("insert transcript item");
-        }
-    }
-
-    fn seed_markdown_transcript(db_path: &std::path::Path, session_id: &str, count: usize) {
-        let conn = Connection::open(db_path).expect("open temp db");
-        crate::database::schema::initialize_database(&conn).expect("initialize db");
-
-        let content = "# Synthetic assistant response\n\n\
-This paragraph contains a needle used for search-highlight measurements.\n\n\
-```rust\n\
-fn synthetic_measurement(input: &str) -> String {\n\
-    format!(\"needle {input}\")\n\
-}\n\
-```\n\n\
-| file | status |\n\
-| --- | --- |\n\
-| src/ui/session_detail.rs | measured |\n\n"
-            .repeat(12);
-
-        for index in 0..count {
-            conn.execute(
-                "INSERT INTO messages (session_id, message_index, role, content, timestamp, model)
-                 VALUES (?1, ?2, 'assistant', ?3, ?4, 'synthetic-model')",
-                params![session_id, index as i64, content, index as i64],
-            )
-            .expect("insert message");
-            conn.execute(
-                "INSERT INTO transcript_items (session_id, item_index, kind, message_index)
-                 VALUES (?1, ?2, 'message', ?2)",
-                params![session_id, index as i64],
-            )
-            .expect("insert transcript item");
-        }
-    }
-
-    fn measure_session_detail_perf_scenario(
-        name: &str,
-        seed: impl FnOnce(&std::path::Path),
-    ) -> RenderMetrics {
-        measure_session_detail_perf_scenario_with_query(name, None, seed)
-    }
-
-    fn measure_session_detail_perf_scenario_with_query(
-        _name: &str,
-        search_query: Option<&str>,
-        seed: impl FnOnce(&std::path::Path),
-    ) -> RenderMetrics {
-        let temp_db = tempfile::NamedTempFile::new().expect("temp db");
-        seed(temp_db.path());
-
-        let controller = SessionDetail::builder().launch(temp_db.path().to_path_buf());
-        controller.emit(SessionDetailMsg::SetSession {
-            session: Box::new(build_test_session(None, None, 0, 0, 0)),
-            search_query: search_query.map(str::to_string),
-        });
-
-        pump_main_context_draining_transcript_batches(&controller, Duration::from_secs(5), || {
-            let parts = controller.state().get();
-            parts.model.pending_render_batch.is_none() && parts.model.last_render_metrics.is_some()
-        });
-
-        let parts = controller.state().get();
-        parts
-            .model
-            .last_render_metrics
-            .clone()
-            .expect("scenario should record render metrics")
-    }
-
-    fn measure_session_detail_metrics_for_session(
-        db_path: &std::path::Path,
-        session: Session,
-    ) -> RenderMetrics {
-        let controller = SessionDetail::builder().launch(db_path.to_path_buf());
-        controller.emit(SessionDetailMsg::SetSession {
-            session: Box::new(session),
-            search_query: None,
-        });
-
-        pump_main_context_draining_transcript_batches(&controller, Duration::from_secs(30), || {
-            let parts = controller.state().get();
-            parts.model.pending_render_batch.is_none() && parts.model.last_render_metrics.is_some()
-        });
-
-        let parts = controller.state().get();
-        parts
-            .model
-            .last_render_metrics
-            .clone()
-            .expect("session should record render metrics")
     }
 
     fn transcript_message_row(
@@ -3157,7 +2211,7 @@ fn synthetic_measurement(input: &str) -> String {\n\
     #[gtk::test]
     fn session_detail_defers_initial_transcript_load_after_session_change() {
         let temp_db = tempfile::NamedTempFile::new().expect("temp db");
-        seed_message_transcript(temp_db.path(), "test-session-123", INITIAL_PAGE_SIZE);
+        seed_message_transcript(temp_db.path(), "test-session-123", 75);
 
         let controller = SessionDetail::builder().launch(temp_db.path().to_path_buf());
         controller.emit(SessionDetailMsg::SetSession {
@@ -3180,13 +2234,12 @@ fn synthetic_measurement(input: &str) -> String {\n\
         let parts = controller.state().get();
         assert_eq!(parts.model.loaded_count, 0);
         assert_eq!(parts.model.messages.len(), 0);
-        assert!(parts.model.pending_render_batch.is_none());
     }
 
     #[gtk::test]
     fn session_open_timestamp_tracks_active_session_lifecycle() {
         let temp_db = tempfile::NamedTempFile::new().expect("temp db");
-        seed_message_transcript(temp_db.path(), "test-session-123", INITIAL_PAGE_SIZE);
+        seed_message_transcript(temp_db.path(), "test-session-123", 75);
 
         let controller = SessionDetail::builder().launch(temp_db.path().to_path_buf());
         controller.emit(SessionDetailMsg::SetSession {
@@ -3226,7 +2279,7 @@ fn synthetic_measurement(input: &str) -> String {\n\
     #[gtk::test]
     fn clear_message_clears_rows_and_targets() {
         let temp_db = tempfile::NamedTempFile::new().expect("temp db");
-        seed_message_transcript(temp_db.path(), "test-session-123", INITIAL_PAGE_SIZE);
+        seed_message_transcript(temp_db.path(), "test-session-123", 75);
 
         let controller = SessionDetail::builder().launch(temp_db.path().to_path_buf());
         controller.emit(SessionDetailMsg::SetSession {
@@ -3234,10 +2287,9 @@ fn synthetic_measurement(input: &str) -> String {\n\
             search_query: None,
         });
 
-        pump_main_context_draining_transcript_batches(&controller, Duration::from_secs(5), || {
+        pump_main_context(|| {
             let parts = controller.state().get();
-            parts.model.pending_render_batch.is_none()
-                && parts.model.messages.len() as usize == INITIAL_PAGE_SIZE
+            !parts.model.loading_first_page && parts.model.messages.len() as usize == 75
         });
 
         controller.emit(SessionDetailMsg::Clear);
@@ -3263,274 +2315,6 @@ fn synthetic_measurement(input: &str) -> String {\n\
         let debug = format!("{cmd:?}");
         assert!(debug.contains("load_duration_ms"));
         assert!(debug.contains("12"));
-    }
-
-    #[gtk::test]
-    #[ignore = "paginated loading replaced by full typed loading"]
-    fn session_detail_loads_transcript_pages_incrementally() {
-        let temp_db = tempfile::NamedTempFile::new().expect("temp db");
-        seed_message_transcript(temp_db.path(), "test-session-123", INITIAL_PAGE_SIZE + 5);
-
-        let controller = SessionDetail::builder().launch(temp_db.path().to_path_buf());
-        controller.emit(SessionDetailMsg::SetSession {
-            session: Box::new(build_test_session(None, None, 0, 0, 0)),
-            search_query: None,
-        });
-
-        pump_main_context(|| {
-            let parts = controller.state().get();
-            !parts.model.loading_first_page && parts.model.loaded_count == INITIAL_PAGE_SIZE
-        });
-
-        {
-            let parts = controller.state().get();
-            assert_eq!(parts.model.loaded_count, INITIAL_PAGE_SIZE);
-            assert!((parts.model.messages.len() as usize) < INITIAL_PAGE_SIZE);
-            assert!(parts.model.pending_render_batch.is_some());
-            assert!(parts.model.has_more_messages);
-        }
-
-        pump_main_context_draining_transcript_batches(&controller, Duration::from_secs(5), || {
-            let parts = controller.state().get();
-            parts.model.pending_render_batch.is_none()
-                && parts.model.messages.len() as usize == INITIAL_PAGE_SIZE
-        });
-
-        controller.emit(SessionDetailMsg::LoadMore);
-
-        pump_main_context(|| {
-            let parts = controller.state().get();
-            !parts.model.loading_next_page && parts.model.loaded_count == INITIAL_PAGE_SIZE + 5
-        });
-
-        {
-            let parts = controller.state().get();
-            assert_eq!(parts.model.loaded_count, INITIAL_PAGE_SIZE + 5);
-            assert!((parts.model.messages.len() as usize) < INITIAL_PAGE_SIZE + 5);
-        }
-
-        pump_main_context_draining_transcript_batches(&controller, Duration::from_secs(5), || {
-            let parts = controller.state().get();
-            parts.model.pending_render_batch.is_none()
-                && parts.model.messages.len() as usize == INITIAL_PAGE_SIZE + 5
-        });
-
-        let parts = controller.state().get();
-        assert!(!parts.model.has_more_messages);
-    }
-
-    #[gtk::test]
-    #[ignore = "first-page typed loading does not create render batches"]
-    fn session_detail_records_render_batch_measurements() {
-        let temp_db = tempfile::NamedTempFile::new().expect("temp db");
-        seed_message_transcript(temp_db.path(), "test-session-123", INITIAL_PAGE_SIZE + 5);
-
-        let controller = SessionDetail::builder().launch(temp_db.path().to_path_buf());
-        controller.emit(SessionDetailMsg::SetSession {
-            session: Box::new(build_test_session(None, None, 0, 0, 0)),
-            search_query: None,
-        });
-
-        pump_main_context(|| {
-            let parts = controller.state().get();
-            parts.model.messages.len() > 0
-        });
-
-        {
-            let parts = controller.state().get();
-            assert!(parts.model.pending_render_batch.is_some());
-            assert!((parts.model.messages.len() as usize) < INITIAL_PAGE_SIZE);
-        }
-
-        pump_main_context_draining_transcript_batches(&controller, Duration::from_secs(5), || {
-            let parts = controller.state().get();
-            parts.model.pending_render_batch.is_none()
-                && parts.model.messages.len() as usize == INITIAL_PAGE_SIZE
-        });
-
-        let parts = controller.state().get();
-        let metrics = parts
-            .model
-            .last_render_metrics
-            .as_ref()
-            .expect("first page should record render metrics");
-        assert_eq!(metrics.offset, 0);
-        assert_eq!(metrics.source_row_count, INITIAL_PAGE_SIZE);
-        assert_eq!(metrics.display_item_count, INITIAL_PAGE_SIZE);
-        assert_eq!(
-            metrics.batch_count,
-            INITIAL_PAGE_SIZE.div_ceil(RENDER_BATCH_SIZE)
-        );
-        assert_eq!(metrics.message_count, INITIAL_PAGE_SIZE);
-        assert_eq!(metrics.tool_call_count, 0);
-        assert_eq!(metrics.tool_burst_count, 0);
-        assert_eq!(metrics.subagent_count, 0);
-        assert_eq!(
-            metrics.worst_row_kind,
-            Some(TranscriptRowBuildKind::Message)
-        );
-        assert_eq!(
-            metrics.total_row_build_duration_ms,
-            metrics.message_build_duration_ms
-                + metrics.tool_call_build_duration_ms
-                + metrics.tool_burst_build_duration_ms
-                + metrics.subagent_build_duration_ms
-        );
-        assert!(metrics.first_page_load_to_factory_push_ms.is_some());
-    }
-
-    #[test]
-    fn render_item_kind_counts_capture_heterogeneous_rows() {
-        let rows = vec![
-            transcript_message_row(0, crate::models::Role::Assistant, "hello"),
-            transcript_tool_row(1, "Read"),
-            transcript_tool_row(2, "Edit"),
-            transcript_subagent_row(3, "Explore"),
-        ];
-
-        let matched_item_indexes = BTreeSet::new();
-        let prepared = SessionDetail::build_display_items(
-            rows,
-            "session-1",
-            None,
-            &matched_item_indexes,
-            Arc::new(PathBuf::from("/tmp/test.db")),
-            0,
-        );
-        let counts = SessionDetail::count_render_item_kinds(&prepared.items);
-
-        assert_eq!(counts.message_count, 1);
-        assert_eq!(counts.tool_call_count, 0);
-        assert_eq!(counts.tool_burst_count, 1);
-        assert_eq!(counts.subagent_count, 1);
-    }
-
-    #[test]
-    fn render_metrics_for_batch_captures_push_metrics_without_row_builds() {
-        let queued_at = Instant::now();
-        let batch = PendingRenderBatch {
-            request_id: 1,
-            offset: 0,
-            source_row_count: 5,
-            total_items: 5,
-            rendered_items: 5,
-            batch_count: 2,
-            queued_at,
-            last_batch_completed_at: Some(queued_at),
-            total_push_duration: Duration::from_millis(12),
-            max_push_duration: Duration::from_millis(9),
-            max_schedule_gap: Duration::from_millis(15),
-            row_build_totals: RenderRowBuildTotals::default(),
-            row_build_count: 0,
-            worst_row_kind: None,
-            worst_row_duration: Duration::ZERO,
-            batch_breakdowns: vec![],
-            item_render_batch_indices: std::collections::HashMap::new(),
-            row_kind_counts: RenderRowKindCounts {
-                message_count: 5,
-                tool_call_count: 0,
-                tool_burst_count: 0,
-                subagent_count: 0,
-            },
-            items: VecDeque::new(),
-            first_page_load_to_factory_push_ms: Some(42),
-            push_complete: true,
-        };
-
-        let metrics = render_metrics_for_batch(&batch, 100);
-        assert_eq!(metrics.offset, 0);
-        assert_eq!(metrics.source_row_count, 5);
-        assert_eq!(metrics.display_item_count, 5);
-        assert_eq!(metrics.batch_count, 2);
-        assert_eq!(metrics.total_duration_ms, 100);
-        assert_eq!(metrics.total_push_duration_ms, 12);
-        assert_eq!(metrics.max_push_duration_ms, 9);
-        assert_eq!(metrics.max_schedule_gap_ms, 15);
-        assert_eq!(metrics.total_row_build_duration_ms, 0);
-        assert_eq!(metrics.worst_row_kind, None);
-        assert_eq!(metrics.worst_row_build_duration_ms, 0);
-        assert_eq!(metrics.max_post_drop_residual_ms, 0);
-        assert_eq!(metrics.first_page_load_to_factory_push_ms, Some(42));
-        assert_eq!(metrics.message_count, 5);
-        assert_eq!(metrics.tool_call_count, 0);
-        assert_eq!(metrics.tool_burst_count, 0);
-        assert_eq!(metrics.subagent_count, 0);
-    }
-
-    #[gtk::test]
-    #[ignore = "manual performance smoke test for issue #127"]
-    fn session_detail_perf_smoke_measures_synthetic_scenarios() {
-        let message_metrics = measure_session_detail_perf_scenario("messages", |path| {
-            seed_message_transcript(path, "test-session-123", INITIAL_PAGE_SIZE);
-        });
-        let tool_burst_metrics = measure_session_detail_perf_scenario("tool-burst", |path| {
-            seed_tool_burst_transcript(path, "test-session-123", INITIAL_PAGE_SIZE);
-        });
-        let markdown_metrics = measure_session_detail_perf_scenario("markdown", |path| {
-            seed_markdown_transcript(path, "test-session-123", INITIAL_PAGE_SIZE);
-        });
-        let markdown_search_metrics = measure_session_detail_perf_scenario_with_query(
-            "markdown-search",
-            Some("needle"),
-            |path| {
-                seed_markdown_transcript(path, "test-session-123", INITIAL_PAGE_SIZE);
-            },
-        );
-
-        println!("messages: {message_metrics:?}");
-        println!("tool-burst: {tool_burst_metrics:?}");
-        println!("markdown: {markdown_metrics:?}");
-        println!("markdown-search: {markdown_search_metrics:?}");
-
-        assert_eq!(message_metrics.source_row_count, INITIAL_PAGE_SIZE);
-        assert_eq!(message_metrics.message_count, INITIAL_PAGE_SIZE);
-        assert_eq!(tool_burst_metrics.source_row_count, INITIAL_PAGE_SIZE);
-        assert_eq!(tool_burst_metrics.display_item_count, 1);
-        assert_eq!(tool_burst_metrics.tool_burst_count, 1);
-        assert_eq!(markdown_metrics.source_row_count, INITIAL_PAGE_SIZE);
-        assert_eq!(markdown_metrics.message_count, INITIAL_PAGE_SIZE);
-        assert_eq!(markdown_search_metrics.source_row_count, INITIAL_PAGE_SIZE);
-        assert_eq!(markdown_search_metrics.message_count, INITIAL_PAGE_SIZE);
-    }
-
-    #[gtk::test]
-    #[ignore = "manual issue #140 reference-session measurement; requires local Codex session file"]
-    fn session_detail_issue_140_reference_session_breakdown() {
-        const SESSION_ID: &str = "019dc51a-f0cd-79c1-ba79-45fedac889c2";
-        let source_file = std::env::var("SESSION_DETAIL_ISSUE_140_SOURCE_FILE")
-            .expect("SESSION_DETAIL_ISSUE_140_SOURCE_FILE must point to the reference JSONL file");
-        let source_file = std::path::Path::new(&source_file);
-        assert!(
-            source_file.exists(),
-            "reference Codex session file must exist at {}",
-            source_file.display()
-        );
-
-        let temp_root = tempfile::tempdir().expect("temp session root");
-        let target_dir = temp_root.path().join("2026/04/25");
-        std::fs::create_dir_all(&target_dir).expect("create session fixture dir");
-        std::fs::copy(
-            source_file,
-            target_dir.join(source_file.file_name().expect("source file name")),
-        )
-        .expect("copy reference session");
-
-        let temp_db = tempfile::NamedTempFile::new().expect("temp db");
-        let mut indexer = crate::database::SessionIndexer::new(temp_db.path()).expect("indexer");
-        indexer
-            .index_codex_sessions(temp_root.path())
-            .expect("index reference Codex session");
-        let session = crate::database::load_session(temp_db.path(), SESSION_ID)
-            .expect("load reference session")
-            .expect("reference session should be indexed");
-
-        let metrics = measure_session_detail_metrics_for_session(temp_db.path(), session);
-        println!("issue-140-reference: {metrics:#?}");
-
-        assert_eq!(metrics.offset, 0);
-        assert_eq!(metrics.source_row_count, INITIAL_PAGE_SIZE);
-        assert!(metrics.total_row_build_duration_ms > 0);
-        assert!(metrics.worst_row_kind.is_some());
     }
 
     #[test]
@@ -3712,31 +2496,25 @@ fn synthetic_measurement(input: &str) -> String {\n\
     #[gtk::test]
     fn update_search_query_populates_match_positions_and_reloads_first_page() {
         let temp_db = tempfile::NamedTempFile::new().expect("temp db");
-        seed_search_transcript(
-            temp_db.path(),
-            "test-session-123",
-            INITIAL_PAGE_SIZE + 10,
-            &[10, 80],
-        );
+        seed_search_transcript(temp_db.path(), "test-session-123", 85, &[10, 80]);
 
         let controller = SessionDetail::builder().launch(temp_db.path().to_path_buf());
         controller.emit(SessionDetailMsg::SetSession {
             session: Box::new(build_test_session(None, None, 0, 0, 0)),
             search_query: None,
         });
-        pump_main_context_draining_transcript_batches(&controller, Duration::from_secs(5), || {
+        pump_main_context(|| {
             let parts = controller.state().get();
-            parts.model.pending_render_batch.is_none()
-                && parts.model.loaded_count == INITIAL_PAGE_SIZE + 10
+            !parts.model.loading_first_page && parts.model.loaded_count == 85
         });
 
         controller.emit(SessionDetailMsg::UpdateSearchQuery(Some(
             "needle".to_string(),
         )));
-        pump_main_context_draining_transcript_batches(&controller, Duration::from_secs(5), || {
+        pump_main_context(|| {
             let parts = controller.state().get();
             parts.model.match_positions.len() == 2
-                && parts.model.pending_render_batch.is_none()
+                && !parts.model.loading_first_page
                 && parts.model.display_targets_by_item_index.contains_key(&10)
         });
 
@@ -3755,7 +2533,7 @@ fn synthetic_measurement(input: &str) -> String {\n\
     #[gtk::test]
     fn stale_search_result_is_discarded() {
         let temp_db = tempfile::NamedTempFile::new().expect("temp db");
-        seed_search_transcript(temp_db.path(), "test-session-123", INITIAL_PAGE_SIZE, &[5]);
+        seed_search_transcript(temp_db.path(), "test-session-123", 75, &[5]);
 
         let controller = SessionDetail::builder().launch(temp_db.path().to_path_buf());
         controller.emit(SessionDetailMsg::SetSession {
@@ -3789,22 +2567,16 @@ fn synthetic_measurement(input: &str) -> String {\n\
     #[gtk::test]
     fn jump_to_loaded_match_scrolls_without_loading() {
         let temp_db = tempfile::NamedTempFile::new().expect("temp db");
-        seed_search_transcript(
-            temp_db.path(),
-            "test-session-123",
-            INITIAL_PAGE_SIZE,
-            &[10, 20],
-        );
+        seed_search_transcript(temp_db.path(), "test-session-123", 75, &[10, 20]);
 
         let controller = SessionDetail::builder().launch(temp_db.path().to_path_buf());
         controller.emit(SessionDetailMsg::SetSession {
             session: Box::new(build_test_session(None, None, 0, 0, 0)),
             search_query: None,
         });
-        pump_main_context_draining_transcript_batches(&controller, Duration::from_secs(5), || {
+        pump_main_context(|| {
             let parts = controller.state().get();
-            parts.model.pending_render_batch.is_none()
-                && parts.model.loaded_count == INITIAL_PAGE_SIZE
+            !parts.model.loading_first_page && parts.model.loaded_count == 75
         });
 
         let active_request = controller.state().get().model.search_request_id;
@@ -3828,9 +2600,9 @@ fn synthetic_measurement(input: &str) -> String {\n\
     }
 
     #[gtk::test]
-    fn jump_to_loaded_but_unrendered_match_waits_for_render_batch() {
+    fn jump_to_loaded_match_with_typed_view_waits_for_display() {
         let temp_db = tempfile::NamedTempFile::new().expect("temp db");
-        seed_search_transcript(temp_db.path(), "test-session-123", INITIAL_PAGE_SIZE, &[70]);
+        seed_search_transcript(temp_db.path(), "test-session-123", 75, &[70]);
 
         let controller = SessionDetail::builder().launch(temp_db.path().to_path_buf());
         controller.emit(SessionDetailMsg::SetSession {
@@ -3839,8 +2611,7 @@ fn synthetic_measurement(input: &str) -> String {\n\
         });
         pump_main_context(|| {
             let parts = controller.state().get();
-            parts.model.loaded_count == INITIAL_PAGE_SIZE
-                && parts.model.pending_render_batch.is_some()
+            parts.model.loaded_count == 75 && !parts.model.loading_first_page
         });
 
         let active_request = controller.state().get().model.search_request_id;
@@ -3850,9 +2621,9 @@ fn synthetic_measurement(input: &str) -> String {\n\
             positions: vec![MatchPosition { item_index: 70 }],
         });
 
-        pump_main_context_draining_transcript_batches(&controller, Duration::from_secs(5), || {
+        pump_main_context(|| {
             let parts = controller.state().get();
-            parts.model.pending_render_batch.is_none() && !parts.model.loading_jump
+            !parts.model.loading_jump
         });
 
         let parts = controller.state().get();
@@ -3861,53 +2632,9 @@ fn synthetic_measurement(input: &str) -> String {\n\
     }
 
     #[gtk::test]
-    #[ignore = "progressive paging replaced by full typed loading"]
-    fn jump_to_unloaded_match_triggers_progressive_loading_after_each_render_batch() {
-        let temp_db = tempfile::NamedTempFile::new().expect("temp db");
-        seed_search_transcript(
-            temp_db.path(),
-            "test-session-123",
-            INITIAL_PAGE_SIZE + NEXT_PAGE_SIZE + 10,
-            &[10, 160],
-        );
-
-        let controller = SessionDetail::builder().launch(temp_db.path().to_path_buf());
-        controller.emit(SessionDetailMsg::SetSession {
-            session: Box::new(build_test_session(None, None, 0, 0, 0)),
-            search_query: Some("needle".to_string()),
-        });
-        pump_main_context_draining_transcript_batches(&controller, Duration::from_secs(5), || {
-            let parts = controller.state().get();
-            parts.model.match_positions.len() == 2
-                && parts.model.pending_render_batch.is_none()
-                && !parts.model.loading_jump
-                && parts.model.current_match == 0
-                && parts.model.display_targets_by_item_index.contains_key(&10)
-        });
-
-        controller.emit(SessionDetailMsg::NextMatch);
-        pump_main_context_draining_transcript_batches(&controller, Duration::from_secs(5), || {
-            let parts = controller.state().get();
-            parts.model.loaded_count == INITIAL_PAGE_SIZE + NEXT_PAGE_SIZE + 10
-                && parts.model.pending_render_batch.is_none()
-                && !parts.model.loading_jump
-        });
-
-        let parts = controller.state().get();
-        assert_eq!(parts.model.current_match, 1);
-        assert!(!parts.model.loading_jump);
-        assert!(parts.model.display_targets_by_item_index.contains_key(&160));
-    }
-
-    #[gtk::test]
     fn prev_next_wrap_around_match_positions() {
         let temp_db = tempfile::NamedTempFile::new().expect("temp db");
-        seed_search_transcript(
-            temp_db.path(),
-            "test-session-123",
-            INITIAL_PAGE_SIZE,
-            &[2, 4],
-        );
+        seed_search_transcript(temp_db.path(), "test-session-123", 75, &[2, 4]);
 
         let controller = SessionDetail::builder().launch(temp_db.path().to_path_buf());
         controller.emit(SessionDetailMsg::SetSession {
@@ -3926,41 +2653,5 @@ fn synthetic_measurement(input: &str) -> String {\n\
 
         let parts = controller.state().get();
         assert_eq!(parts.model.current_match, 0);
-    }
-
-    #[gtk::test]
-    #[ignore = "progressive paging replaced by full typed loading"]
-    fn search_nav_bar_reflects_loading_jump_state() {
-        let temp_db = tempfile::NamedTempFile::new().expect("temp db");
-        seed_search_transcript(
-            temp_db.path(),
-            "test-session-123",
-            INITIAL_PAGE_SIZE + NEXT_PAGE_SIZE + 10,
-            &[10, 160],
-        );
-
-        let controller = SessionDetail::builder().launch(temp_db.path().to_path_buf());
-        controller.emit(SessionDetailMsg::SetSession {
-            session: Box::new(build_test_session(None, None, 0, 0, 0)),
-            search_query: Some("needle".to_string()),
-        });
-        pump_main_context(|| {
-            let parts = controller.state().get();
-            parts.model.match_positions.len() == 2 && !parts.model.loading_jump
-        });
-
-        controller.emit(SessionDetailMsg::NextMatch);
-        pump_main_context(|| controller.state().get().model.loading_jump);
-
-        let parts = controller.state().get();
-        assert!(parts.widgets.search_jump_spinner.is_visible());
-        assert!(parts.widgets.search_jump_spinner.is_spinning());
-        assert!(parts.widgets.loaded_match_counter_label.is_visible());
-        assert_eq!(
-            parts.widgets.loaded_match_counter_label.label(),
-            "(1/2 loaded)"
-        );
-        assert!(!parts.widgets.previous_match_button.is_sensitive());
-        assert!(!parts.widgets.next_match_button.is_sensitive());
     }
 }

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -1875,7 +1875,7 @@ impl SessionDetail {
 
     fn apply_highlight_query_to_typed_items(&self, query: Option<String>) {
         for item in self.messages.iter() {
-            item.borrow_mut().highlight_query = query.clone();
+            item.borrow_mut().apply_highlight_query(query.clone());
         }
     }
 

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -62,6 +62,7 @@ pub struct SessionDetail {
     pending_render_batch: Option<PendingRenderBatch>,
     last_render_metrics: Option<RenderMetrics>,
     pending_boundary_tool_rows: Vec<crate::database::TranscriptItemRow>,
+    typed_transcript_items: Vec<TranscriptItemData>,
     search_query: Option<String>,
     match_positions: Vec<crate::database::MatchPosition>,
     display_targets_by_item_index: BTreeMap<i64, ScrollTarget>,
@@ -905,6 +906,7 @@ impl Component for SessionDetail {
             pending_render_batch: None,
             last_render_metrics: None,
             pending_boundary_tool_rows: Vec::new(),
+            typed_transcript_items: Vec::new(),
             search_query: None,
             match_positions: Vec::new(),
             display_targets_by_item_index: BTreeMap::new(),
@@ -950,6 +952,7 @@ impl Component for SessionDetail {
                 session,
                 search_query,
             } => {
+                self.typed_transcript_items.clear();
                 self.invalidate_search_requests();
                 let normalized = search_query.and_then(|query| {
                     let trimmed = query.trim().to_string();
@@ -1103,10 +1106,9 @@ impl Component for SessionDetail {
                 self.pending_toast.set(true);
             }
             SessionDetailMsg::ToggleMessageExpand { item_index } => {
-                tracing::debug!(
-                    item_index,
-                    "Typed message expand requested before typed view wiring"
-                );
+                let toggled =
+                    toggle_typed_message_expanded(&self.typed_transcript_items, item_index);
+                tracing::debug!(item_index, toggled, "Typed message expand requested");
             }
             SessionDetailMsg::RowBuilt {
                 item_index,
@@ -1135,6 +1137,7 @@ impl Component for SessionDetail {
                 self.search_query = None;
                 self.reset_search_matches();
                 self.clear_pending_boundary_tool_rows();
+                self.typed_transcript_items.clear();
                 self.inspector.emit(ToolInspectorPaneMsg::Clear);
                 self.set_inspector_open(false, &sender);
             }

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -7,6 +7,7 @@ use std::time::{Duration, Instant};
 
 use gtk::glib;
 use gtk::prelude::*;
+use relm4::binding::Binding;
 use relm4::factory::FactoryVecDeque;
 use relm4::{
     Component, ComponentController, ComponentParts, ComponentSender, Controller, RelmWidgetExt,
@@ -23,6 +24,7 @@ use crate::ui::transcript_display::{
     DisplayTranscriptItem, group_transcript_rows, regroup_boundary, trailing_tool_call_rows,
     trailing_tool_rows_from_display,
 };
+use crate::ui::transcript_item_data::TranscriptItemData;
 use crate::ui::transcript_row::{
     TranscriptItemInit, TranscriptRow, TranscriptRowBuildKind, TranscriptRowOutput,
     transcript_item_init_from_display_item,
@@ -71,6 +73,15 @@ pub struct SessionDetail {
     pending_toast: Cell<bool>,
     inspector: Controller<ToolInspectorPane>,
     inspector_open: bool,
+}
+
+fn toggle_typed_message_expanded(items: &[TranscriptItemData], item_index: usize) -> bool {
+    let Some(item) = items.iter().find(|item| item.item_index == item_index) else {
+        return false;
+    };
+
+    item.expanded.set(!item.expanded.get());
+    true
 }
 
 /// Resolved scroll destination for global search navigation.
@@ -294,6 +305,9 @@ pub enum SessionDetailMsg {
     /// Indicates that a transcript row failed to expand to its full content and
     /// should trigger the shared toast notification path.
     ShowExpandLoadFailure,
+    ToggleMessageExpand {
+        item_index: usize,
+    },
     RowBuilt {
         item_index: usize,
         kind: TranscriptRowBuildKind,
@@ -1087,6 +1101,12 @@ impl Component for SessionDetail {
             SessionDetailMsg::ShowExpandLoadFailure => {
                 tracing::warn!("Could not load full message content");
                 self.pending_toast.set(true);
+            }
+            SessionDetailMsg::ToggleMessageExpand { item_index } => {
+                tracing::debug!(
+                    item_index,
+                    "Typed message expand requested before typed view wiring"
+                );
             }
             SessionDetailMsg::RowBuilt {
                 item_index,
@@ -2606,8 +2626,11 @@ impl SessionDetail {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
+    use std::sync::Arc;
     use std::time::Duration;
 
+    use relm4::binding::Binding;
     use relm4::{Component, ComponentController};
     use rusqlite::{Connection, params};
 
@@ -2641,6 +2664,42 @@ mod tests {
             command_count,
             ending_status: crate::models::SessionEndingStatus::Clean,
         }
+    }
+
+    #[test]
+    fn toggle_typed_message_expanded_flips_matching_item_binding() {
+        let (sender, _receiver) = relm4::channel::<SessionDetailMsg>();
+        let item = TranscriptItemData::from_init(
+            TranscriptItemInit::Message(crate::ui::transcript_row::MessageItemInit {
+                item_index: 7,
+                transcript_item_index: 11,
+                preview: crate::models::MessagePreview {
+                    session_id: "session-1".to_string(),
+                    message_index: 4,
+                    role: crate::models::Role::Assistant,
+                    content_preview: "preview".to_string(),
+                    content_len: 42,
+                    timestamp: chrono::Utc::now(),
+                    model: Some("gpt-5.4".to_string()),
+                    reasoning_preview: crate::models::ReasoningPreview::default(),
+                },
+                highlight_query: None,
+                db_path: Arc::new(PathBuf::from("/tmp/session-detail-toggle.db")),
+            }),
+            sender,
+        );
+
+        assert!(!item.expanded.get());
+        assert!(toggle_typed_message_expanded(
+            std::slice::from_ref(&item),
+            7
+        ));
+        assert!(item.expanded.get());
+        assert!(!toggle_typed_message_expanded(
+            std::slice::from_ref(&item),
+            8
+        ));
+        assert!(item.expanded.get());
     }
 
     fn pump_main_context(condition: impl Fn() -> bool) {

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -581,7 +581,9 @@ impl Component for SessionDetail {
                             gtk::Separator {},
 
                             #[local_ref]
-                            messages_box -> gtk::ListView {},
+                            messages_box -> gtk::ListView {
+                                add_css_class: "transcript-list",
+                            },
                         },
                     },
                     }, // close inspector_split (adw::OverlaySplitView)

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -2401,17 +2401,6 @@ impl SessionDetail {
         }
     }
 
-    fn reload_current_session(
-        &mut self,
-        sender: &ComponentSender<Self>,
-        clear_reason: &'static str,
-    ) {
-        if let Some(session) = &self.session {
-            let session_id = session.id.clone();
-            self.start_first_page_load(sender, &session_id, false, clear_reason);
-        }
-    }
-
     fn clear_pending_boundary_tool_rows(&mut self) {
         self.pending_boundary_tool_rows.clear();
     }

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -965,11 +965,16 @@ impl Component for SessionDetail {
                 self.invalidate_search_requests();
                 self.reset_search_matches();
 
+                if !self.messages.is_empty() {
+                    for item in self.messages.iter() {
+                        item.borrow_mut().highlight_query = normalized.clone();
+                    }
+                    self.refresh_typed_rows_preserving_scroll();
+                }
+
                 if let (Some(session), Some(query)) = (&self.session, normalized) {
                     let request_id = self.search_request_id;
                     self.spawn_match_positions_load(&sender, request_id, session.id.clone(), query);
-                } else {
-                    self.reload_current_session(&sender, "search");
                 }
             }
             SessionDetailMsg::SetMatchPositions {
@@ -1005,7 +1010,9 @@ impl Component for SessionDetail {
                 self.clamp_current_match();
                 self.pending_jump = None;
                 self.loading_jump = false;
-                self.start_first_page_load(&sender, &session_id, false, "search");
+                if self.messages.is_empty() {
+                    self.start_first_page_load(&sender, &session_id, false, "search");
+                }
                 if !self.match_positions.is_empty() {
                     self.jump_to(0, &sender);
                 }
@@ -1099,7 +1106,12 @@ impl Component for SessionDetail {
                 self.search_query = None;
                 self.invalidate_search_requests();
                 self.reset_search_matches();
-                self.reload_current_session(&sender, "clear_search");
+                if !self.messages.is_empty() {
+                    for item in self.messages.iter() {
+                        item.borrow_mut().highlight_query = None;
+                    }
+                    self.refresh_typed_rows_preserving_scroll();
+                }
             }
             SessionDetailMsg::Clear => {
                 self.invalidate_transcript_requests();
@@ -1431,15 +1443,74 @@ impl Component for SessionDetail {
         }
 
         if let Some(target) = self.scroll_to_item.take() {
-            let messages_widget: gtk::ListView = self.messages.view.clone();
+            let list_view = self.messages.view.clone();
+            list_view.scroll_to(
+                target.display_index as u32,
+                gtk::ListScrollFlags::NONE,
+                None,
+            );
             let scroll_child = widgets.scroll_child.clone();
             glib::idle_add_local_once(move || {
-                let Some(row_widget) = messages_widget
+                let Some(row_widget) = list_view
                     .observe_children()
                     .item(target.display_index as u32)
                     .and_then(|obj| obj.downcast::<gtk::ListItem>().ok())
                     .and_then(|item| item.child())
                 else {
+                    let list_view_for_tick = list_view.clone();
+                    let scroll_child_for_tick = scroll_child.clone();
+                    let tick_count = std::cell::Cell::new(0u32);
+                    list_view.add_tick_callback(move |_, _| {
+                        let ticks = tick_count.get() + 1;
+                        tick_count.set(ticks);
+                        if ticks > 60 {
+                            return glib::ControlFlow::Break;
+                        }
+                        let Some(row_widget) = list_view_for_tick
+                            .observe_children()
+                            .item(target.display_index as u32)
+                            .and_then(|obj| obj.downcast::<gtk::ListItem>().ok())
+                            .and_then(|item| item.child())
+                        else {
+                            return glib::ControlFlow::Continue;
+                        };
+                        if let Some(child_index) = target.child_index
+                            && let Some((header_button, revealer)) =
+                                Self::tool_burst_header_and_revealer(&row_widget)
+                        {
+                            if !revealer.reveals_child() {
+                                header_button.emit_clicked();
+                            }
+                            let revealer_for_tick = revealer.clone();
+                            let scroll_for_burst = scroll_child_for_tick.clone();
+                            let burst_tick_count = std::cell::Cell::new(0u32);
+                            revealer.add_tick_callback(move |_, _| {
+                                let ticks = burst_tick_count.get() + 1;
+                                burst_tick_count.set(ticks);
+                                if ticks > 60 {
+                                    return glib::ControlFlow::Break;
+                                }
+                                let Some(child_box) = revealer_for_tick
+                                    .child()
+                                    .and_then(|w| w.downcast::<gtk::Box>().ok())
+                                else {
+                                    return glib::ControlFlow::Break;
+                                };
+                                let Some(child_widget) = child_box
+                                    .observe_children()
+                                    .item(child_index as u32)
+                                    .and_then(|obj| obj.downcast::<gtk::Widget>().ok())
+                                else {
+                                    return glib::ControlFlow::Continue;
+                                };
+                                Self::scroll_widget_into_view(&child_widget, &scroll_for_burst);
+                                glib::ControlFlow::Break
+                            });
+                        } else {
+                            Self::scroll_widget_into_view(&row_widget, &scroll_child_for_tick);
+                        }
+                        glib::ControlFlow::Break
+                    });
                     return;
                 };
 
@@ -2291,7 +2362,7 @@ impl SessionDetail {
             return;
         };
 
-        if self.is_transcript_loading() {
+        if self.is_transcript_loading() && self.messages.is_empty() {
             return;
         }
 
@@ -2564,19 +2635,58 @@ impl SessionDetail {
     }
 
     /// Looks up the `(header_button, revealer)` pair for a tool-burst transcript
-    /// row. The row widget is a vertical `gtk::Box` whose first child is the
-    /// header toggle button and whose second child is the `gtk::Revealer`
-    /// holding the grouped tool call rows.
+    /// row. Typed rows wrap the page contents in a `gtk::Stack`; this traverses
+    /// the Stack's "tool-burst" named child to find the header button and
+    /// revealer.
     fn tool_burst_header_and_revealer(
         row_widget: &gtk::Widget,
     ) -> Option<(gtk::Button, gtk::Revealer)> {
-        let header_button = row_widget
+        let stack = row_widget
+            .first_child()
+            .and_then(|w| w.downcast::<gtk::Stack>().ok())?;
+        let tool_burst_page = stack
+            .child_by_name("tool-burst")
+            .and_then(|w| w.downcast::<gtk::Box>().ok())?;
+        let header_button = tool_burst_page
             .first_child()
             .and_then(|w| w.downcast::<gtk::Button>().ok())?;
         let revealer = header_button
             .next_sibling()
             .and_then(|w| w.downcast::<gtk::Revealer>().ok())?;
         Some((header_button, revealer))
+    }
+
+    /// Snapshot scroll position, clone all items, clear and re-extend to force
+    /// GTK re-bind (propagating in-place `highlight_query` mutations), then
+    /// restore scroll position via idle callback.
+    fn refresh_typed_rows_preserving_scroll(&mut self) {
+        let saved_vadj = self
+            .messages
+            .view
+            .ancestor(gtk::ScrolledWindow::static_type())
+            .and_then(|w| w.downcast::<gtk::ScrolledWindow>().ok())
+            .map(|sw| sw.vadjustment().value());
+
+        let items: Vec<TranscriptItemData> = self
+            .messages
+            .iter()
+            .map(|item| item.borrow().clone())
+            .collect();
+
+        self.messages.clear();
+        self.messages.extend_from_iter(items);
+
+        if let Some(saved_value) = saved_vadj {
+            let view = self.messages.view.clone();
+            glib::idle_add_local_once(move || {
+                if let Some(sw) = view
+                    .ancestor(gtk::ScrolledWindow::static_type())
+                    .and_then(|w| w.downcast::<gtk::ScrolledWindow>().ok())
+                {
+                    sw.vadjustment().set_value(saved_value);
+                }
+            });
+        }
     }
 
     fn scroll_widget_into_view(widget: &gtk::Widget, scroll_child: &gtk::Box) {
@@ -3221,7 +3331,7 @@ fn synthetic_measurement(input: &str) -> String {\n\
     }
 
     #[gtk::test]
-    #[ignore = "paginated batch metrics not used with full typed loading"]
+    #[ignore = "first-page typed loading does not create render batches"]
     fn session_detail_records_render_batch_measurements() {
         let temp_db = tempfile::NamedTempFile::new().expect("temp db");
         seed_message_transcript(temp_db.path(), "test-session-123", INITIAL_PAGE_SIZE + 5);
@@ -3729,7 +3839,6 @@ fn synthetic_measurement(input: &str) -> String {\n\
     }
 
     #[gtk::test]
-    #[ignore = "paginated render batch replaced by full typed loading"]
     fn jump_to_loaded_but_unrendered_match_waits_for_render_batch() {
         let temp_db = tempfile::NamedTempFile::new().expect("temp db");
         seed_search_transcript(temp_db.path(), "test-session-123", INITIAL_PAGE_SIZE, &[70]);

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -31,18 +31,18 @@ const DEFERRED_CLEAR_DELAY_MS: u64 = 250;
 
 /// Detail view for a single indexed session.
 ///
-/// This component owns the session summary header, paginated transcript
+/// This component owns the session summary header, transcript
 /// rendering, the inspector pane (right-hand split sidebar), and transcript
 /// search navigation.
 pub struct SessionDetail {
     db_path: Arc<PathBuf>,
     session: Option<Session>,
-    first_page_load_started_at: Option<Instant>,
+    transcript_load_started_at: Option<Instant>,
     messages: TypedListView<TranscriptItemData, gtk::NoSelection>,
     transcript_render_widget: gtk::Widget,
     preview_len: usize,
     loaded_count: usize,
-    loading_first_page: bool,
+    loading_transcript: bool,
     transcript_request_id: u64,
     search_query: Option<String>,
     match_positions: Vec<crate::database::MatchPosition>,
@@ -149,7 +149,7 @@ pub enum SessionDetailMsg {
 }
 
 pub enum SessionDetailCmd {
-    TranscriptPageLoaded {
+    TranscriptLoaded {
         request_id: u64,
         session_id: String,
         load_duration_ms: u128,
@@ -166,7 +166,7 @@ pub enum SessionDetailCmd {
 impl std::fmt::Debug for SessionDetailCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::TranscriptPageLoaded {
+            Self::TranscriptLoaded {
                 request_id,
                 session_id,
                 load_duration_ms,
@@ -177,7 +177,7 @@ impl std::fmt::Debug for SessionDetailCmd {
                     Err(err) => format!("Err({err})"),
                 };
 
-                f.debug_struct("TranscriptPageLoaded")
+                f.debug_struct("TranscriptLoaded")
                     .field("request_id", request_id)
                     .field("session_id", session_id)
                     .field("load_duration_ms", load_duration_ms)
@@ -665,12 +665,12 @@ impl Component for SessionDetail {
         let model = Self {
             db_path,
             session: None,
-            first_page_load_started_at: None,
+            transcript_load_started_at: None,
             messages,
             transcript_render_widget,
             preview_len: PREVIEW_LEN,
             loaded_count: 0,
-            loading_first_page: false,
+            loading_transcript: false,
             transcript_request_id: 0,
             search_query: None,
             match_positions: Vec::new(),
@@ -730,7 +730,7 @@ impl Component for SessionDetail {
                 let has_search_query = normalized.is_some();
                 let query_len = normalized.as_ref().map(|query| query.len()).unwrap_or(0);
                 self.session = Some(session);
-                self.start_first_page_load(&sender, &session_id, true, "open");
+                self.start_transcript_load(&sender, &session_id, true, "open");
                 tracing::info!(
                     request_id = self.transcript_request_id,
                     session_id = session_id.as_str(),
@@ -813,7 +813,7 @@ impl Component for SessionDetail {
                 self.pending_jump = None;
                 self.loading_jump = false;
                 if self.messages.is_empty() {
-                    self.start_first_page_load(&sender, &session_id, false, "search");
+                    self.start_transcript_load(&sender, &session_id, false, "search");
                 }
                 if !self.match_positions.is_empty() {
                     self.jump_to(0, &sender);
@@ -907,10 +907,10 @@ impl Component for SessionDetail {
                 self.invalidate_transcript_requests();
                 self.invalidate_search_requests();
                 self.session = None;
-                self.first_page_load_started_at = None;
+                self.transcript_load_started_at = None;
                 self.clear_messages_safely_with_metrics("component_clear");
                 self.loaded_count = 0;
-                self.loading_first_page = false;
+                self.loading_transcript = false;
                 self.search_query = None;
                 self.reset_search_matches();
                 self.inspector.emit(ToolInspectorPaneMsg::Clear);
@@ -1009,7 +1009,7 @@ impl Component for SessionDetail {
         _root: &Self::Root,
     ) {
         match message {
-            SessionDetailCmd::TranscriptPageLoaded { .. } => {
+            SessionDetailCmd::TranscriptLoaded { .. } => {
                 self.apply_transcript_page_result(&sender, message);
             }
             SessionDetailCmd::SearchPositionsLoaded {
@@ -1443,7 +1443,7 @@ impl SessionDetail {
     /// because `display_targets_by_item_index` is only populated as pages
     /// finish rendering.
     fn is_transcript_loading(&self) -> bool {
-        self.loading_first_page
+        self.loading_transcript
     }
 
     fn spawn_match_positions_load(
@@ -1492,7 +1492,7 @@ impl SessionDetail {
     /// `ClearSearch`). Deferring those would leave the transcript blank for
     /// 250 ms after every keystroke, since this method clears the existing
     /// rows synchronously before scheduling the load.
-    fn start_first_page_load(
+    fn start_transcript_load(
         &mut self,
         sender: &ComponentSender<Self>,
         session_id: &str,
@@ -1500,10 +1500,10 @@ impl SessionDetail {
         clear_reason: &'static str,
     ) {
         self.invalidate_transcript_requests();
-        self.loading_first_page = true;
+        self.loading_transcript = true;
         self.loaded_count = 0;
         self.clear_messages_safely_with_metrics(clear_reason);
-        self.first_page_load_started_at = Some(Instant::now());
+        self.transcript_load_started_at = Some(Instant::now());
 
         let request_id = self.transcript_request_id;
         let session_id = session_id.to_string();
@@ -1539,7 +1539,7 @@ impl SessionDetail {
                 .map_err(|err| format!("{err:#}"));
             let load_duration_ms = started_at.elapsed().as_millis();
 
-            SessionDetailCmd::TranscriptPageLoaded {
+            SessionDetailCmd::TranscriptLoaded {
                 request_id,
                 session_id,
                 load_duration_ms,
@@ -1548,14 +1548,14 @@ impl SessionDetail {
         });
     }
 
-    fn apply_first_page_rows(
+    fn apply_transcript_rows(
         &mut self,
         sender: &ComponentSender<Self>,
         request_id: u64,
         session_id: &str,
         rows: Vec<crate::database::TranscriptItemRow>,
     ) {
-        self.loading_first_page = false;
+        self.loading_transcript = false;
         self.loaded_count = rows.len();
         let highlight = self.search_query.clone();
         let db_path = self.db_path.clone();
@@ -1600,7 +1600,7 @@ impl SessionDetail {
         );
         self.clear_messages_safely_with_metrics("transcript_error");
         self.loaded_count = 0;
-        self.loading_first_page = false;
+        self.loading_transcript = false;
         self.pending_jump = None;
         self.loading_jump = false;
     }
@@ -1610,7 +1610,7 @@ impl SessionDetail {
         sender: &ComponentSender<Self>,
         message: SessionDetailCmd,
     ) {
-        let SessionDetailCmd::TranscriptPageLoaded {
+        let SessionDetailCmd::TranscriptLoaded {
             request_id,
             session_id,
             load_duration_ms,
@@ -1647,7 +1647,7 @@ impl SessionDetail {
                     load_duration_ms,
                     "Loaded transcript"
                 );
-                self.apply_first_page_rows(sender, request_id, &session_id, rows)
+                self.apply_transcript_rows(sender, request_id, &session_id, rows)
             }
             Err(err) => self.handle_transcript_page_error(&session_id, err),
         }
@@ -1738,7 +1738,7 @@ impl SessionDetail {
 
     fn prepare_for_navigation_back(&mut self, sender: &ComponentSender<Self>) {
         self.invalidate_transcript_requests();
-        self.loading_first_page = false;
+        self.loading_transcript = false;
 
         let request_id = self.transcript_request_id;
         let input_sender = sender.input_sender().clone();
@@ -1750,7 +1750,7 @@ impl SessionDetail {
     fn clear_for_navigation_back(&mut self) {
         self.invalidate_search_requests();
         self.session = None;
-        self.first_page_load_started_at = None;
+        self.transcript_load_started_at = None;
         self.clear_messages_safely_with_metrics("navigation_back");
         self.loaded_count = 0;
         self.search_query = None;
@@ -2171,7 +2171,7 @@ mod tests {
 
         pump_main_context(|| {
             let parts = controller.state().get();
-            parts.model.session.is_some() && parts.model.loading_first_page
+            parts.model.session.is_some() && parts.model.loading_transcript
         });
 
         let context = gtk::glib::MainContext::default();
@@ -2202,7 +2202,7 @@ mod tests {
                 .state()
                 .get()
                 .model
-                .first_page_load_started_at
+                .transcript_load_started_at
                 .is_some()
         });
         assert!(
@@ -2210,7 +2210,7 @@ mod tests {
                 .state()
                 .get()
                 .model
-                .first_page_load_started_at
+                .transcript_load_started_at
                 .is_some()
         );
 
@@ -2221,7 +2221,7 @@ mod tests {
                 .state()
                 .get()
                 .model
-                .first_page_load_started_at
+                .transcript_load_started_at
                 .is_none()
         );
     }
@@ -2239,7 +2239,7 @@ mod tests {
 
         pump_main_context(|| {
             let parts = controller.state().get();
-            !parts.model.loading_first_page && parts.model.messages.len() as usize == 75
+            !parts.model.loading_transcript && parts.model.messages.len() as usize == 75
         });
 
         controller.emit(SessionDetailMsg::Clear);
@@ -2455,7 +2455,7 @@ mod tests {
         });
         pump_main_context(|| {
             let parts = controller.state().get();
-            !parts.model.loading_first_page && parts.model.loaded_count == 85
+            !parts.model.loading_transcript && parts.model.loaded_count == 85
         });
 
         controller.emit(SessionDetailMsg::UpdateSearchQuery(Some(
@@ -2464,7 +2464,7 @@ mod tests {
         pump_main_context(|| {
             let parts = controller.state().get();
             parts.model.match_positions.len() == 2
-                && !parts.model.loading_first_page
+                && !parts.model.loading_transcript
                 && parts.model.display_targets_by_item_index.contains_key(&10)
         });
 
@@ -2526,7 +2526,7 @@ mod tests {
         });
         pump_main_context(|| {
             let parts = controller.state().get();
-            !parts.model.loading_first_page && parts.model.loaded_count == 75
+            !parts.model.loading_transcript && parts.model.loaded_count == 75
         });
 
         let active_request = controller.state().get().model.search_request_id;
@@ -2561,7 +2561,7 @@ mod tests {
         });
         pump_main_context(|| {
             let parts = controller.state().get();
-            parts.model.loaded_count == 75 && !parts.model.loading_first_page
+            parts.model.loaded_count == 75 && !parts.model.loading_transcript
         });
 
         let active_request = controller.state().get().model.search_request_id;

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -8,13 +8,13 @@ use std::time::{Duration, Instant};
 use gtk::glib;
 use gtk::prelude::*;
 use relm4::binding::Binding;
-use relm4::factory::FactoryVecDeque;
+use relm4::typed_view::list::TypedListView;
 use relm4::{
     Component, ComponentController, ComponentParts, ComponentSender, Controller, RelmWidgetExt,
     adw, gtk,
 };
 
-use crate::database::{MatchPosition, find_session_match_positions, load_transcript_items};
+use crate::database::{MatchPosition, find_session_match_positions, load_all_transcript_items};
 use crate::models::Session;
 use crate::ui::activity_bar::SessionActivityBar;
 use crate::ui::tool_inspector_pane::{
@@ -26,8 +26,7 @@ use crate::ui::transcript_display::{
 };
 use crate::ui::transcript_item_data::TranscriptItemData;
 use crate::ui::transcript_row::{
-    TranscriptItemInit, TranscriptRow, TranscriptRowBuildKind, TranscriptRowOutput,
-    transcript_item_init_from_display_item,
+    TranscriptItemInit, TranscriptRowBuildKind, transcript_item_init_from_display_item,
 };
 
 const INITIAL_PAGE_SIZE: usize = 75;
@@ -49,7 +48,7 @@ pub struct SessionDetail {
     db_path: Arc<PathBuf>,
     session: Option<Session>,
     first_page_load_started_at: Option<Instant>,
-    messages: FactoryVecDeque<TranscriptRow>,
+    messages: TypedListView<TranscriptItemData, gtk::NoSelection>,
     transcript_render_widget: gtk::Widget,
     initial_page_size: usize,
     page_size: usize,
@@ -62,7 +61,6 @@ pub struct SessionDetail {
     pending_render_batch: Option<PendingRenderBatch>,
     last_render_metrics: Option<RenderMetrics>,
     pending_boundary_tool_rows: Vec<crate::database::TranscriptItemRow>,
-    typed_transcript_items: Vec<TranscriptItemData>,
     search_query: Option<String>,
     match_positions: Vec<crate::database::MatchPosition>,
     display_targets_by_item_index: BTreeMap<i64, ScrollTarget>,
@@ -740,10 +738,7 @@ impl Component for SessionDetail {
                             gtk::Separator {},
 
                             #[local_ref]
-                            messages_box -> gtk::Box {
-                                set_orientation: gtk::Orientation::Vertical,
-                                set_spacing: 8,
-                            },
+                            messages_box -> gtk::ListView {},
 
                             #[name = "load_more_button"]
                             gtk::Button {
@@ -856,30 +851,8 @@ impl Component for SessionDetail {
         root: Self::Root,
         sender: ComponentSender<Self>,
     ) -> ComponentParts<Self> {
-        let messages: FactoryVecDeque<TranscriptRow> = FactoryVecDeque::builder()
-            .launch_default()
-            .forward(sender.input_sender(), |output| match output {
-                TranscriptRowOutput::ExpandLoadFailed { .. } => {
-                    SessionDetailMsg::ShowExpandLoadFailure
-                }
-                TranscriptRowOutput::InspectToolCall(id) => SessionDetailMsg::InspectToolCall(id),
-                TranscriptRowOutput::InspectSubagent(id) => SessionDetailMsg::InspectSubagent(id),
-                TranscriptRowOutput::InspectReasoning {
-                    transcript_item_index,
-                    ..
-                } => SessionDetailMsg::InspectReasoning(transcript_item_index),
-                TranscriptRowOutput::RowBuilt {
-                    item_index,
-                    kind,
-                    build_duration_ms,
-                } => SessionDetailMsg::RowBuilt {
-                    item_index,
-                    kind,
-                    build_duration_ms,
-                },
-            });
-
-        let transcript_render_widget = messages.widget().clone().upcast::<gtk::Widget>();
+        let messages: TypedListView<TranscriptItemData, gtk::NoSelection> = TypedListView::new();
+        let transcript_render_widget = messages.view.clone().upcast::<gtk::Widget>();
         let db_path = Arc::new(db_path);
         let inspector = ToolInspectorPane::builder()
             .launch(db_path.clone())
@@ -906,7 +879,6 @@ impl Component for SessionDetail {
             pending_render_batch: None,
             last_render_metrics: None,
             pending_boundary_tool_rows: Vec::new(),
-            typed_transcript_items: Vec::new(),
             search_query: None,
             match_positions: Vec::new(),
             display_targets_by_item_index: BTreeMap::new(),
@@ -920,7 +892,7 @@ impl Component for SessionDetail {
             inspector_open: false,
         };
 
-        let messages_box = model.messages.widget();
+        let messages_box = model.messages.view.clone();
         let widgets = view_output!();
 
         widgets
@@ -952,7 +924,6 @@ impl Component for SessionDetail {
                 session,
                 search_query,
             } => {
-                self.typed_transcript_items.clear();
                 self.invalidate_search_requests();
                 let normalized = search_query.and_then(|query| {
                     let trimmed = query.trim().to_string();
@@ -1106,8 +1077,13 @@ impl Component for SessionDetail {
                 self.pending_toast.set(true);
             }
             SessionDetailMsg::ToggleMessageExpand { item_index } => {
-                let toggled =
-                    toggle_typed_message_expanded(&self.typed_transcript_items, item_index);
+                let toggled = if let Some(item) = self.messages.get(item_index as u32) {
+                    let expanded = item.borrow().expanded.get();
+                    item.borrow().expanded.set(!expanded);
+                    true
+                } else {
+                    false
+                };
                 tracing::debug!(item_index, toggled, "Typed message expand requested");
             }
             SessionDetailMsg::RowBuilt {
@@ -1137,7 +1113,6 @@ impl Component for SessionDetail {
                 self.search_query = None;
                 self.reset_search_matches();
                 self.clear_pending_boundary_tool_rows();
-                self.typed_transcript_items.clear();
                 self.inspector.emit(ToolInspectorPaneMsg::Clear);
                 self.set_inspector_open(false, &sender);
             }
@@ -1454,13 +1429,14 @@ impl Component for SessionDetail {
         }
 
         if let Some(target) = self.scroll_to_item.take() {
-            let messages_widget = self.messages.widget().clone();
+            let messages_widget: gtk::ListView = self.messages.view.clone();
             let scroll_child = widgets.scroll_child.clone();
             glib::idle_add_local_once(move || {
                 let Some(row_widget) = messages_widget
                     .observe_children()
                     .item(target.display_index as u32)
-                    .and_then(|obj| obj.downcast::<gtk::Widget>().ok())
+                    .and_then(|obj| obj.downcast::<gtk::ListItem>().ok())
+                    .and_then(|item| item.child())
                 else {
                     return;
                 };
@@ -1733,14 +1709,8 @@ impl SessionDetail {
 
         sender.spawn_oneshot_command(move || {
             let started_at = Instant::now();
-            let result = load_transcript_items(
-                &db_path,
-                &session_id,
-                limit as i64,
-                offset as i64,
-                preview_len,
-            )
-            .map_err(|err| format!("{err:#}"));
+            let result = load_all_transcript_items(&db_path, &session_id, preview_len)
+                .map_err(|err| format!("{err:#}"));
             let load_duration_ms = started_at.elapsed().as_millis();
 
             SessionDetailCmd::TranscriptPageLoaded {
@@ -1883,10 +1853,10 @@ impl SessionDetail {
             .unwrap_or(Duration::ZERO);
         batch.max_schedule_gap = batch.max_schedule_gap.max(schedule_gap);
 
-        let mut guard = self.messages.guard();
         let push_started_at = Instant::now();
         let mut rendered_this_batch = 0usize;
         let render_batch_index = batch.batch_count + 1;
+        let input_sender = sender.input_sender().clone();
         for _ in 0..RENDER_BATCH_SIZE {
             let Some(item) = batch.items.pop_front() else {
                 break;
@@ -1894,7 +1864,8 @@ impl SessionDetail {
             batch
                 .item_render_batch_indices
                 .insert(item.item_index(), render_batch_index);
-            guard.push_back(item);
+            self.messages
+                .append(TranscriptItemData::from_init(item, input_sender.clone()));
             rendered_this_batch += 1;
         }
         let push_duration = push_started_at.elapsed();
@@ -1922,7 +1893,6 @@ impl SessionDetail {
             logged: false,
         });
         batch.last_batch_completed_at = Some(Instant::now());
-        drop(guard);
 
         if has_more_items {
             tracing::debug!(
@@ -2146,11 +2116,11 @@ impl SessionDetail {
     ) {
         self.loading_first_page = false;
         self.loading_next_page = false;
-        self.has_more_messages = rows.len() == limit;
+        self.has_more_messages = false;
         self.loaded_count = rows.len();
         let highlight = self.search_query.clone();
         let db_path = self.db_path.clone();
-        self.track_pending_boundary_tool_rows(&rows);
+        self.clear_pending_boundary_tool_rows();
         self.clear_messages_safely_with_metrics("first_page_apply");
         let build_started_at = Instant::now();
         let source_row_count = rows.len();
@@ -2174,13 +2144,14 @@ impl SessionDetail {
             build_duration_ms = build_started_at.elapsed().as_millis(),
             "Prepared first transcript page"
         );
-        self.queue_transcript_items_for_render(
-            sender,
-            request_id,
-            0,
-            source_row_count,
-            prepared.items,
-        );
+
+        let input_sender = sender.input_sender().clone();
+        let items: Vec<TranscriptItemData> = prepared
+            .items
+            .into_iter()
+            .map(|init| TranscriptItemData::from_init(init, input_sender.clone()))
+            .collect();
+        self.messages.extend_from_iter(items);
         self.continue_pending_jump(sender);
     }
 
@@ -2327,7 +2298,7 @@ impl SessionDetail {
             .display_targets_by_item_index
             .get(&position.item_index)
             .copied()
-            && self.messages.len() > scroll_target.display_index
+            && (self.messages.len() as usize) > scroll_target.display_index
         {
             self.pending_jump = None;
             self.loading_jump = false;
@@ -2470,7 +2441,8 @@ impl SessionDetail {
         }
         let matched_item_indexes = self.current_match_item_indexes();
 
-        let pre_replacement_len = self.messages.len() - if need_replacement { 1 } else { 0 };
+        let pre_replacement_len = self.messages.len() as usize;
+        let pre_replacement_len = pre_replacement_len - if need_replacement { 1 } else { 0 };
 
         let mut replacement_targets = BTreeMap::new();
         let mut replacement_inits = Vec::new();
@@ -2508,15 +2480,13 @@ impl SessionDetail {
         );
         let display_item_count = prepared.items.len();
 
-        {
-            let mut guard = self.messages.guard();
-            if need_replacement {
-                let _ = guard.pop_back();
-                for item in replacement_inits {
-                    guard.push_back(item);
-                }
+        let input_sender = sender.input_sender().clone();
+        if need_replacement {
+            self.messages.remove(self.messages.len() - 1);
+            for item in replacement_inits {
+                self.messages
+                    .append(TranscriptItemData::from_init(item, input_sender.clone()));
             }
-            drop(guard);
         }
 
         self.extend_display_targets(replacement_targets);
@@ -2548,12 +2518,12 @@ impl SessionDetail {
     /// Clear transcript rows after releasing focus from any currently-focused row widget.
     fn clear_messages_safely(&mut self) {
         self.release_focus_from_transcript_if_needed();
-        self.messages.guard().clear();
+        self.messages.clear();
         self.display_targets_by_item_index.clear();
     }
 
     fn clear_messages_safely_with_metrics(&mut self, reason: &'static str) -> ClearMessagesMetrics {
-        let row_count_before = self.messages.len();
+        let row_count_before = self.messages.len() as usize;
         let had_pending_render = self.pending_render_batch.is_some();
         let started_at = Instant::now();
         self.clear_messages_safely();
@@ -2574,7 +2544,7 @@ impl SessionDetail {
 
     /// Avoid GTK focus traversing a row subtree while it is being replaced.
     fn release_focus_from_transcript_if_needed(&self) {
-        let messages_widget = self.messages.widget();
+        let messages_widget: gtk::Widget = self.messages.view.clone().upcast();
         let Some(window) = messages_widget
             .ancestor(gtk::Window::static_type())
             .and_then(|w| w.downcast::<gtk::Window>().ok())
@@ -2586,7 +2556,7 @@ impl SessionDetail {
             return;
         };
 
-        if focus_widget.is_ancestor(messages_widget) {
+        if focus_widget.is_ancestor(&messages_widget) {
             tracing::debug!("Clearing window focus before replacing transcript rows");
             gtk::prelude::GtkWindowExt::set_focus(&window, Option::<&gtk::Widget>::None);
         }
@@ -3203,7 +3173,7 @@ fn synthetic_measurement(input: &str) -> String {\n\
         pump_main_context_draining_transcript_batches(&controller, Duration::from_secs(5), || {
             let parts = controller.state().get();
             parts.model.pending_render_batch.is_none()
-                && parts.model.messages.len() == INITIAL_PAGE_SIZE
+                && parts.model.messages.len() as usize == INITIAL_PAGE_SIZE
         });
 
         controller.emit(SessionDetailMsg::Clear);
@@ -3232,6 +3202,7 @@ fn synthetic_measurement(input: &str) -> String {\n\
     }
 
     #[gtk::test]
+    #[ignore = "paginated loading replaced by full typed loading"]
     fn session_detail_loads_transcript_pages_incrementally() {
         let temp_db = tempfile::NamedTempFile::new().expect("temp db");
         seed_message_transcript(temp_db.path(), "test-session-123", INITIAL_PAGE_SIZE + 5);
@@ -3250,7 +3221,7 @@ fn synthetic_measurement(input: &str) -> String {\n\
         {
             let parts = controller.state().get();
             assert_eq!(parts.model.loaded_count, INITIAL_PAGE_SIZE);
-            assert!(parts.model.messages.len() < INITIAL_PAGE_SIZE);
+            assert!((parts.model.messages.len() as usize) < INITIAL_PAGE_SIZE);
             assert!(parts.model.pending_render_batch.is_some());
             assert!(parts.model.has_more_messages);
         }
@@ -3258,7 +3229,7 @@ fn synthetic_measurement(input: &str) -> String {\n\
         pump_main_context_draining_transcript_batches(&controller, Duration::from_secs(5), || {
             let parts = controller.state().get();
             parts.model.pending_render_batch.is_none()
-                && parts.model.messages.len() == INITIAL_PAGE_SIZE
+                && parts.model.messages.len() as usize == INITIAL_PAGE_SIZE
         });
 
         controller.emit(SessionDetailMsg::LoadMore);
@@ -3271,13 +3242,13 @@ fn synthetic_measurement(input: &str) -> String {\n\
         {
             let parts = controller.state().get();
             assert_eq!(parts.model.loaded_count, INITIAL_PAGE_SIZE + 5);
-            assert!(parts.model.messages.len() < INITIAL_PAGE_SIZE + 5);
+            assert!((parts.model.messages.len() as usize) < INITIAL_PAGE_SIZE + 5);
         }
 
         pump_main_context_draining_transcript_batches(&controller, Duration::from_secs(5), || {
             let parts = controller.state().get();
             parts.model.pending_render_batch.is_none()
-                && parts.model.messages.len() == INITIAL_PAGE_SIZE + 5
+                && parts.model.messages.len() as usize == INITIAL_PAGE_SIZE + 5
         });
 
         let parts = controller.state().get();
@@ -3285,6 +3256,7 @@ fn synthetic_measurement(input: &str) -> String {\n\
     }
 
     #[gtk::test]
+    #[ignore = "paginated batch metrics not used with full typed loading"]
     fn session_detail_records_render_batch_measurements() {
         let temp_db = tempfile::NamedTempFile::new().expect("temp db");
         seed_message_transcript(temp_db.path(), "test-session-123", INITIAL_PAGE_SIZE + 5);
@@ -3303,13 +3275,13 @@ fn synthetic_measurement(input: &str) -> String {\n\
         {
             let parts = controller.state().get();
             assert!(parts.model.pending_render_batch.is_some());
-            assert!(parts.model.messages.len() < INITIAL_PAGE_SIZE);
+            assert!((parts.model.messages.len() as usize) < INITIAL_PAGE_SIZE);
         }
 
         pump_main_context_draining_transcript_batches(&controller, Duration::from_secs(5), || {
             let parts = controller.state().get();
             parts.model.pending_render_batch.is_none()
-                && parts.model.messages.len() == INITIAL_PAGE_SIZE
+                && parts.model.messages.len() as usize == INITIAL_PAGE_SIZE
         });
 
         let parts = controller.state().get();
@@ -3691,7 +3663,7 @@ fn synthetic_measurement(input: &str) -> String {\n\
         pump_main_context_draining_transcript_batches(&controller, Duration::from_secs(5), || {
             let parts = controller.state().get();
             parts.model.pending_render_batch.is_none()
-                && parts.model.loaded_count == INITIAL_PAGE_SIZE
+                && parts.model.loaded_count == INITIAL_PAGE_SIZE + 10
         });
 
         controller.emit(SessionDetailMsg::UpdateSearchQuery(Some(
@@ -3792,6 +3764,7 @@ fn synthetic_measurement(input: &str) -> String {\n\
     }
 
     #[gtk::test]
+    #[ignore = "paginated render batch replaced by full typed loading"]
     fn jump_to_loaded_but_unrendered_match_waits_for_render_batch() {
         let temp_db = tempfile::NamedTempFile::new().expect("temp db");
         seed_search_transcript(temp_db.path(), "test-session-123", INITIAL_PAGE_SIZE, &[70]);
@@ -3825,6 +3798,7 @@ fn synthetic_measurement(input: &str) -> String {\n\
     }
 
     #[gtk::test]
+    #[ignore = "progressive paging replaced by full typed loading"]
     fn jump_to_unloaded_match_triggers_progressive_loading_after_each_render_batch() {
         let temp_db = tempfile::NamedTempFile::new().expect("temp db");
         seed_search_transcript(
@@ -3851,7 +3825,7 @@ fn synthetic_measurement(input: &str) -> String {\n\
         controller.emit(SessionDetailMsg::NextMatch);
         pump_main_context_draining_transcript_batches(&controller, Duration::from_secs(5), || {
             let parts = controller.state().get();
-            parts.model.loaded_count == INITIAL_PAGE_SIZE + NEXT_PAGE_SIZE
+            parts.model.loaded_count == INITIAL_PAGE_SIZE + NEXT_PAGE_SIZE + 10
                 && parts.model.pending_render_batch.is_none()
                 && !parts.model.loading_jump
         });
@@ -3892,6 +3866,7 @@ fn synthetic_measurement(input: &str) -> String {\n\
     }
 
     #[gtk::test]
+    #[ignore = "progressive paging replaced by full typed loading"]
     fn search_nav_bar_reflects_loading_jump_state() {
         let temp_db = tempfile::NamedTempFile::new().expect("temp db");
         seed_search_transcript(

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -1450,6 +1450,24 @@ impl Component for SessionDetail {
     }
 }
 
+/// Search highlighting must stay aligned with match navigation: `Next` /
+/// `Previous` and the match counter are produced from `find_session_match_positions`,
+/// which only reports message-kind FTS matches. Highlighting tool calls, tool
+/// bursts, or unmatched messages would show highlights and burst match badges
+/// that navigation can never reach and the counter never includes.
+fn highlight_query_for_navigable_row(
+    is_message: bool,
+    transcript_item_index: i64,
+    matched_item_indexes: &BTreeSet<i64>,
+    highlight_query: Option<&str>,
+) -> Option<String> {
+    if is_message && matched_item_indexes.contains(&transcript_item_index) {
+        highlight_query.map(str::to_string)
+    } else {
+        None
+    }
+}
+
 impl SessionDetail {
     fn current_match_item_indexes(&self) -> BTreeSet<i64> {
         self.match_positions
@@ -1496,7 +1514,7 @@ impl SessionDetail {
         rows: Vec<crate::database::TranscriptItemRow>,
         session_id: &str,
         highlight_query: Option<String>,
-        _matched_item_indexes: &BTreeSet<i64>,
+        matched_item_indexes: &BTreeSet<i64>,
         db_path: Arc<PathBuf>,
         base_display_index: usize,
     ) -> PreparedTranscriptItems {
@@ -1508,7 +1526,15 @@ impl SessionDetail {
             display_targets_by_item_index
                 .extend(Self::display_targets_for_item(display_index, &item));
 
-            let item_highlight = highlight_query.clone();
+            let item_highlight = match &item {
+                DisplayTranscriptItem::Single(row) => highlight_query_for_navigable_row(
+                    row.kind == crate::models::TranscriptItemKind::Message,
+                    row.item_index,
+                    matched_item_indexes,
+                    highlight_query.as_deref(),
+                ),
+                DisplayTranscriptItem::ToolBurst(_) => None,
+            };
 
             items.push(transcript_item_init_from_display_item(
                 display_index,
@@ -1906,8 +1932,23 @@ impl SessionDetail {
     }
 
     fn apply_highlight_query_to_typed_items(&self, query: Option<String>) {
+        let matched_item_indexes = self.current_match_item_indexes();
         for item in self.messages.iter() {
-            item.borrow_mut().apply_highlight_query(query.clone());
+            let mut data = item.borrow_mut();
+            let is_message = matches!(
+                data.kind,
+                crate::ui::transcript_item_data::TranscriptItemKind::Message(_)
+            );
+            let item_query = match data.transcript_item_index {
+                Some(transcript_item_index) => highlight_query_for_navigable_row(
+                    is_message,
+                    transcript_item_index,
+                    &matched_item_indexes,
+                    query.as_deref(),
+                ),
+                None => None,
+            };
+            data.apply_highlight_query(item_query);
         }
     }
 
@@ -1998,12 +2039,15 @@ impl SessionDetail {
         Some((header_button, revealer))
     }
 
+    /// Resolves the named transcript row root from a [`gtk::ListView`] child.
+    ///
+    /// `GtkListView` wraps every factory-produced row in an internal
+    /// `GtkListItemWidget`; the row root we name `transcript-row-{index}` is
+    /// that wrapper's child, so the wrapper itself never carries the name.
+    /// Descend one level when a child exists, otherwise return the widget as-is.
     fn list_view_row_widget_from_child(obj: gtk::glib::Object) -> Option<gtk::Widget> {
-        if let Ok(list_item) = obj.clone().downcast::<gtk::ListItem>() {
-            return list_item.child();
-        }
-
-        obj.downcast::<gtk::Widget>().ok()
+        let widget = obj.downcast::<gtk::Widget>().ok()?;
+        Some(widget.first_child().unwrap_or(widget))
     }
 
     fn observed_row_widget_for_display_index(
@@ -2315,7 +2359,7 @@ mod tests {
     }
 
     #[test]
-    fn build_display_items_applies_search_highlight_query_to_all_rows() {
+    fn build_display_items_limits_search_highlight_to_navigable_matches() {
         let rows = vec![
             transcript_message_row(0, crate::models::Role::Assistant, "needle in counted row"),
             transcript_tool_row(1, "Read"),
@@ -2325,6 +2369,7 @@ mod tests {
                 "needle outside fts result",
             ),
         ];
+        // Only item 0 is an FTS match that Next/Previous can navigate to.
         let matched_item_indexes = BTreeSet::from([0_i64]);
 
         let prepared = SessionDetail::build_display_items(
@@ -2338,7 +2383,11 @@ mod tests {
 
         match &prepared.items[0] {
             TranscriptItemInit::Message(message) => {
-                assert_eq!(message.highlight_query.as_deref(), Some("needle"));
+                assert_eq!(
+                    message.highlight_query.as_deref(),
+                    Some("needle"),
+                    "a matched message row must be highlighted"
+                );
             }
             other => panic!(
                 "expected first item to be a message, got {:?}",
@@ -2348,7 +2397,11 @@ mod tests {
 
         match &prepared.items[1] {
             TranscriptItemInit::ToolCall(tool_call) => {
-                assert_eq!(tool_call.highlight_query.as_deref(), Some("needle"));
+                assert_eq!(
+                    tool_call.highlight_query.as_deref(),
+                    None,
+                    "tool-call rows are not in the FTS match list and must not be highlighted"
+                );
             }
             other => panic!(
                 "expected second item to be a tool call, got {:?}",
@@ -2358,7 +2411,11 @@ mod tests {
 
         match &prepared.items[2] {
             TranscriptItemInit::Message(message) => {
-                assert_eq!(message.highlight_query.as_deref(), Some("needle"));
+                assert_eq!(
+                    message.highlight_query.as_deref(),
+                    None,
+                    "a message row outside the FTS match list must not be highlighted"
+                );
             }
             other => panic!(
                 "expected third item to be a message, got {:?}",
@@ -2690,6 +2747,51 @@ mod tests {
     }
 
     #[gtk::test]
+    fn search_highlight_is_limited_to_navigable_message_matches() {
+        let temp_db = tempfile::NamedTempFile::new().expect("temp db");
+        seed_search_transcript(temp_db.path(), "test-session-123", 12, &[3, 9]);
+
+        let controller = SessionDetail::builder().launch(temp_db.path().to_path_buf());
+        controller.emit(SessionDetailMsg::SetSession {
+            session: Box::new(build_test_session(None, None, 0, 0, 0)),
+            search_query: None,
+        });
+        pump_main_context(|| {
+            let parts = controller.state().get();
+            !parts.model.loading_transcript && parts.model.loaded_count == 12
+        });
+
+        controller.emit(SessionDetailMsg::UpdateSearchQuery(Some(
+            "needle".to_string(),
+        )));
+        pump_main_context(|| {
+            let parts = controller.state().get();
+            parts.model.match_positions.len() == 2 && !parts.model.loading_transcript
+        });
+
+        let parts = controller.state().get();
+        let highlighted: Vec<(i64, bool)> = parts
+            .model
+            .messages
+            .iter()
+            .filter_map(|item| {
+                let data = item.borrow();
+                data.transcript_item_index
+                    .map(|idx| (idx, data.highlight_query.is_some()))
+            })
+            .collect();
+
+        assert_eq!(highlighted.len(), 12);
+        for (idx, has_highlight) in highlighted {
+            let is_navigable_match = idx == 3 || idx == 9;
+            assert_eq!(
+                has_highlight, is_navigable_match,
+                "row {idx} highlight must match whether Next/Previous can reach it"
+            );
+        }
+    }
+
+    #[gtk::test]
     fn stale_search_result_is_discarded() {
         let temp_db = tempfile::NamedTempFile::new().expect("temp db");
         seed_search_transcript(temp_db.path(), "test-session-123", 75, &[5]);
@@ -2731,6 +2833,57 @@ mod tests {
             .expect("direct widget child should resolve");
 
         assert_eq!(resolved, row);
+    }
+
+    /// Builds a realized `GtkListView` whose rows carry `transcript-row-{index}`
+    /// names, mirroring how the typed transcript view names its row roots.
+    fn realized_named_list_view(row_count: u32) -> (gtk::Window, gtk::ListView) {
+        let items: Vec<String> = (0..row_count).map(|i| i.to_string()).collect();
+        let item_refs: Vec<&str> = items.iter().map(String::as_str).collect();
+        let model = gtk::StringList::new(&item_refs);
+        let factory = gtk::SignalListItemFactory::new();
+        factory.connect_setup(|_, list_item| {
+            let list_item = list_item.downcast_ref::<gtk::ListItem>().unwrap();
+            list_item.set_child(Some(&gtk::Label::new(Some("row"))));
+        });
+        factory.connect_bind(|_, list_item| {
+            let list_item = list_item.downcast_ref::<gtk::ListItem>().unwrap();
+            let pos = list_item.position();
+            if let Some(child) = list_item.child() {
+                child.set_widget_name(&format!("{TRANSCRIPT_ROW_WIDGET_NAME_PREFIX}{pos}"));
+            }
+        });
+
+        let selection = gtk::NoSelection::new(Some(model));
+        let list_view = gtk::ListView::new(Some(selection), Some(factory));
+        let window = gtk::Window::new();
+        window.set_default_size(400, 600);
+        window.set_child(Some(&list_view));
+        window.present();
+
+        let deadline = std::time::Instant::now() + Duration::from_millis(800);
+        let context = gtk::glib::MainContext::default();
+        while std::time::Instant::now() < deadline && list_view.observe_children().n_items() == 0 {
+            context.iteration(true);
+        }
+
+        (window, list_view)
+    }
+
+    #[gtk::test]
+    fn observed_row_widget_finds_named_row_through_list_item_wrapper() {
+        let (window, list_view) = realized_named_list_view(3);
+
+        let resolved = SessionDetail::observed_row_widget_for_display_index(&list_view, 1)
+            .expect("row 1 widget must be resolvable from the realized ListView");
+        assert_eq!(
+            resolved.widget_name().as_str(),
+            "transcript-row-1",
+            "the resolved widget must be the named transcript row root, \
+             not the GtkListView's internal list-item wrapper"
+        );
+
+        window.destroy();
     }
 
     #[gtk::test]

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -1077,13 +1077,24 @@ impl Component for SessionDetail {
                 self.pending_toast.set(true);
             }
             SessionDetailMsg::ToggleMessageExpand { item_index } => {
-                let toggled = if let Some(item) = self.messages.get(item_index as u32) {
-                    let expanded = item.borrow().expanded.get();
-                    item.borrow().expanded.set(!expanded);
-                    true
+                let idx = item_index as u32;
+                let (toggled, clone_opt) = if let Some(item) = self.messages.get(idx) {
+                    let ref_data = item.borrow();
+                    let expanded = ref_data.expanded.get();
+                    ref_data.expanded.set(!expanded);
+                    let clone = ref_data.clone();
+                    (true, Some(clone))
                 } else {
-                    false
+                    (false, None)
                 };
+                if let Some(clone) = clone_opt {
+                    self.messages.remove(idx);
+                    self.messages.insert(idx, clone);
+                    tracing::info!(
+                        item_index,
+                        "Full message content load not yet wired for the typed path"
+                    );
+                }
                 tracing::debug!(item_index, toggled, "Typed message expand requested");
             }
             SessionDetailMsg::RowBuilt {

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use adw::prelude::BreakpointBinExt;
 use gtk::glib;
 use gtk::prelude::*;
 use relm4::binding::Binding;
@@ -265,6 +266,15 @@ impl Component for SessionDetail {
 
                     #[name = "detail_overlay"]
                     gtk::Overlay {
+
+                    #[wrap(Some)]
+                    #[name = "inspector_breakpoint_bin"]
+                    set_child = &adw::BreakpointBin {
+                        set_vexpand: true,
+                        // BreakpointBin only collapses the split once it can be
+                        // allocated narrower than the split's natural width, so
+                        // it needs a small minimum size of its own.
+                        set_width_request: 360,
 
                     #[wrap(Some)]
                     #[name = "inspector_split"]
@@ -587,6 +597,7 @@ impl Component for SessionDetail {
                         },
                     },
                     }, // close inspector_split (adw::OverlaySplitView)
+                    }, // close inspector_breakpoint_bin (adw::BreakpointBin)
 
                     // Floating search navigation bar
                     add_overlay = &gtk::Box {
@@ -736,6 +747,25 @@ impl Component for SessionDetail {
                     ))
                     .ok();
             });
+
+        // Collapse the inspector into an overlay when the detail area is too
+        // narrow to host the 360px sidebar beside a readable transcript.
+        // Without this the split keeps the sidebar inline and forces the
+        // window past its minimum width, which in turn disrupts the header bar.
+        //
+        // The threshold sits well above the inline layout's natural minimum
+        // (360px sidebar + a usable transcript): if it were close to that
+        // minimum, there would be a band of widths where the split is still
+        // inline but allocated below its minimum, rendering the pane wrong.
+        let inspector_breakpoint = adw::Breakpoint::new(adw::BreakpointCondition::new_length(
+            adw::BreakpointConditionLengthType::MaxWidth,
+            860.0,
+            adw::LengthUnit::Sp,
+        ));
+        inspector_breakpoint.add_setter(&widgets.inspector_split, "collapsed", Some(&true.into()));
+        widgets
+            .inspector_breakpoint_bin
+            .add_breakpoint(inspector_breakpoint);
 
         ComponentParts { model, widgets }
     }

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -13,7 +13,10 @@ use relm4::{
     adw, gtk,
 };
 
-use crate::database::{MatchPosition, find_session_match_positions, load_all_transcript_items};
+use crate::database::{
+    MatchPosition, find_session_match_positions, load_all_transcript_items,
+    load_message_full_content,
+};
 use crate::models::Session;
 use crate::ui::activity_bar::SessionActivityBar;
 use crate::ui::tool_inspector_pane::{
@@ -24,6 +27,7 @@ use crate::ui::transcript_item_data::TranscriptItemData;
 use crate::ui::transcript_row::{
     TranscriptItemInit, TranscriptRowBuildKind, transcript_item_init_from_display_item,
 };
+use crate::ui::typed_transcript_row::TRANSCRIPT_ROW_WIDGET_NAME_PREFIX;
 
 const PREVIEW_LEN: usize = 2000;
 const DEFERRED_FIRST_PAGE_LOAD_DELAY_MS: u64 = 250;
@@ -161,6 +165,12 @@ pub enum SessionDetailCmd {
         load_duration_ms: u128,
         result: Result<Vec<MatchPosition>, String>,
     },
+    MessageFullContentReady {
+        item_index: usize,
+        session_id: String,
+        message_index: usize,
+        result: Result<String, String>,
+    },
 }
 
 impl std::fmt::Debug for SessionDetailCmd {
@@ -198,6 +208,23 @@ impl std::fmt::Debug for SessionDetailCmd {
                     .field("request_id", request_id)
                     .field("session_id", session_id)
                     .field("load_duration_ms", load_duration_ms)
+                    .field("result", &result_summary)
+                    .finish()
+            }
+            Self::MessageFullContentReady {
+                item_index,
+                session_id,
+                message_index,
+                result,
+            } => {
+                let result_summary = match result {
+                    Ok(content) => format!("Ok({} chars)", content.len()),
+                    Err(err) => format!("Err({err})"),
+                };
+                f.debug_struct("MessageFullContentReady")
+                    .field("item_index", item_index)
+                    .field("session_id", session_id)
+                    .field("message_index", message_index)
                     .field("result", &result_summary)
                     .finish()
             }
@@ -768,9 +795,7 @@ impl Component for SessionDetail {
                 self.reset_search_matches();
 
                 if !self.messages.is_empty() {
-                    for item in self.messages.iter() {
-                        item.borrow_mut().highlight_query = normalized.clone();
-                    }
+                    self.apply_highlight_query_to_typed_items(normalized.clone());
                     self.refresh_typed_rows_preserving_scroll();
                 }
 
@@ -814,6 +839,9 @@ impl Component for SessionDetail {
                 self.loading_jump = false;
                 if self.messages.is_empty() {
                     self.start_transcript_load(&sender, &session_id, false, "search");
+                } else {
+                    self.apply_highlight_query_to_typed_items(self.search_query.clone());
+                    self.refresh_typed_rows_preserving_scroll();
                 }
                 if !self.match_positions.is_empty() {
                     self.jump_to(0, &sender);
@@ -866,10 +894,23 @@ impl Component for SessionDetail {
             }
             SessionDetailMsg::ToggleMessageExpand { item_index } => {
                 let idx = item_index as u32;
+                let mut load_request = None;
                 let (toggled, clone_opt) = if let Some(item) = self.messages.get(idx) {
                     let ref_data = item.borrow();
                     let expanded = ref_data.expanded.get();
-                    ref_data.expanded.set(!expanded);
+                    let will_expand = !expanded;
+                    ref_data.expanded.set(will_expand);
+                    if will_expand
+                        && ref_data.full_content.is_none()
+                        && let crate::ui::transcript_item_data::TranscriptItemKind::Message(message) =
+                            &ref_data.kind
+                    {
+                        load_request = Some((
+                            message.db_path.clone(),
+                            message.preview.session_id.clone(),
+                            message.preview.message_index,
+                        ));
+                    }
                     let clone = ref_data.clone();
                     (true, Some(clone))
                 } else {
@@ -878,10 +919,21 @@ impl Component for SessionDetail {
                 if let Some(clone) = clone_opt {
                     self.messages.remove(idx);
                     self.messages.insert(idx, clone);
-                    tracing::info!(
-                        item_index,
-                        "Full message content load not yet wired for the typed path"
-                    );
+                    if let Some((db_path, session_id, message_index)) = load_request {
+                        sender.spawn_oneshot_command(move || {
+                            SessionDetailCmd::MessageFullContentReady {
+                                item_index,
+                                session_id: session_id.clone(),
+                                message_index,
+                                result: load_message_full_content(
+                                    &db_path,
+                                    &session_id,
+                                    message_index,
+                                )
+                                .map_err(|err| format!("{err:#}")),
+                            }
+                        });
+                    }
                 }
                 tracing::debug!(item_index, toggled, "Typed message expand requested");
             }
@@ -897,9 +949,7 @@ impl Component for SessionDetail {
                 self.invalidate_search_requests();
                 self.reset_search_matches();
                 if !self.messages.is_empty() {
-                    for item in self.messages.iter() {
-                        item.borrow_mut().highlight_query = None;
-                    }
+                    self.apply_highlight_query_to_typed_items(None);
                     self.refresh_typed_rows_preserving_scroll();
                 }
             }
@@ -1050,6 +1100,35 @@ impl Component for SessionDetail {
                         session_id,
                         positions,
                     });
+            }
+            SessionDetailCmd::MessageFullContentReady {
+                item_index,
+                session_id,
+                message_index,
+                result,
+            } => {
+                if !self.typed_message_full_content_target_matches(
+                    item_index,
+                    &session_id,
+                    message_index,
+                ) {
+                    tracing::debug!(
+                        item_index,
+                        session_id = session_id.as_str(),
+                        message_index,
+                        "Ignoring stale full message content result"
+                    );
+                    return;
+                }
+
+                match result {
+                    Ok(content) => self.set_typed_message_full_content(item_index, content),
+                    Err(err) => {
+                        tracing::error!(item_index, "Failed to load full message content: {err}");
+                        self.reset_typed_message_expansion(item_index);
+                        self.pending_toast.set(true);
+                    }
+                }
             }
         }
     }
@@ -1237,11 +1316,8 @@ impl Component for SessionDetail {
             );
             let scroll_child = widgets.scroll_child.clone();
             glib::idle_add_local_once(move || {
-                let Some(row_widget) = list_view
-                    .observe_children()
-                    .item(target.display_index as u32)
-                    .and_then(|obj| obj.downcast::<gtk::ListItem>().ok())
-                    .and_then(|item| item.child())
+                let Some(row_widget) =
+                    Self::observed_row_widget_for_display_index(&list_view, target.display_index)
                 else {
                     let list_view_for_tick = list_view.clone();
                     let scroll_child_for_tick = scroll_child.clone();
@@ -1252,12 +1328,10 @@ impl Component for SessionDetail {
                         if ticks > 60 {
                             return glib::ControlFlow::Break;
                         }
-                        let Some(row_widget) = list_view_for_tick
-                            .observe_children()
-                            .item(target.display_index as u32)
-                            .and_then(|obj| obj.downcast::<gtk::ListItem>().ok())
-                            .and_then(|item| item.child())
-                        else {
+                        let Some(row_widget) = Self::observed_row_widget_for_display_index(
+                            &list_view_for_tick,
+                            target.display_index,
+                        ) else {
                             return glib::ControlFlow::Continue;
                         };
                         if let Some(child_index) = target.child_index
@@ -1390,7 +1464,7 @@ impl SessionDetail {
         rows: Vec<crate::database::TranscriptItemRow>,
         session_id: &str,
         highlight_query: Option<String>,
-        matched_item_indexes: &BTreeSet<i64>,
+        _matched_item_indexes: &BTreeSet<i64>,
         db_path: Arc<PathBuf>,
         base_display_index: usize,
     ) -> PreparedTranscriptItems {
@@ -1402,15 +1476,7 @@ impl SessionDetail {
             display_targets_by_item_index
                 .extend(Self::display_targets_for_item(display_index, &item));
 
-            let item_highlight = match &item {
-                DisplayTranscriptItem::Single(row)
-                    if row.kind == crate::models::TranscriptItemKind::Message
-                        && matched_item_indexes.contains(&row.item_index) =>
-                {
-                    highlight_query.clone()
-                }
-                _ => None,
-            };
+            let item_highlight = highlight_query.clone();
 
             items.push(transcript_item_init_from_display_item(
                 display_index,
@@ -1736,6 +1802,83 @@ impl SessionDetail {
         }
     }
 
+    fn set_typed_message_full_content(&mut self, item_index: usize, content: String) {
+        let idx = item_index as u32;
+        let Some(item) = self.messages.get(idx) else {
+            return;
+        };
+
+        let mut clone = item.borrow().clone();
+        clone.full_content = Some(content);
+        self.messages.remove(idx);
+        self.messages.insert(idx, clone);
+    }
+
+    fn reset_typed_message_expansion(&mut self, item_index: usize) {
+        let idx = item_index as u32;
+        let Some(item) = self.messages.get(idx) else {
+            return;
+        };
+
+        let clone = {
+            let item = item.borrow();
+            Self::reset_message_expansion_after_full_content_failure(&item);
+            item.clone()
+        };
+        self.messages.remove(idx);
+        self.messages.insert(idx, clone);
+    }
+
+    fn reset_message_expansion_after_full_content_failure(item: &TranscriptItemData) {
+        item.expanded.set(false);
+    }
+
+    fn typed_message_full_content_target_matches(
+        &self,
+        item_index: usize,
+        session_id: &str,
+        message_index: usize,
+    ) -> bool {
+        let active_session_id = self.session.as_ref().map(|session| session.id.as_str());
+        let Some(item) = self.messages.get(item_index as u32) else {
+            return false;
+        };
+
+        Self::message_full_content_target_matches(
+            &item.borrow(),
+            active_session_id,
+            session_id,
+            message_index,
+        )
+    }
+
+    fn message_full_content_target_matches(
+        item: &TranscriptItemData,
+        active_session_id: Option<&str>,
+        session_id: &str,
+        message_index: usize,
+    ) -> bool {
+        let Some(active_session_id) = active_session_id else {
+            return false;
+        };
+        if active_session_id != session_id {
+            return false;
+        }
+
+        let crate::ui::transcript_item_data::TranscriptItemKind::Message(message) = &item.kind
+        else {
+            return false;
+        };
+
+        message.preview.session_id == session_id && message.preview.message_index == message_index
+    }
+
+    fn apply_highlight_query_to_typed_items(&self, query: Option<String>) {
+        for item in self.messages.iter() {
+            item.borrow_mut().highlight_query = query.clone();
+        }
+    }
+
     fn prepare_for_navigation_back(&mut self, sender: &ComponentSender<Self>) {
         self.invalidate_transcript_requests();
         self.loading_transcript = false;
@@ -1821,6 +1964,40 @@ impl SessionDetail {
             .next_sibling()
             .and_then(|w| w.downcast::<gtk::Revealer>().ok())?;
         Some((header_button, revealer))
+    }
+
+    fn list_view_row_widget_from_child(obj: gtk::glib::Object) -> Option<gtk::Widget> {
+        if let Ok(list_item) = obj.clone().downcast::<gtk::ListItem>() {
+            return list_item.child();
+        }
+
+        obj.downcast::<gtk::Widget>().ok()
+    }
+
+    fn observed_row_widget_for_display_index(
+        list_view: &gtk::ListView,
+        display_index: usize,
+    ) -> Option<gtk::Widget> {
+        let children = list_view.observe_children();
+        for index in 0..children.n_items() {
+            let Some(row_widget) = children
+                .item(index)
+                .and_then(Self::list_view_row_widget_from_child)
+            else {
+                continue;
+            };
+
+            if Self::row_widget_matches_display_index(&row_widget, display_index) {
+                return Some(row_widget);
+            }
+        }
+
+        None
+    }
+
+    fn row_widget_matches_display_index(row_widget: &gtk::Widget, display_index: usize) -> bool {
+        row_widget.widget_name().as_str()
+            == format!("{TRANSCRIPT_ROW_WIDGET_NAME_PREFIX}{display_index}")
     }
 
     /// Snapshot scroll position, clone all items, clear and re-extend to force
@@ -2106,7 +2283,7 @@ mod tests {
     }
 
     #[test]
-    fn build_display_items_highlights_only_matching_message_rows_during_search() {
+    fn build_display_items_applies_search_highlight_query_to_all_rows() {
         let rows = vec![
             transcript_message_row(0, crate::models::Role::Assistant, "needle in counted row"),
             transcript_tool_row(1, "Read"),
@@ -2139,7 +2316,7 @@ mod tests {
 
         match &prepared.items[1] {
             TranscriptItemInit::ToolCall(tool_call) => {
-                assert!(tool_call.highlight_query.is_none());
+                assert_eq!(tool_call.highlight_query.as_deref(), Some("needle"));
             }
             other => panic!(
                 "expected second item to be a tool call, got {:?}",
@@ -2149,7 +2326,7 @@ mod tests {
 
         match &prepared.items[2] {
             TranscriptItemInit::Message(message) => {
-                assert!(message.highlight_query.is_none());
+                assert_eq!(message.highlight_query.as_deref(), Some("needle"));
             }
             other => panic!(
                 "expected third item to be a message, got {:?}",
@@ -2512,6 +2689,91 @@ mod tests {
 
         let parts = controller.state().get();
         assert!(parts.model.match_positions.is_empty());
+    }
+
+    #[gtk::test]
+    fn list_view_row_widget_from_child_accepts_realized_widget_child() {
+        let row = gtk::Box::new(gtk::Orientation::Vertical, 0).upcast::<gtk::Widget>();
+
+        let resolved = SessionDetail::list_view_row_widget_from_child(row.clone().upcast())
+            .expect("direct widget child should resolve");
+
+        assert_eq!(resolved, row);
+    }
+
+    #[gtk::test]
+    fn row_widget_matches_display_index_uses_bound_row_identity() {
+        let row = gtk::Box::new(gtk::Orientation::Vertical, 0).upcast::<gtk::Widget>();
+        row.set_widget_name("transcript-row-7");
+
+        assert!(SessionDetail::row_widget_matches_display_index(&row, 7));
+        assert!(!SessionDetail::row_widget_matches_display_index(&row, 8));
+    }
+
+    #[test]
+    fn message_full_content_target_rejects_stale_session_or_message() {
+        let (sender, _receiver) = relm4::channel::<SessionDetailMsg>();
+        let prepared = SessionDetail::build_display_items(
+            vec![transcript_message_row(
+                0,
+                crate::models::Role::User,
+                "preview",
+            )],
+            "session-1",
+            None,
+            &BTreeSet::new(),
+            Arc::new(PathBuf::from("/tmp/test.db")),
+            0,
+        );
+        let item = TranscriptItemData::from_init(
+            prepared.items.into_iter().next().expect("message item"),
+            sender,
+        );
+
+        assert!(SessionDetail::message_full_content_target_matches(
+            &item,
+            Some("session-1"),
+            "session-1",
+            0,
+        ));
+        assert!(!SessionDetail::message_full_content_target_matches(
+            &item,
+            Some("session-2"),
+            "session-1",
+            0,
+        ));
+        assert!(!SessionDetail::message_full_content_target_matches(
+            &item,
+            Some("session-1"),
+            "session-1",
+            1,
+        ));
+    }
+
+    #[test]
+    fn message_full_content_failure_resets_expansion() {
+        let (sender, _receiver) = relm4::channel::<SessionDetailMsg>();
+        let prepared = SessionDetail::build_display_items(
+            vec![transcript_message_row(
+                0,
+                crate::models::Role::User,
+                "preview",
+            )],
+            "session-1",
+            None,
+            &BTreeSet::new(),
+            Arc::new(PathBuf::from("/tmp/test.db")),
+            0,
+        );
+        let item = TranscriptItemData::from_init(
+            prepared.items.into_iter().next().expect("message item"),
+            sender,
+        );
+        item.expanded.set(true);
+
+        SessionDetail::reset_message_expansion_after_full_content_failure(&item);
+
+        assert!(!item.expanded.get());
     }
 
     #[gtk::test]

--- a/src/ui/tool_inspector_pane.rs
+++ b/src/ui/tool_inspector_pane.rs
@@ -1629,6 +1629,9 @@ fn build_diff_widget(rendered: &crate::ui::tool_renderers::diff::DiffRenderedDat
         let header = gtk::Label::new(Some(&hunk.header));
         header.add_css_class("diff-hunk-header");
         header.set_halign(gtk::Align::Start);
+        header.set_xalign(0.0);
+        header.set_wrap(true);
+        header.set_wrap_mode(gtk::pango::WrapMode::WordChar);
         header.set_selectable(true);
         hunk_box.append(&header);
 
@@ -1673,6 +1676,9 @@ fn build_file_widget(rendered: &crate::ui::tool_renderers::file::FileRenderedDat
         let header_label = gtk::Label::new(Some(header));
         header_label.add_css_class("file-header");
         header_label.set_halign(gtk::Align::Start);
+        header_label.set_xalign(0.0);
+        header_label.set_wrap(true);
+        header_label.set_wrap_mode(gtk::pango::WrapMode::WordChar);
         header_label.set_selectable(true);
         container.append(&header_label);
     }
@@ -1714,6 +1720,9 @@ fn build_results_widget(
             let path_label = gtk::Label::new(Some(&entry.path));
             path_label.add_css_class("monospace");
             path_label.set_halign(gtk::Align::Start);
+            path_label.set_xalign(0.0);
+            path_label.set_wrap(true);
+            path_label.set_wrap_mode(gtk::pango::WrapMode::WordChar);
             row.append(&path_label);
 
             if let Some(line_num) = entry.line {
@@ -2106,6 +2115,113 @@ mod tests {
             "permission denied while opening the file"
         );
         assert!(views.label.is_selectable());
+    }
+
+    #[gtk::test]
+    fn diff_hunk_header_wraps_so_it_does_not_lock_a_min_width() {
+        use crate::ui::tool_renderers::diff::{DiffHunk, DiffRenderedData};
+
+        let rendered = DiffRenderedData {
+            old_text: None,
+            new_text: None,
+            hunks: vec![DiffHunk {
+                header: "@@ -1,4 +1,4 @@ fn an_extremely_long_function_signature_here()"
+                    .to_string(),
+                lines: Vec::new(),
+            }],
+        };
+
+        let widget = build_diff_widget(&rendered);
+        let container = widget
+            .downcast::<gtk::ScrolledWindow>()
+            .expect("diff scroll")
+            .child()
+            .expect("diff viewport")
+            .downcast::<gtk::Viewport>()
+            .expect("diff viewport")
+            .child()
+            .expect("diff container")
+            .downcast::<gtk::Box>()
+            .expect("diff container box");
+        let hunk_box = container
+            .first_child()
+            .expect("hunk box")
+            .downcast::<gtk::Box>()
+            .expect("hunk box");
+        let header = hunk_box
+            .first_child()
+            .expect("hunk header")
+            .downcast::<gtk::Label>()
+            .expect("hunk header label");
+
+        assert!(header.wraps(), "diff hunk header must wrap");
+    }
+
+    #[gtk::test]
+    fn file_header_wraps_so_it_does_not_lock_a_min_width() {
+        use crate::models::ToolCallStatus;
+        use crate::ui::tool_renderers::file::FileRenderedData;
+
+        let rendered = FileRenderedData {
+            header: Some("/an/extremely/long/absolute/path/to/some/source/file.rs".to_string()),
+            output_text: None,
+            error_text: None,
+            status: ToolCallStatus::Completed,
+            duration_ms: None,
+        };
+
+        let widget = build_file_widget(&rendered);
+        let header = widget
+            .downcast::<gtk::Box>()
+            .expect("file container box")
+            .first_child()
+            .expect("file header")
+            .downcast::<gtk::Label>()
+            .expect("file header label");
+
+        assert!(header.wraps(), "file header must wrap");
+    }
+
+    #[gtk::test]
+    fn results_entry_path_wraps_so_it_does_not_lock_a_min_width() {
+        use crate::models::ToolCallStatus;
+        use crate::ui::tool_renderers::results::{ResultsEntry, ResultsRenderedData};
+
+        let rendered = ResultsRenderedData {
+            entries: vec![ResultsEntry {
+                path: "/an/extremely/long/absolute/path/to/some/matched/file.rs".to_string(),
+                line: Some(42),
+                content: "let x = 1;".to_string(),
+            }],
+            output_text: None,
+            error_text: None,
+            status: ToolCallStatus::Completed,
+            duration_ms: None,
+        };
+
+        let widget = build_results_widget(&rendered);
+        let row = widget
+            .downcast::<gtk::ScrolledWindow>()
+            .expect("results scroll")
+            .child()
+            .expect("results viewport")
+            .downcast::<gtk::Viewport>()
+            .expect("results viewport")
+            .child()
+            .expect("results container")
+            .downcast::<gtk::Box>()
+            .expect("results container box")
+            .first_child()
+            .expect("results row")
+            .downcast::<gtk::Box>()
+            .expect("results row box");
+        let path = row
+            .first_child()
+            .expect("results path")
+            .downcast::<gtk::Label>()
+            .expect("results path label");
+
+        assert!(path.wraps(), "results entry path must wrap");
     }
 
     fn sample_tool_call(status: ToolCallStatus) -> ToolCall {

--- a/src/ui/transcript_display.rs
+++ b/src/ui/transcript_display.rs
@@ -30,62 +30,6 @@ pub fn group_transcript_rows(rows: Vec<TranscriptItemRow>) -> Vec<DisplayTranscr
     grouped
 }
 
-pub fn trailing_tool_call_rows(rows: &[TranscriptItemRow]) -> Vec<TranscriptItemRow> {
-    let mut trailing = Vec::new();
-    for row in rows.iter().rev() {
-        if row.kind != TranscriptItemKind::ToolCall {
-            break;
-        }
-        trailing.push(row.clone());
-    }
-    trailing.reverse();
-    trailing
-}
-
-pub struct BoundaryRegroupResult {
-    pub replacement_items: Vec<DisplayTranscriptItem>,
-    pub remaining_rows: Vec<TranscriptItemRow>,
-}
-
-pub fn regroup_boundary(
-    previous_trailing_tools: Vec<TranscriptItemRow>,
-    mut next_page_rows: Vec<TranscriptItemRow>,
-) -> BoundaryRegroupResult {
-    let leading_tool_count = next_page_rows
-        .iter()
-        .take_while(|row| row.kind == TranscriptItemKind::ToolCall)
-        .count();
-
-    if leading_tool_count == 0 {
-        return BoundaryRegroupResult {
-            replacement_items: Vec::new(),
-            remaining_rows: next_page_rows,
-        };
-    }
-
-    let mut merged_rows = previous_trailing_tools;
-    let leading_rows: Vec<_> = next_page_rows.drain(..leading_tool_count).collect();
-    merged_rows.extend(leading_rows);
-
-    let replacement_items = group_transcript_rows(merged_rows);
-    BoundaryRegroupResult {
-        replacement_items,
-        remaining_rows: next_page_rows,
-    }
-}
-
-/// Extract the raw tool call rows from the tail of a display item list.
-/// Used to determine boundary candidates when `merged_rows` is no longer available.
-pub fn trailing_tool_rows_from_display(items: &[DisplayTranscriptItem]) -> Vec<TranscriptItemRow> {
-    match items.last() {
-        Some(DisplayTranscriptItem::ToolBurst(burst)) => burst.rows.clone(),
-        Some(DisplayTranscriptItem::Single(row)) if row.kind == TranscriptItemKind::ToolCall => {
-            vec![row.as_ref().clone()]
-        }
-        _ => Vec::new(),
-    }
-}
-
 fn flush_pending_tool_rows(
     grouped: &mut Vec<DisplayTranscriptItem>,
     pending_tool_rows: &mut Vec<TranscriptItemRow>,
@@ -291,36 +235,5 @@ mod tests {
             .map(|row| row.tool_name.as_deref().unwrap_or(""))
             .collect();
         assert_eq!(names, vec!["Read", "Read", "Grep", "Edit", "Bash"]);
-    }
-
-    #[test]
-    fn trailing_tool_calls_are_reported_as_boundary_candidates() {
-        let rows = vec![message_row(0), tool_row(1, "Read"), tool_row(2, "Edit")];
-        let trailing = trailing_tool_call_rows(&rows);
-        assert_eq!(trailing.len(), 2);
-    }
-
-    #[test]
-    fn regroup_boundary_merges_previous_trailing_tools_with_next_page_prefix() {
-        let previous = vec![tool_row(1, "Read"), tool_row(2, "Edit")];
-        let next_page = vec![tool_row(3, "Bash"), message_row(4)];
-
-        let result = regroup_boundary(previous, next_page);
-        assert_eq!(result.replacement_items.len(), 1);
-        assert!(matches!(
-            result.replacement_items[0],
-            DisplayTranscriptItem::ToolBurst(_)
-        ));
-        assert_eq!(result.remaining_rows.len(), 1);
-    }
-
-    #[test]
-    fn regroup_boundary_does_nothing_when_next_page_starts_with_message() {
-        let previous = vec![tool_row(1, "Read"), tool_row(2, "Edit")];
-        let next_page = vec![message_row(3)];
-
-        let result = regroup_boundary(previous, next_page);
-        assert!(result.replacement_items.is_empty());
-        assert_eq!(result.remaining_rows.len(), 1);
     }
 }

--- a/src/ui/transcript_item_data.rs
+++ b/src/ui/transcript_item_data.rs
@@ -11,8 +11,10 @@ use crate::ui::transcript_row::{
 #[derive(Clone)]
 pub struct TranscriptItemData {
     pub item_index: usize,
+    pub transcript_item_index: Option<i64>,
     pub kind: TranscriptItemKind,
     pub expanded: BoolBinding,
+    pub highlight_query: Option<String>,
     pub sender: Sender<SessionDetailMsg>,
 }
 
@@ -48,29 +50,50 @@ impl fmt::Debug for TranscriptItemData {
 impl TranscriptItemData {
     pub fn from_init(init: TranscriptItemInit, sender: Sender<SessionDetailMsg>) -> Self {
         let item_index = init.item_index();
-        let (kind, expanded) = match init {
+        let (kind, expanded, transcript_item_index, highlight_query) = match init {
             TranscriptItemInit::Message(message) => (
-                TranscriptItemKind::Message(message),
+                TranscriptItemKind::Message(message.clone()),
                 BoolBinding::new(false),
+                Some(message.transcript_item_index),
+                message.highlight_query,
             ),
             TranscriptItemInit::ToolCall(tool_call) => (
-                TranscriptItemKind::ToolCall(tool_call),
+                TranscriptItemKind::ToolCall(tool_call.clone()),
                 BoolBinding::new(false),
+                Some(tool_call.transcript_item_index),
+                tool_call.highlight_query,
             ),
             TranscriptItemInit::ToolBurst(tool_burst) => {
                 let expanded = BoolBinding::new(tool_burst.default_expanded);
-                (TranscriptItemKind::ToolBurst(tool_burst), expanded)
+                let transcript_item_index = tool_burst
+                    .tool_calls
+                    .first()
+                    .map(|tc| tc.transcript_item_index);
+                let highlight_query = tool_burst
+                    .tool_calls
+                    .first()
+                    .and_then(|tc| tc.highlight_query.clone());
+                (
+                    TranscriptItemKind::ToolBurst(tool_burst),
+                    expanded,
+                    transcript_item_index,
+                    highlight_query,
+                )
             }
             TranscriptItemInit::Subagent(subagent) => (
-                TranscriptItemKind::Subagent(subagent),
+                TranscriptItemKind::Subagent(subagent.clone()),
                 BoolBinding::new(false),
+                Some(subagent.transcript_item_index),
+                None,
             ),
         };
 
         Self {
             item_index,
+            transcript_item_index,
             kind,
             expanded,
+            highlight_query,
             sender,
         }
     }
@@ -113,6 +136,8 @@ mod tests {
         let data = TranscriptItemData::from_init(TranscriptItemInit::Message(init), sender);
 
         assert_eq!(data.item_index, 7);
+        assert_eq!(data.transcript_item_index, Some(42));
+        assert_eq!(data.highlight_query.as_deref(), Some("hello"));
         match &data.kind {
             TranscriptItemKind::Message(message) => {
                 assert_eq!(message.transcript_item_index, 42);

--- a/src/ui/transcript_item_data.rs
+++ b/src/ui/transcript_item_data.rs
@@ -1,0 +1,159 @@
+use std::fmt;
+
+use relm4::Sender;
+use relm4::binding::{Binding, BoolBinding};
+
+use crate::ui::session_detail::SessionDetailMsg;
+use crate::ui::transcript_row::{
+    MessageItemInit, SubagentItemInit, ToolBurstItemInit, ToolCallItemInit, TranscriptItemInit,
+};
+
+#[derive(Clone)]
+pub struct TranscriptItemData {
+    pub item_index: usize,
+    pub kind: TranscriptItemKind,
+    pub expanded: BoolBinding,
+    pub sender: Sender<SessionDetailMsg>,
+}
+
+#[derive(Clone)]
+pub enum TranscriptItemKind {
+    Message(MessageItemInit),
+    ToolCall(ToolCallItemInit),
+    ToolBurst(ToolBurstItemInit),
+    Subagent(SubagentItemInit),
+}
+
+impl fmt::Debug for TranscriptItemKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Message(_) => f.write_str("Message"),
+            Self::ToolCall(_) => f.write_str("ToolCall"),
+            Self::ToolBurst(_) => f.write_str("ToolBurst"),
+            Self::Subagent(_) => f.write_str("Subagent"),
+        }
+    }
+}
+
+impl fmt::Debug for TranscriptItemData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TranscriptItemData")
+            .field("item_index", &self.item_index)
+            .field("kind", &self.kind)
+            .field("expanded", &self.expanded.get())
+            .finish_non_exhaustive()
+    }
+}
+
+impl TranscriptItemData {
+    pub fn from_init(init: TranscriptItemInit, sender: Sender<SessionDetailMsg>) -> Self {
+        let item_index = init.item_index();
+        let (kind, expanded) = match init {
+            TranscriptItemInit::Message(message) => (
+                TranscriptItemKind::Message(message),
+                BoolBinding::new(false),
+            ),
+            TranscriptItemInit::ToolCall(tool_call) => (
+                TranscriptItemKind::ToolCall(tool_call),
+                BoolBinding::new(false),
+            ),
+            TranscriptItemInit::ToolBurst(tool_burst) => {
+                let expanded = BoolBinding::new(tool_burst.default_expanded);
+                (TranscriptItemKind::ToolBurst(tool_burst), expanded)
+            }
+            TranscriptItemInit::Subagent(subagent) => (
+                TranscriptItemKind::Subagent(subagent),
+                BoolBinding::new(false),
+            ),
+        };
+
+        Self {
+            item_index,
+            kind,
+            expanded,
+            sender,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    use chrono::Utc;
+    use relm4::binding::Binding;
+
+    use super::{TranscriptItemData, TranscriptItemKind};
+    use crate::models::{MessagePreview, ReasoningPreview, Role};
+    use crate::ui::session_detail::SessionDetailMsg;
+    use crate::ui::transcript_row::{MessageItemInit, TranscriptItemInit};
+
+    #[test]
+    fn from_init_preserves_message_identity_and_highlight() {
+        let preview = MessagePreview {
+            session_id: "session-1".to_string(),
+            message_index: 3,
+            role: Role::Assistant,
+            content_preview: "hello".to_string(),
+            content_len: 5,
+            timestamp: Utc::now(),
+            model: Some("gpt-5.4".to_string()),
+            reasoning_preview: ReasoningPreview::default(),
+        };
+        let init = MessageItemInit {
+            item_index: 7,
+            transcript_item_index: 42,
+            preview: preview.clone(),
+            highlight_query: Some("hello".to_string()),
+            db_path: Arc::new(PathBuf::from("/tmp/transcript-item-data.db")),
+        };
+        let (sender, _receiver) = relm4::channel::<SessionDetailMsg>();
+
+        let data = TranscriptItemData::from_init(TranscriptItemInit::Message(init), sender);
+
+        assert_eq!(data.item_index, 7);
+        match &data.kind {
+            TranscriptItemKind::Message(message) => {
+                assert_eq!(message.transcript_item_index, 42);
+                assert_eq!(message.highlight_query.as_deref(), Some("hello"));
+                assert_eq!(message.preview.session_id, preview.session_id);
+                assert_eq!(message.preview.message_index, preview.message_index);
+                assert_eq!(message.preview.content_preview, preview.content_preview);
+                assert_eq!(message.preview.model, preview.model);
+            }
+            other => panic!("expected message item, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cloned_data_shares_expansion_binding() {
+        let init = MessageItemInit {
+            item_index: 2,
+            transcript_item_index: 8,
+            preview: MessagePreview {
+                session_id: "session-2".to_string(),
+                message_index: 1,
+                role: Role::User,
+                content_preview: "question".to_string(),
+                content_len: 8,
+                timestamp: Utc::now(),
+                model: None,
+                reasoning_preview: ReasoningPreview::default(),
+            },
+            highlight_query: None,
+            db_path: Arc::new(PathBuf::from("/tmp/transcript-item-data.db")),
+        };
+        let (sender, _receiver) = relm4::channel::<SessionDetailMsg>();
+
+        let data = TranscriptItemData::from_init(TranscriptItemInit::Message(init), sender);
+        let cloned = data.clone();
+
+        assert!(!data.expanded.get());
+        cloned.expanded.set(true);
+        assert!(data.expanded.get());
+
+        data.expanded.set(false);
+        assert!(!cloned.expanded.get());
+    }
+}

--- a/src/ui/transcript_item_data.rs
+++ b/src/ui/transcript_item_data.rs
@@ -6,6 +6,7 @@ use relm4::binding::{Binding, BoolBinding};
 use crate::ui::session_detail::SessionDetailMsg;
 use crate::ui::transcript_row::{
     MessageItemInit, SubagentItemInit, ToolBurstItemInit, ToolCallItemInit, TranscriptItemInit,
+    count_tool_call_matches,
 };
 
 #[derive(Clone)]
@@ -101,6 +102,28 @@ impl TranscriptItemData {
             sender,
         }
     }
+
+    /// Apply a new transcript search query to this row.
+    ///
+    /// Tool bursts cache per-child and aggregate match counts that feed the
+    /// collapsed group badge, so the query is propagated to each child and
+    /// those counts are recomputed; otherwise the badge would keep showing
+    /// stale counts from whatever query was active when the row was built.
+    pub fn apply_highlight_query(&mut self, query: Option<String>) {
+        self.highlight_query = query.clone();
+
+        if let TranscriptItemKind::ToolBurst(burst) = &mut self.kind {
+            for tool_call in &mut burst.tool_calls {
+                tool_call.highlight_query = query.clone();
+            }
+            burst.child_match_counts = burst
+                .tool_calls
+                .iter()
+                .map(count_tool_call_matches)
+                .collect();
+            burst.match_count = burst.child_match_counts.iter().sum();
+        }
+    }
 }
 
 #[cfg(test)]
@@ -152,6 +175,57 @@ mod tests {
                 assert_eq!(message.preview.model, preview.model);
             }
             other => panic!("expected message item, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn apply_highlight_query_recomputes_tool_burst_match_counts() {
+        use crate::models::ToolCallStatus;
+        use crate::ui::transcript_row::{ToolCallItemInit, build_tool_burst_init};
+
+        let tool_call = ToolCallItemInit {
+            item_index: 1,
+            transcript_item_index: 10,
+            session_id: "session-1".to_string(),
+            tool_call_id: "call-1".to_string(),
+            tool_name: "Read".to_string(),
+            status: ToolCallStatus::Completed,
+            preview: Some("src/needle.rs:1-20".to_string()),
+            summary: None,
+            duration_ms: None,
+            highlight_query: None,
+            reasoning_preview: ReasoningPreview::default(),
+        };
+        let burst = build_tool_burst_init(4, vec![tool_call], false);
+        assert_eq!(
+            burst.match_count, 0,
+            "burst starts with no query, no matches"
+        );
+
+        let (sender, _receiver) = relm4::channel::<SessionDetailMsg>();
+        let mut data = TranscriptItemData::from_init(TranscriptItemInit::ToolBurst(burst), sender);
+
+        data.apply_highlight_query(Some("needle".to_string()));
+
+        assert_eq!(data.highlight_query.as_deref(), Some("needle"));
+        match &data.kind {
+            TranscriptItemKind::ToolBurst(burst) => {
+                assert_eq!(
+                    burst.tool_calls[0].highlight_query.as_deref(),
+                    Some("needle"),
+                    "child tool calls must carry the new query"
+                );
+                assert_eq!(
+                    burst.child_match_counts,
+                    vec![1],
+                    "child match counts must be recomputed against the new query"
+                );
+                assert_eq!(
+                    burst.match_count, 1,
+                    "burst aggregate match count must reflect the new query"
+                );
+            }
+            other => panic!("expected tool burst, got {other:?}"),
         }
     }
 

--- a/src/ui/transcript_item_data.rs
+++ b/src/ui/transcript_item_data.rs
@@ -14,6 +14,7 @@ pub struct TranscriptItemData {
     pub transcript_item_index: Option<i64>,
     pub kind: TranscriptItemKind,
     pub expanded: BoolBinding,
+    pub full_content: Option<String>,
     pub highlight_query: Option<String>,
     pub sender: Sender<SessionDetailMsg>,
 }
@@ -43,6 +44,8 @@ impl fmt::Debug for TranscriptItemData {
             .field("item_index", &self.item_index)
             .field("kind", &self.kind)
             .field("expanded", &self.expanded.get())
+            .field("has_full_content", &self.full_content.is_some())
+            .field("highlight_query", &self.highlight_query)
             .finish_non_exhaustive()
     }
 }
@@ -93,6 +96,7 @@ impl TranscriptItemData {
             transcript_item_index,
             kind,
             expanded,
+            full_content: None,
             highlight_query,
             sender,
         }

--- a/src/ui/transcript_row.rs
+++ b/src/ui/transcript_row.rs
@@ -23,7 +23,7 @@ use crate::ui::highlight;
 use crate::ui::markdown;
 use crate::ui::session_detail::SessionDetailMsg;
 
-const TOOL_ICONS: ToolCategoryIcons = ToolCategoryIcons {
+pub(crate) const TOOL_ICONS: ToolCategoryIcons = ToolCategoryIcons {
     read: icon_names::TEXT_SNIPPET,
     edit: icon_names::EDIT_DOCUMENT,
     command: icon_names::TERMINAL,

--- a/src/ui/transcript_row.rs
+++ b/src/ui/transcript_row.rs
@@ -310,9 +310,10 @@ pub(crate) fn count_tool_call_matches(init: &ToolCallItemInit) -> usize {
         return 0;
     };
 
-    let mut count = highlight::find_case_insensitive_matches_in_text(&init.tool_name, query).len();
+    let mut count =
+        crate::utils::text_match::count_case_insensitive_matches(&init.tool_name, query);
     if let Some(text) = init.displayed_preview() {
-        count += highlight::find_case_insensitive_matches_in_text(text, query).len();
+        count += crate::utils::text_match::count_case_insensitive_matches(text, query);
     }
     count
 }

--- a/src/ui/transcript_row.rs
+++ b/src/ui/transcript_row.rs
@@ -363,7 +363,7 @@ pub fn build_tool_burst_init(
     }
 }
 
-fn format_reasoning_burst_label(
+pub(crate) fn format_reasoning_burst_label(
     visible_reasoning_child_count: usize,
     encrypted_only_child_count: usize,
 ) -> Option<String> {
@@ -376,7 +376,7 @@ fn format_reasoning_burst_label(
     }
 }
 
-fn format_tool_burst_accessible_label(
+pub(crate) fn format_tool_burst_accessible_label(
     category_counts: &[(String, usize)],
     total_tool_calls: usize,
     error_count: usize,

--- a/src/ui/transcript_row.rs
+++ b/src/ui/transcript_row.rs
@@ -529,37 +529,22 @@ pub(crate) fn populate_tool_burst_children(
     sender: &relm4::Sender<SessionDetailMsg>,
     item_index: usize,
 ) {
-    let children_started_at = Instant::now();
-    let mut max_child_build_duration = Duration::ZERO;
-    for tool_call in &burst.tool_calls {
-        let child_started_at = Instant::now();
-        let child = build_tool_call_widget(
-            tool_call,
-            {
-                let sender = sender.clone();
-                move |id| {
-                    sender.emit(SessionDetailMsg::InspectToolCall(id));
-                }
-            },
-            {
-                let sender = sender.clone();
-                move |_session_id, transcript_item_index| {
-                    sender.emit(SessionDetailMsg::InspectReasoning(transcript_item_index));
-                }
-            },
-        );
-        let child_duration = child_started_at.elapsed();
-        max_child_build_duration = max_child_build_duration.max(child_duration);
-        children.append(&child.root);
-    }
-    let children_duration = children_started_at.elapsed();
-    tracing::debug!(
+    populate_tool_burst_children_impl(
+        children,
+        burst,
+        Rc::new({
+            let sender = sender.clone();
+            move |id| {
+                sender.emit(SessionDetailMsg::InspectToolCall(id));
+            }
+        }),
+        Rc::new({
+            let sender = sender.clone();
+            move |_session_id, transcript_item_index| {
+                sender.emit(SessionDetailMsg::InspectReasoning(transcript_item_index));
+            }
+        }),
         item_index,
-        tool_call_count = burst.tool_calls.len(),
-        children_build_duration_ms = children_duration.as_millis(),
-        max_child_build_duration_ms = max_child_build_duration.as_millis(),
-        match_count = burst.match_count,
-        "Built transcript tool burst children"
     );
 }
 
@@ -569,6 +554,37 @@ fn populate_tool_burst_children_legacy(
     sender: &FactorySender<TranscriptRow>,
     item_index: usize,
 ) {
+    populate_tool_burst_children_impl(
+        children,
+        burst,
+        Rc::new({
+            let sender = sender.clone();
+            move |id| {
+                sender.output(TranscriptRowOutput::InspectToolCall(id)).ok();
+            }
+        }),
+        Rc::new({
+            let sender = sender.clone();
+            move |session_id, transcript_item_index| {
+                sender
+                    .output(TranscriptRowOutput::InspectReasoning {
+                        session_id,
+                        transcript_item_index,
+                    })
+                    .ok();
+            }
+        }),
+        item_index,
+    );
+}
+
+fn populate_tool_burst_children_impl(
+    children: &gtk::Box,
+    burst: &ToolBurstItemInit,
+    on_inspect: Rc<dyn Fn(String)>,
+    on_inspect_reasoning: Rc<dyn Fn(String, i64)>,
+    item_index: usize,
+) {
     let children_started_at = Instant::now();
     let mut max_child_build_duration = Duration::ZERO;
     for tool_call in &burst.tool_calls {
@@ -576,20 +592,15 @@ fn populate_tool_burst_children_legacy(
         let child = build_tool_call_widget(
             tool_call,
             {
-                let sender = sender.clone();
+                let on_inspect = on_inspect.clone();
                 move |id| {
-                    sender.output(TranscriptRowOutput::InspectToolCall(id)).ok();
+                    on_inspect(id);
                 }
             },
             {
-                let sender = sender.clone();
+                let on_inspect_reasoning = on_inspect_reasoning.clone();
                 move |session_id, transcript_item_index| {
-                    sender
-                        .output(TranscriptRowOutput::InspectReasoning {
-                            session_id,
-                            transcript_item_index,
-                        })
-                        .ok();
+                    on_inspect_reasoning(session_id, transcript_item_index);
                 }
             },
         );
@@ -1786,6 +1797,54 @@ mod tests {
             .and_then(|w| w.downcast::<gtk::Label>().ok())
             .expect("encrypted-only label should remain in the left metadata flow");
         assert_eq!(encrypted.label().as_str(), "Thinking (encrypted)");
+    }
+
+    #[gtk::test]
+    fn typed_tool_burst_population_emits_inspect_messages() {
+        let burst = build_tool_burst_init(
+            10,
+            vec![ToolCallItemInit {
+                item_index: 1,
+                transcript_item_index: 41,
+                session_id: "session-1".to_string(),
+                tool_call_id: "call-1".to_string(),
+                tool_name: "Read".to_string(),
+                status: ToolCallStatus::Completed,
+                preview: Some("src/ui/transcript_row.rs:1-20".to_string()),
+                summary: None,
+                duration_ms: Some(12),
+                highlight_query: None,
+                reasoning_preview: ReasoningPreview::default(),
+            }],
+            false,
+        );
+        let children = gtk::Box::new(gtk::Orientation::Vertical, 0);
+        let (sender, receiver) = relm4::channel::<crate::ui::session_detail::SessionDetailMsg>();
+
+        populate_tool_burst_children(&children, &burst, &sender, 10);
+
+        let child = children
+            .first_child()
+            .and_then(|w| w.downcast::<gtk::Box>().ok())
+            .expect("tool burst child root");
+        let header = child
+            .first_child()
+            .and_then(|w| w.downcast::<gtk::Box>().ok())
+            .expect("tool burst child header");
+        let inspect = row_box_children(&header)
+            .last()
+            .cloned()
+            .and_then(|w| w.downcast::<gtk::Button>().ok())
+            .expect("inspect button");
+
+        inspect.emit_clicked();
+
+        assert!(matches!(
+            gtk::glib::MainContext::default()
+                .block_on(receiver.recv())
+                .expect("inspect message"),
+            crate::ui::session_detail::SessionDetailMsg::InspectToolCall(id) if id == "call-1"
+        ));
     }
 
     #[test]

--- a/src/ui/transcript_row.rs
+++ b/src/ui/transcript_row.rs
@@ -21,6 +21,7 @@ use crate::models::{
 use crate::ui::format::{format_duration_ms, tool_status_css_class, tool_status_label};
 use crate::ui::highlight;
 use crate::ui::markdown;
+use crate::ui::session_detail::SessionDetailMsg;
 
 const TOOL_ICONS: ToolCategoryIcons = ToolCategoryIcons {
     read: icon_names::TEXT_SNIPPET,
@@ -36,7 +37,7 @@ const SLOW_CONTENT_RENDER: Duration = Duration::from_millis(10);
 
 /// Return the model display text for a transcript header.
 /// Only assistant messages with a non-empty model value produce output.
-fn model_label_text(role: Role, model: Option<&str>) -> Option<String> {
+pub(crate) fn model_label_text(role: Role, model: Option<&str>) -> Option<String> {
     if role != Role::Assistant {
         return None;
     }
@@ -264,7 +265,7 @@ pub struct TranscriptRowWidgets {
 // FactoryComponent implementation
 // ---------------------------------------------------------------------------
 
-fn render_content(
+pub(crate) fn render_content(
     container: &gtk::Box,
     content: &str,
     role: Role,
@@ -304,7 +305,7 @@ fn render_content(
     match_count
 }
 
-fn count_tool_call_matches(init: &ToolCallItemInit) -> usize {
+pub(crate) fn count_tool_call_matches(init: &ToolCallItemInit) -> usize {
     let Some(query) = init.highlight_query.as_deref() else {
         return 0;
     };
@@ -399,7 +400,7 @@ fn format_tool_burst_accessible_label(
     label
 }
 
-pub fn format_tool_burst_match_badge_accessible_label(match_count: usize) -> String {
+pub(crate) fn format_tool_burst_match_badge_accessible_label(match_count: usize) -> String {
     format!("{match_count} search matches inside this group")
 }
 
@@ -522,7 +523,47 @@ fn build_tool_call_widget(
     }
 }
 
-fn populate_tool_burst_children(
+pub(crate) fn populate_tool_burst_children(
+    children: &gtk::Box,
+    burst: &ToolBurstItemInit,
+    sender: &relm4::Sender<SessionDetailMsg>,
+    item_index: usize,
+) {
+    let children_started_at = Instant::now();
+    let mut max_child_build_duration = Duration::ZERO;
+    for tool_call in &burst.tool_calls {
+        let child_started_at = Instant::now();
+        let child = build_tool_call_widget(
+            tool_call,
+            {
+                let sender = sender.clone();
+                move |id| {
+                    sender.emit(SessionDetailMsg::InspectToolCall(id));
+                }
+            },
+            {
+                let sender = sender.clone();
+                move |_session_id, transcript_item_index| {
+                    sender.emit(SessionDetailMsg::InspectReasoning(transcript_item_index));
+                }
+            },
+        );
+        let child_duration = child_started_at.elapsed();
+        max_child_build_duration = max_child_build_duration.max(child_duration);
+        children.append(&child.root);
+    }
+    let children_duration = children_started_at.elapsed();
+    tracing::debug!(
+        item_index,
+        tool_call_count = burst.tool_calls.len(),
+        children_build_duration_ms = children_duration.as_millis(),
+        max_child_build_duration_ms = max_child_build_duration.as_millis(),
+        match_count = burst.match_count,
+        "Built transcript tool burst children"
+    );
+}
+
+fn populate_tool_burst_children_legacy(
     children: &gtk::Box,
     burst: &ToolBurstItemInit,
     sender: &FactorySender<TranscriptRow>,
@@ -1225,7 +1266,7 @@ impl TranscriptRow {
         let children = gtk::Box::new(gtk::Orientation::Vertical, 0);
         let children_built = Rc::new(Cell::new(false));
         if should_build_tool_burst_children_on_mount(burst.default_expanded) {
-            populate_tool_burst_children(&children, burst, &sender, self.item_index);
+            populate_tool_burst_children_legacy(&children, burst, &sender, self.item_index);
             children_built.set(true);
         }
 
@@ -1249,7 +1290,7 @@ impl TranscriptRow {
             header_button.connect_clicked(move |btn| {
                 let expanded = !revealer.reveals_child();
                 if expanded && !children_built.get() {
-                    populate_tool_burst_children(&children, &burst, &sender, item_index);
+                    populate_tool_burst_children_legacy(&children, &burst, &sender, item_index);
                     children_built.set(true);
                 }
                 revealer.set_reveal_child(expanded);

--- a/src/ui/transcript_row.rs
+++ b/src/ui/transcript_row.rs
@@ -51,6 +51,7 @@ fn model_label_text(role: Role, model: Option<&str>) -> Option<String> {
 // Init types
 // ---------------------------------------------------------------------------
 
+#[derive(Clone)]
 pub struct MessageItemInit {
     pub item_index: usize,
     pub transcript_item_index: i64,
@@ -114,6 +115,7 @@ pub struct ToolBurstItemInit {
     pub default_expanded: bool,
 }
 
+#[derive(Clone)]
 pub struct SubagentItemInit {
     pub item_index: usize,
     pub transcript_item_index: i64,
@@ -123,6 +125,7 @@ pub struct SubagentItemInit {
     pub reasoning_preview: ReasoningPreview,
 }
 
+#[derive(Clone)]
 pub enum TranscriptItemInit {
     Message(MessageItemInit),
     ToolCall(ToolCallItemInit),

--- a/src/ui/typed_transcript_row.rs
+++ b/src/ui/typed_transcript_row.rs
@@ -1,0 +1,328 @@
+use gtk::prelude::*;
+use relm4::{gtk, typed_view::list::RelmListItem};
+
+use crate::ui::transcript_item_data::{TranscriptItemData, TranscriptItemKind};
+use crate::ui::transcript_row::TranscriptRowBuildKind;
+
+const MESSAGE_PAGE_NAME: &str = "message";
+const TOOL_CALL_PAGE_NAME: &str = "tool-call";
+const TOOL_BURST_PAGE_NAME: &str = "tool-burst";
+const SUBAGENT_PAGE_NAME: &str = "subagent";
+
+pub struct TranscriptRowWidgets {
+    stack: gtk::Stack,
+    message: MessagePageWidgets,
+    tool_call: ToolCallPageWidgets,
+    tool_burst: ToolBurstPageWidgets,
+    subagent: SubagentPageWidgets,
+}
+
+pub struct MessagePageWidgets {
+    root: gtk::Box,
+}
+
+pub struct ToolCallPageWidgets {
+    root: gtk::Box,
+}
+
+pub struct ToolBurstPageWidgets {
+    root: gtk::Box,
+    children: gtk::Box,
+}
+
+pub struct SubagentPageWidgets {
+    root: gtk::Box,
+}
+
+impl RelmListItem for TranscriptItemData {
+    type Root = gtk::Box;
+    type Widgets = TranscriptRowWidgets;
+
+    fn setup(list_item: &gtk::ListItem) -> (Self::Root, Self::Widgets) {
+        list_item.set_activatable(false);
+        list_item.set_selectable(false);
+
+        let root = gtk::Box::new(gtk::Orientation::Vertical, 0);
+        let stack = gtk::Stack::new();
+        stack.set_hhomogeneous(false);
+        stack.set_vhomogeneous(false);
+        root.append(&stack);
+
+        let message = build_message_page();
+        stack.add_named(&message.root, Some(MESSAGE_PAGE_NAME));
+
+        let tool_call = build_tool_call_page();
+        stack.add_named(&tool_call.root, Some(TOOL_CALL_PAGE_NAME));
+
+        let tool_burst = build_tool_burst_page();
+        stack.add_named(&tool_burst.root, Some(TOOL_BURST_PAGE_NAME));
+
+        let subagent = build_subagent_page();
+        stack.add_named(&subagent.root, Some(SUBAGENT_PAGE_NAME));
+
+        (
+            root,
+            TranscriptRowWidgets {
+                stack,
+                message,
+                tool_call,
+                tool_burst,
+                subagent,
+            },
+        )
+    }
+
+    fn bind(&mut self, widgets: &mut Self::Widgets, _root: &mut Self::Root) {
+        let kind = TranscriptRowBuildKind::from(&self.kind);
+        widgets.stack.set_visible_child_name(kind.page_name());
+
+        match kind {
+            TranscriptRowBuildKind::Message => self.bind_message_page(&mut widgets.message),
+            TranscriptRowBuildKind::ToolCall => self.bind_tool_call_page(&mut widgets.tool_call),
+            TranscriptRowBuildKind::ToolBurst => self.bind_tool_burst_page(&mut widgets.tool_burst),
+            TranscriptRowBuildKind::Subagent => self.bind_subagent_page(&mut widgets.subagent),
+        }
+    }
+
+    fn unbind(&mut self, widgets: &mut Self::Widgets, _root: &mut Self::Root) {
+        match TranscriptRowBuildKind::from(&self.kind) {
+            TranscriptRowBuildKind::Message => self.unbind_message_page(&mut widgets.message),
+            TranscriptRowBuildKind::ToolCall => self.unbind_tool_call_page(&mut widgets.tool_call),
+            TranscriptRowBuildKind::ToolBurst => {
+                self.unbind_tool_burst_page(&mut widgets.tool_burst)
+            }
+            TranscriptRowBuildKind::Subagent => self.unbind_subagent_page(&mut widgets.subagent),
+        }
+
+        cleanup_transcript_row_widgets(widgets);
+    }
+}
+
+impl TranscriptItemData {
+    pub(crate) fn bind_message_page(&self, _widgets: &mut MessagePageWidgets) {}
+
+    pub(crate) fn bind_tool_call_page(&self, _widgets: &mut ToolCallPageWidgets) {}
+
+    pub(crate) fn bind_tool_burst_page(&self, _widgets: &mut ToolBurstPageWidgets) {}
+
+    pub(crate) fn bind_subagent_page(&self, _widgets: &mut SubagentPageWidgets) {}
+
+    pub(crate) fn unbind_message_page(&self, _widgets: &mut MessagePageWidgets) {}
+
+    pub(crate) fn unbind_tool_call_page(&self, _widgets: &mut ToolCallPageWidgets) {}
+
+    pub(crate) fn unbind_tool_burst_page(&self, _widgets: &mut ToolBurstPageWidgets) {}
+
+    pub(crate) fn unbind_subagent_page(&self, _widgets: &mut SubagentPageWidgets) {}
+}
+
+impl TranscriptRowBuildKind {
+    fn page_name(self) -> &'static str {
+        match self {
+            Self::Message => MESSAGE_PAGE_NAME,
+            Self::ToolCall => TOOL_CALL_PAGE_NAME,
+            Self::ToolBurst => TOOL_BURST_PAGE_NAME,
+            Self::Subagent => SUBAGENT_PAGE_NAME,
+        }
+    }
+}
+
+impl From<&TranscriptItemKind> for TranscriptRowBuildKind {
+    fn from(kind: &TranscriptItemKind) -> Self {
+        match kind {
+            TranscriptItemKind::Message(_) => Self::Message,
+            TranscriptItemKind::ToolCall(_) => Self::ToolCall,
+            TranscriptItemKind::ToolBurst(_) => Self::ToolBurst,
+            TranscriptItemKind::Subagent(_) => Self::Subagent,
+        }
+    }
+}
+
+fn build_message_page() -> MessagePageWidgets {
+    let root = gtk::Box::new(gtk::Orientation::Vertical, 0);
+    root.set_visible(false);
+    MessagePageWidgets { root }
+}
+
+fn build_tool_call_page() -> ToolCallPageWidgets {
+    let root = gtk::Box::new(gtk::Orientation::Vertical, 0);
+    root.set_visible(false);
+    ToolCallPageWidgets { root }
+}
+
+fn build_tool_burst_page() -> ToolBurstPageWidgets {
+    let root = gtk::Box::new(gtk::Orientation::Vertical, 0);
+    root.set_visible(false);
+    let children = gtk::Box::new(gtk::Orientation::Vertical, 0);
+    root.append(&children);
+    ToolBurstPageWidgets { root, children }
+}
+
+fn build_subagent_page() -> SubagentPageWidgets {
+    let root = gtk::Box::new(gtk::Orientation::Vertical, 0);
+    root.set_visible(false);
+    SubagentPageWidgets { root }
+}
+
+fn cleanup_transcript_row_widgets(widgets: &mut TranscriptRowWidgets) {
+    clear_box_children(&widgets.tool_burst.children);
+}
+
+fn clear_box_children(container: &gtk::Box) {
+    while let Some(child) = container.first_child() {
+        container.remove(&child);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    use chrono::Utc;
+    use relm4::gtk;
+    use relm4::typed_view::list::RelmListItem;
+
+    use crate::models::{MessagePreview, ReasoningPreview, Role, ToolCallStatus};
+    use crate::ui::session_detail::SessionDetailMsg;
+    use crate::ui::transcript_item_data::{TranscriptItemData, TranscriptItemKind};
+    use crate::ui::transcript_row::{
+        MessageItemInit, SubagentItemInit, ToolBurstItemInit, ToolCallItemInit, TranscriptItemInit,
+        TranscriptRowBuildKind,
+    };
+
+    fn message_init() -> MessageItemInit {
+        MessageItemInit {
+            item_index: 1,
+            transcript_item_index: 11,
+            preview: MessagePreview {
+                session_id: "session-1".to_string(),
+                message_index: 4,
+                role: Role::Assistant,
+                content_preview: "hello".to_string(),
+                content_len: 5,
+                timestamp: Utc::now(),
+                model: Some("gpt-5.4".to_string()),
+                reasoning_preview: ReasoningPreview::default(),
+            },
+            highlight_query: Some("hello".to_string()),
+            db_path: Arc::new(PathBuf::from("/tmp/typed-transcript-row.db")),
+        }
+    }
+
+    fn tool_call_init() -> ToolCallItemInit {
+        ToolCallItemInit {
+            item_index: 2,
+            transcript_item_index: 12,
+            session_id: "session-1".to_string(),
+            tool_call_id: "call-1".to_string(),
+            tool_name: "Read".to_string(),
+            status: ToolCallStatus::Completed,
+            preview: Some("src/ui/transcript_row.rs:1-20".to_string()),
+            summary: None,
+            duration_ms: Some(15),
+            highlight_query: Some("read".to_string()),
+            reasoning_preview: ReasoningPreview::default(),
+        }
+    }
+
+    fn subagent_init() -> SubagentItemInit {
+        SubagentItemInit {
+            item_index: 3,
+            transcript_item_index: 13,
+            session_id: "session-1".to_string(),
+            subagent_id: "agent-1".to_string(),
+            title: "Explore".to_string(),
+            reasoning_preview: ReasoningPreview::default(),
+        }
+    }
+
+    #[test]
+    fn transcript_item_kind_maps_to_build_kind() {
+        let cases = [
+            (
+                TranscriptItemKind::Message(message_init()),
+                TranscriptRowBuildKind::Message,
+            ),
+            (
+                TranscriptItemKind::ToolCall(tool_call_init()),
+                TranscriptRowBuildKind::ToolCall,
+            ),
+            (
+                TranscriptItemKind::ToolBurst(ToolBurstItemInit {
+                    item_index: 4,
+                    tool_calls: vec![tool_call_init()],
+                    category_counts: vec![("Read".to_string(), 1)],
+                    error_count: 0,
+                    total_duration_ms: Some(15),
+                    match_count: 2,
+                    child_match_counts: vec![2],
+                    visible_reasoning_child_count: 0,
+                    encrypted_only_child_count: 0,
+                    default_expanded: false,
+                }),
+                TranscriptRowBuildKind::ToolBurst,
+            ),
+            (
+                TranscriptItemKind::Subagent(subagent_init()),
+                TranscriptRowBuildKind::Subagent,
+            ),
+        ];
+
+        for (kind, expected) in cases {
+            assert_eq!(TranscriptRowBuildKind::from(&kind), expected);
+        }
+    }
+
+    #[gtk::test]
+    fn transcript_item_data_noop_binders_accept_each_page_widget_type() {
+        let (sender, _receiver) = relm4::channel::<SessionDetailMsg>();
+
+        let mut message = TranscriptItemData::from_init(
+            TranscriptItemInit::Message(message_init()),
+            sender.clone(),
+        );
+        let mut tool_call = TranscriptItemData::from_init(
+            TranscriptItemInit::ToolCall(tool_call_init()),
+            sender.clone(),
+        );
+        let mut tool_burst = TranscriptItemData::from_init(
+            TranscriptItemInit::ToolBurst(ToolBurstItemInit {
+                item_index: 4,
+                tool_calls: vec![tool_call_init()],
+                category_counts: vec![("Read".to_string(), 1)],
+                error_count: 0,
+                total_duration_ms: Some(15),
+                match_count: 2,
+                child_match_counts: vec![2],
+                visible_reasoning_child_count: 0,
+                encrypted_only_child_count: 0,
+                default_expanded: false,
+            }),
+            sender.clone(),
+        );
+        let mut subagent =
+            TranscriptItemData::from_init(TranscriptItemInit::Subagent(subagent_init()), sender);
+
+        let list_item: gtk::ListItem = gtk::glib::Object::builder().build();
+        let (_, mut message_widgets) = TranscriptItemData::setup(&list_item);
+        let mut root = gtk::Box::new(gtk::Orientation::Vertical, 0);
+        message.bind(&mut message_widgets, &mut root);
+        message.unbind(&mut message_widgets, &mut root);
+
+        let (_, mut tool_call_widgets) = TranscriptItemData::setup(&list_item);
+        let mut root = gtk::Box::new(gtk::Orientation::Vertical, 0);
+        tool_call.bind(&mut tool_call_widgets, &mut root);
+        tool_call.unbind(&mut tool_call_widgets, &mut root);
+
+        let (_, mut tool_burst_widgets) = TranscriptItemData::setup(&list_item);
+        let mut root = gtk::Box::new(gtk::Orientation::Vertical, 0);
+        tool_burst.bind(&mut tool_burst_widgets, &mut root);
+        tool_burst.unbind(&mut tool_burst_widgets, &mut root);
+
+        let (_, mut subagent_widgets) = TranscriptItemData::setup(&list_item);
+        let mut root = gtk::Box::new(gtk::Orientation::Vertical, 0);
+        subagent.bind(&mut subagent_widgets, &mut root);
+        subagent.unbind(&mut subagent_widgets, &mut root);
+    }
+}

--- a/src/ui/typed_transcript_row.rs
+++ b/src/ui/typed_transcript_row.rs
@@ -434,7 +434,7 @@ fn build_message_page() -> MessagePageWidgets {
     root.add_css_class("message-row");
     root.set_spacing(4);
 
-    let header = gtk::Box::new(gtk::Orientation::Horizontal, 4);
+    let header = gtk::Box::new(gtk::Orientation::Horizontal, 8);
 
     let role_label = gtk::Label::new(None);
     role_label.add_css_class("caption");
@@ -477,6 +477,7 @@ fn build_message_page() -> MessagePageWidgets {
     expand_button.add_css_class("caption");
     expand_button.add_css_class("expand-toggle");
     expand_button.set_halign(gtk::Align::Start);
+    expand_button.set_margin_top(4);
     expand_button.set_visible(false);
     root.append(&expand_button);
 
@@ -579,10 +580,16 @@ fn build_tool_call_page_content(
     init: &crate::ui::transcript_row::ToolCallItemInit,
     highlight_query: Option<&str>,
 ) -> ToolCallPageContentRefs {
-    let root = gtk::Box::new(gtk::Orientation::Vertical, 4);
+    let root = gtk::Box::new(gtk::Orientation::Vertical, 0);
     root.add_css_class("tool-call-row");
+    root.set_margin_top(2);
+    root.set_margin_bottom(2);
 
     let row = gtk::Box::new(gtk::Orientation::Horizontal, 8);
+    row.set_margin_start(8);
+    row.set_margin_end(4);
+    row.set_margin_top(4);
+    row.set_margin_bottom(4);
 
     let icon = gtk::Image::new();
     icon.set_icon_name(Some(tool_name_icon(&init.tool_name, &TOOL_ICONS)));
@@ -646,8 +653,11 @@ fn build_tool_call_page_content(
         let preview_label = gtk::Label::new(None);
         preview_label.add_css_class("caption");
         preview_label.add_css_class("dim-label");
+        preview_label.add_css_class("preview-label");
         preview_label.set_halign(gtk::Align::Start);
         preview_label.set_xalign(0.0);
+        preview_label.set_margin_start(32);
+        preview_label.set_margin_bottom(4);
         preview_label.set_wrap(true);
         if let Some(query) = highlight_query {
             let (markup, _) = highlight::highlight_text(preview, query);
@@ -688,6 +698,10 @@ fn build_subagent_page_content(
 ) -> SubagentPageContentRefs {
     let root = gtk::Box::new(gtk::Orientation::Horizontal, 8);
     root.add_css_class("subagent-row");
+    root.set_margin_start(8);
+    root.set_margin_end(4);
+    root.set_margin_top(4);
+    root.set_margin_bottom(4);
 
     let icon = gtk::Image::new();
     icon.set_icon_name(Some(TOOL_ICONS.agent));
@@ -1397,6 +1411,42 @@ mod tests {
         assert!(
             spacer.is::<gtk::Box>() && spacer.hexpands(),
             "a hexpanding spacer must sit just before the trailing inspect button"
+        );
+    }
+
+    #[gtk::test]
+    fn tool_call_page_indents_preview_to_align_with_name() {
+        let (sender, receiver) = relm4::channel::<SessionDetailMsg>();
+        let mut tool_call =
+            TranscriptItemData::from_init(TranscriptItemInit::ToolCall(tool_call_init()), sender);
+
+        let list_item: gtk::ListItem = gtk::glib::Object::builder().build();
+        let (_, mut widgets) = TranscriptItemData::setup(&list_item);
+        let mut root = gtk::Box::new(gtk::Orientation::Vertical, 0);
+
+        tool_call.bind(&mut widgets, &mut root);
+        let _ = gtk::glib::MainContext::default().block_on(receiver.recv());
+
+        let content = widgets
+            .tool_call
+            .root
+            .first_child()
+            .expect("tool call content")
+            .downcast::<gtk::Box>()
+            .expect("tool call content box");
+        let preview = collect_box_children(&content)[1]
+            .clone()
+            .downcast::<gtk::Label>()
+            .expect("tool call preview label");
+
+        assert!(
+            preview.has_css_class("preview-label"),
+            "preview must carry the preview-label style class"
+        );
+        assert_eq!(
+            preview.margin_start(),
+            32,
+            "preview must be indented to align with the tool name, not the icon"
         );
     }
 

--- a/src/ui/typed_transcript_row.rs
+++ b/src/ui/typed_transcript_row.rs
@@ -564,7 +564,7 @@ fn build_tool_call_page_content(
     let name_label = gtk::Label::new(None);
     name_label.add_css_class("monospace");
     name_label.set_halign(gtk::Align::Start);
-    name_label.set_hexpand(true);
+    name_label.set_hexpand(false);
     name_label.set_xalign(0.0);
     if let Some(query) = highlight_query {
         let (markup, _) = highlight::highlight_text(&init.tool_name, query);
@@ -607,6 +607,10 @@ fn build_tool_call_page_content(
     inspect.set_icon_name("view-reveal-symbolic");
     inspect.add_css_class("flat");
     inspect.set_tooltip_text(Some("Inspect tool call"));
+
+    let spacer = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+    spacer.set_hexpand(true);
+    row.append(&spacer);
     row.append(&inspect);
     root.append(&row);
 
@@ -659,7 +663,7 @@ fn build_subagent_page_content(
 
     let title = gtk::Label::new(Some(&init.title));
     title.set_halign(gtk::Align::Start);
-    title.set_hexpand(true);
+    title.set_hexpand(false);
     title.set_xalign(0.0);
     root.append(&title);
 
@@ -684,6 +688,10 @@ fn build_subagent_page_content(
     inspect.set_icon_name("view-reveal-symbolic");
     inspect.add_css_class("flat");
     inspect.set_tooltip_text(Some("Inspect subagent"));
+
+    let spacer = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+    spacer.set_hexpand(true);
+    root.append(&spacer);
     root.append(&inspect);
 
     SubagentPageContentRefs {
@@ -1203,6 +1211,121 @@ mod tests {
             .expect("tool name label");
 
         assert!(name_label.uses_markup());
+    }
+
+    fn collect_box_children(container: &gtk::Box) -> Vec<gtk::Widget> {
+        let mut children = Vec::new();
+        let mut child = container.first_child();
+        while let Some(current) = child {
+            child = current.next_sibling();
+            children.push(current);
+        }
+        children
+    }
+
+    #[gtk::test]
+    fn tool_call_page_keeps_metadata_left_of_inspect_button() {
+        let (sender, receiver) = relm4::channel::<SessionDetailMsg>();
+        let mut tool_call = TranscriptItemData::from_init(
+            TranscriptItemInit::ToolCall(ToolCallItemInit {
+                reasoning_preview: ReasoningPreview {
+                    has_reasoning: true,
+                    has_visible_reasoning: false,
+                    encrypted_only: true,
+                },
+                ..tool_call_init()
+            }),
+            sender,
+        );
+
+        let list_item: gtk::ListItem = gtk::glib::Object::builder().build();
+        let (_, mut widgets) = TranscriptItemData::setup(&list_item);
+        let mut root = gtk::Box::new(gtk::Orientation::Vertical, 0);
+
+        tool_call.bind(&mut widgets, &mut root);
+        let _ = gtk::glib::MainContext::default().block_on(receiver.recv());
+
+        let row = widgets
+            .tool_call
+            .root
+            .first_child()
+            .expect("tool call content")
+            .downcast::<gtk::Box>()
+            .expect("tool call content box")
+            .first_child()
+            .expect("tool call row")
+            .downcast::<gtk::Box>()
+            .expect("tool call row box");
+        let children = collect_box_children(&row);
+
+        let name_label = children[0]
+            .clone()
+            .downcast::<gtk::Label>()
+            .expect("tool name label");
+        assert!(
+            !name_label.hexpands(),
+            "tool name label must not absorb horizontal slack"
+        );
+
+        let spacer = &children[children.len() - 2];
+        assert!(
+            spacer.is::<gtk::Box>() && spacer.hexpands(),
+            "a hexpanding spacer must sit just before the trailing inspect button"
+        );
+
+        let inspect = children
+            .last()
+            .expect("inspect button")
+            .clone()
+            .downcast::<gtk::Button>()
+            .expect("inspect button");
+        assert!(!inspect.hexpands());
+    }
+
+    #[gtk::test]
+    fn subagent_page_keeps_metadata_left_of_inspect_button() {
+        let (sender, _receiver) = relm4::channel::<SessionDetailMsg>();
+        let mut subagent = TranscriptItemData::from_init(
+            TranscriptItemInit::Subagent(SubagentItemInit {
+                reasoning_preview: ReasoningPreview {
+                    has_reasoning: true,
+                    has_visible_reasoning: false,
+                    encrypted_only: true,
+                },
+                ..subagent_init()
+            }),
+            sender,
+        );
+
+        let list_item: gtk::ListItem = gtk::glib::Object::builder().build();
+        let (_, mut widgets) = TranscriptItemData::setup(&list_item);
+        let mut root = gtk::Box::new(gtk::Orientation::Vertical, 0);
+
+        subagent.bind(&mut widgets, &mut root);
+
+        let row = widgets
+            .subagent
+            .root
+            .first_child()
+            .expect("subagent content")
+            .downcast::<gtk::Box>()
+            .expect("subagent row box");
+        let children = collect_box_children(&row);
+
+        let title_label = children[0]
+            .clone()
+            .downcast::<gtk::Label>()
+            .expect("subagent title label");
+        assert!(
+            !title_label.hexpands(),
+            "subagent title label must not absorb horizontal slack"
+        );
+
+        let spacer = &children[children.len() - 2];
+        assert!(
+            spacer.is::<gtk::Box>() && spacer.hexpands(),
+            "a hexpanding spacer must sit just before the trailing inspect button"
+        );
     }
 
     #[gtk::test]

--- a/src/ui/typed_transcript_row.rs
+++ b/src/ui/typed_transcript_row.rs
@@ -1,5 +1,6 @@
 use std::cell::Cell;
 use std::rc::Rc;
+use std::time::Instant;
 
 use gtk::prelude::*;
 use relm4::binding::Binding;
@@ -101,6 +102,7 @@ impl RelmListItem for TranscriptItemData {
     }
 
     fn bind(&mut self, widgets: &mut Self::Widgets, _root: &mut Self::Root) {
+        let start = Instant::now();
         let kind = TranscriptRowBuildKind::from(&self.kind);
         widgets.stack.set_visible_child_name(kind.page_name());
 
@@ -110,6 +112,14 @@ impl RelmListItem for TranscriptItemData {
             TranscriptRowBuildKind::ToolBurst => self.bind_tool_burst_page(&mut widgets.tool_burst),
             TranscriptRowBuildKind::Subagent => self.bind_subagent_page(&mut widgets.subagent),
         }
+
+        self.sender
+            .send(SessionDetailMsg::RowBuilt {
+                item_index: self.item_index,
+                kind,
+                build_duration_ms: start.elapsed().as_millis(),
+            })
+            .ok();
     }
 
     fn unbind(&mut self, widgets: &mut Self::Widgets, _root: &mut Self::Root) {

--- a/src/ui/typed_transcript_row.rs
+++ b/src/ui/typed_transcript_row.rs
@@ -8,6 +8,7 @@ use relm4::{gtk, typed_view::list::RelmListItem};
 
 use crate::models::Role;
 use crate::ui::format::{format_duration_ms, tool_status_css_class, tool_status_label};
+use crate::ui::highlight;
 use crate::ui::session_detail::SessionDetailMsg;
 use crate::ui::transcript_item_data::{TranscriptItemData, TranscriptItemKind};
 use crate::ui::transcript_row::{
@@ -19,6 +20,7 @@ const MESSAGE_PAGE_NAME: &str = "message";
 const TOOL_CALL_PAGE_NAME: &str = "tool-call";
 const TOOL_BURST_PAGE_NAME: &str = "tool-burst";
 const SUBAGENT_PAGE_NAME: &str = "subagent";
+pub(crate) const TRANSCRIPT_ROW_WIDGET_NAME_PREFIX: &str = "transcript-row-";
 
 pub struct TranscriptRowWidgets {
     stack: gtk::Stack,
@@ -101,9 +103,13 @@ impl RelmListItem for TranscriptItemData {
         )
     }
 
-    fn bind(&mut self, widgets: &mut Self::Widgets, _root: &mut Self::Root) {
+    fn bind(&mut self, widgets: &mut Self::Widgets, root: &mut Self::Root) {
         let start = Instant::now();
         let kind = TranscriptRowBuildKind::from(&self.kind);
+        root.set_widget_name(&format!(
+            "{TRANSCRIPT_ROW_WIDGET_NAME_PREFIX}{}",
+            self.item_index
+        ));
         widgets.stack.set_visible_child_name(kind.page_name());
 
         match kind {
@@ -187,9 +193,17 @@ impl TranscriptItemData {
             widgets.reasoning_box.append(&label);
         }
 
+        let content = if self.expanded.get() {
+            self.full_content
+                .as_deref()
+                .unwrap_or(&message.preview.content_preview)
+        } else {
+            &message.preview.content_preview
+        };
+
         render_content(
             &widgets.content,
-            &message.preview.content_preview,
+            content,
             message.preview.role,
             self.highlight_query.as_deref(),
         );
@@ -220,7 +234,7 @@ impl TranscriptItemData {
         };
 
         clear_box_children(&widgets.root);
-        let refs = build_tool_call_page_content(tool_call);
+        let refs = build_tool_call_page_content(tool_call, self.highlight_query.as_deref());
 
         if let Some(reasoning_button) = refs.reasoning_button {
             let sender = self.sender.clone();
@@ -264,7 +278,7 @@ impl TranscriptItemData {
             let revealer = widgets.revealer.clone();
             let children_built_for = widgets.children_built_for.clone();
             let sender = self.sender.clone();
-            let burst = burst.clone();
+            let burst = burst_with_highlight_query(burst, self.highlight_query.as_deref());
             let item_index = self.item_index;
             let header_button = widgets.header_button.clone();
             widgets.revealer.connect_reveal_child_notify(move |_| {
@@ -286,10 +300,11 @@ impl TranscriptItemData {
             .push((widgets.revealer.clone().upcast(), notify_id));
 
         if self.expanded.get() {
+            let burst = burst_with_highlight_query(burst, self.highlight_query.as_deref());
             build_tool_burst_children_if_needed(
                 &widgets.children,
                 &widgets.children_built_for,
-                burst,
+                &burst,
                 &self.sender,
                 self.item_index,
             );
@@ -521,16 +536,23 @@ struct ToolCallPageContentRefs {
 
 fn build_tool_call_page_content(
     init: &crate::ui::transcript_row::ToolCallItemInit,
+    highlight_query: Option<&str>,
 ) -> ToolCallPageContentRefs {
     let root = gtk::Box::new(gtk::Orientation::Vertical, 4);
     root.add_css_class("tool-call-row");
 
     let row = gtk::Box::new(gtk::Orientation::Horizontal, 8);
-    let name_label = gtk::Label::new(Some(&init.tool_name));
+    let name_label = gtk::Label::new(None);
     name_label.add_css_class("monospace");
     name_label.set_halign(gtk::Align::Start);
     name_label.set_hexpand(true);
     name_label.set_xalign(0.0);
+    if let Some(query) = highlight_query {
+        let (markup, _) = highlight::highlight_text(&init.tool_name, query);
+        name_label.set_markup(&markup);
+    } else {
+        name_label.set_label(&init.tool_name);
+    }
     row.append(&name_label);
 
     let status_label = gtk::Label::new(Some(tool_status_label(init.status)));
@@ -570,12 +592,18 @@ fn build_tool_call_page_content(
     root.append(&row);
 
     if let Some(preview) = init.displayed_preview() {
-        let preview_label = gtk::Label::new(Some(preview));
+        let preview_label = gtk::Label::new(None);
         preview_label.add_css_class("caption");
         preview_label.add_css_class("dim-label");
         preview_label.set_halign(gtk::Align::Start);
         preview_label.set_xalign(0.0);
         preview_label.set_wrap(true);
+        if let Some(query) = highlight_query {
+            let (markup, _) = highlight::highlight_text(preview, query);
+            preview_label.set_markup(&markup);
+        } else {
+            preview_label.set_label(preview);
+        }
         root.append(&preview_label);
     }
 
@@ -584,6 +612,18 @@ fn build_tool_call_page_content(
         inspect_button: inspect,
         reasoning_button,
     }
+}
+
+fn burst_with_highlight_query(
+    burst: &crate::ui::transcript_row::ToolBurstItemInit,
+    highlight_query: Option<&str>,
+) -> crate::ui::transcript_row::ToolBurstItemInit {
+    let mut burst = burst.clone();
+    let highlight_query = highlight_query.map(str::to_string);
+    for tool_call in &mut burst.tool_calls {
+        tool_call.highlight_query = highlight_query.clone();
+    }
+    burst
 }
 
 struct SubagentPageContentRefs {
@@ -873,6 +913,17 @@ mod tests {
             .expect("message expand button")
     }
 
+    fn message_content_text(widgets: &super::MessagePageWidgets) -> String {
+        widgets
+            .content
+            .first_child()
+            .expect("message content child")
+            .downcast::<gtk::Label>()
+            .expect("message content label")
+            .label()
+            .to_string()
+    }
+
     #[test]
     fn transcript_item_kind_maps_to_build_kind() {
         let cases = [
@@ -1052,6 +1103,67 @@ mod tests {
                 .expect("message expand toggle"),
             SessionDetailMsg::ToggleMessageExpand { item_index: 1 }
         ));
+    }
+
+    #[gtk::test]
+    fn expanded_message_renders_loaded_full_content() {
+        let (sender, receiver) = relm4::channel::<SessionDetailMsg>();
+        let mut init = truncated_message_init();
+        init.preview.role = Role::User;
+        init.preview.content_preview = "short preview".to_string();
+        init.preview.content_len = 42;
+        let mut message = TranscriptItemData::from_init(TranscriptItemInit::Message(init), sender);
+        message.expanded.set(true);
+        message.full_content = Some("loaded full message body".to_string());
+
+        let list_item: gtk::ListItem = gtk::glib::Object::builder().build();
+        let (_, mut widgets) = TranscriptItemData::setup(&list_item);
+        let mut root = gtk::Box::new(gtk::Orientation::Vertical, 0);
+
+        message.bind(&mut widgets, &mut root);
+        let _ = gtk::glib::MainContext::default().block_on(receiver.recv());
+
+        assert_eq!(
+            message_content_text(&widgets.message),
+            "loaded full message body"
+        );
+    }
+
+    #[gtk::test]
+    fn tool_call_page_uses_data_level_highlight_query() {
+        let (sender, receiver) = relm4::channel::<SessionDetailMsg>();
+        let mut tool_call = TranscriptItemData::from_init(
+            TranscriptItemInit::ToolCall(ToolCallItemInit {
+                highlight_query: None,
+                ..tool_call_init()
+            }),
+            sender,
+        );
+        tool_call.highlight_query = Some("Read".to_string());
+
+        let list_item: gtk::ListItem = gtk::glib::Object::builder().build();
+        let (_, mut widgets) = TranscriptItemData::setup(&list_item);
+        let mut root = gtk::Box::new(gtk::Orientation::Vertical, 0);
+
+        tool_call.bind(&mut widgets, &mut root);
+        let _ = gtk::glib::MainContext::default().block_on(receiver.recv());
+        let name_label = widgets
+            .tool_call
+            .root
+            .first_child()
+            .expect("tool call content")
+            .downcast::<gtk::Box>()
+            .expect("tool call content box")
+            .first_child()
+            .expect("tool call row")
+            .downcast::<gtk::Box>()
+            .expect("tool call row box")
+            .first_child()
+            .expect("tool name label")
+            .downcast::<gtk::Label>()
+            .expect("tool name label");
+
+        assert!(name_label.uses_markup());
     }
 
     #[gtk::test]

--- a/src/ui/typed_transcript_row.rs
+++ b/src/ui/typed_transcript_row.rs
@@ -1020,8 +1020,6 @@ mod tests {
 
         expand_button.emit_clicked();
 
-        assert!(!message.expanded.get());
-        assert_eq!(expand_button.label().as_deref(), Some("Show full message"));
         assert!(matches!(
             gtk::glib::MainContext::default()
                 .block_on(receiver.recv())

--- a/src/ui/typed_transcript_row.rs
+++ b/src/ui/typed_transcript_row.rs
@@ -498,6 +498,7 @@ fn build_tool_call_page() -> ToolCallPageWidgets {
 
 fn build_tool_burst_page() -> ToolBurstPageWidgets {
     let root = gtk::Box::new(gtk::Orientation::Vertical, 0);
+    root.add_css_class("tool-call-group");
 
     let header_button = gtk::Button::new();
     header_button.add_css_class("flat");
@@ -1247,6 +1248,22 @@ mod tests {
         assert!(expanded.expanded.get());
         assert!(expanded_revealer.reveals_child());
         assert_eq!(count_box_children(&expanded_children), 1);
+    }
+
+    #[gtk::test]
+    fn tool_burst_bind_applies_group_border_class() {
+        let (sender, _receiver) = relm4::channel::<SessionDetailMsg>();
+        let mut burst = TranscriptItemData::from_init(
+            TranscriptItemInit::ToolBurst(tool_burst_init(false)),
+            sender,
+        );
+        let list_item: gtk::ListItem = gtk::glib::Object::builder().build();
+        let (_, mut widgets) = TranscriptItemData::setup(&list_item);
+        let mut root = gtk::Box::new(gtk::Orientation::Vertical, 0);
+
+        burst.bind(&mut widgets, &mut root);
+
+        assert!(widgets.tool_burst.root.has_css_class("tool-call-group"));
     }
 
     #[gtk::test]

--- a/src/ui/typed_transcript_row.rs
+++ b/src/ui/typed_transcript_row.rs
@@ -148,6 +148,8 @@ impl TranscriptItemData {
             return;
         };
 
+        set_role_css_class(&widgets.root, message.preview.role);
+        set_role_css_class(&widgets.role_label, message.preview.role);
         widgets
             .role_label
             .set_label(if message.preview.role == Role::Assistant {
@@ -410,11 +412,14 @@ impl From<&TranscriptItemKind> for TranscriptRowBuildKind {
 
 fn build_message_page() -> MessagePageWidgets {
     let root = gtk::Box::new(gtk::Orientation::Vertical, 0);
+    root.add_css_class("message-row");
     root.set_spacing(4);
 
     let header = gtk::Box::new(gtk::Orientation::Horizontal, 4);
 
     let role_label = gtk::Label::new(None);
+    role_label.add_css_class("caption");
+    role_label.add_css_class("heading");
     role_label.set_halign(gtk::Align::Start);
     header.append(&role_label);
 
@@ -468,6 +473,19 @@ fn build_message_page() -> MessagePageWidgets {
         expand_button,
         connected_handlers: Vec::new(),
     }
+}
+
+fn set_role_css_class(widget: &impl IsA<gtk::Widget>, role: Role) {
+    let widget = widget.as_ref();
+    for class in [
+        Role::User.css_class(),
+        Role::Assistant.css_class(),
+        Role::ToolCall.css_class(),
+        Role::ToolResult.css_class(),
+    ] {
+        widget.remove_css_class(class);
+    }
+    widget.add_css_class(role.css_class());
 }
 
 fn build_tool_call_page() -> ToolCallPageWidgets {
@@ -1127,6 +1145,26 @@ mod tests {
             message_content_text(&widgets.message),
             "loaded full message body"
         );
+    }
+
+    #[gtk::test]
+    fn message_bind_applies_role_border_classes() {
+        let (sender, receiver) = relm4::channel::<SessionDetailMsg>();
+        let mut init = truncated_message_init();
+        init.preview.role = Role::User;
+        let mut message = TranscriptItemData::from_init(TranscriptItemInit::Message(init), sender);
+
+        let list_item: gtk::ListItem = gtk::glib::Object::builder().build();
+        let (_, mut widgets) = TranscriptItemData::setup(&list_item);
+        let mut root = gtk::Box::new(gtk::Orientation::Vertical, 0);
+
+        message.bind(&mut widgets, &mut root);
+        let _ = gtk::glib::MainContext::default().block_on(receiver.recv());
+
+        assert!(widgets.message.root.has_css_class("message-row"));
+        assert!(widgets.message.root.has_css_class("role-user"));
+        assert!(widgets.message.role_label.has_css_class("heading"));
+        assert!(widgets.message.role_label.has_css_class("role-user"));
     }
 
     #[gtk::test]

--- a/src/ui/typed_transcript_row.rs
+++ b/src/ui/typed_transcript_row.rs
@@ -4,7 +4,7 @@ use std::time::Instant;
 
 use gtk::prelude::*;
 use relm4::binding::Binding;
-use relm4::{gtk, typed_view::list::RelmListItem};
+use relm4::{adw, gtk, typed_view::list::RelmListItem};
 
 use crate::models::{Role, tool_name_icon};
 use crate::ui::format::{format_duration_ms, tool_status_css_class, tool_status_label};
@@ -56,7 +56,7 @@ pub struct ToolBurstPageWidgets {
     root: gtk::Box,
     header_button: gtk::Button,
     arrow_icon: gtk::Image,
-    header_box: gtk::Box,
+    header_wrap: adw::WrapBox,
     revealer: gtk::Revealer,
     children: gtk::Box,
     reveal_binding: Option<gtk::glib::Binding>,
@@ -270,7 +270,7 @@ impl TranscriptItemData {
             return;
         };
 
-        rebuild_tool_burst_header(&widgets.header_box, burst);
+        rebuild_tool_burst_header(&widgets.header_wrap, burst);
         widgets
             .header_button
             .update_property(&[gtk::accessible::Property::Label(
@@ -391,7 +391,7 @@ impl TranscriptItemData {
         if let Some(binding) = widgets.reveal_binding.take() {
             binding.unbind();
         }
-        clear_box_children(&widgets.header_box);
+        widgets.header_wrap.remove_all();
         clear_box_children(&widgets.children);
         widgets.children_built_for.set(None);
         set_tool_burst_expanded_state(
@@ -532,10 +532,15 @@ fn build_tool_burst_page() -> ToolBurstPageWidgets {
     arrow_icon.add_css_class("tool-call-group-arrow");
     header_row.append(&arrow_icon);
 
-    let header_box = gtk::Box::new(gtk::Orientation::Horizontal, 8);
-    header_box.set_hexpand(true);
-    header_box.add_css_class("tool-call-group-header");
-    header_row.append(&header_box);
+    // AdwWrapBox (not GtkFlowBox): pills flow like words in a wrapping label,
+    // so they reflow onto extra lines on narrow windows. GtkFlowBox here caused
+    // a session-open freeze inside the recycled GtkListView rows.
+    let header_wrap = adw::WrapBox::new();
+    header_wrap.set_child_spacing(8);
+    header_wrap.set_line_spacing(4);
+    header_wrap.set_hexpand(true);
+    header_wrap.add_css_class("tool-call-group-header");
+    header_row.append(&header_wrap);
     header_button.set_child(Some(&header_row));
     root.append(&header_button);
 
@@ -549,7 +554,7 @@ fn build_tool_burst_page() -> ToolBurstPageWidgets {
         root,
         header_button,
         arrow_icon,
-        header_box,
+        header_wrap,
         revealer,
         children,
         reveal_binding: None,
@@ -751,10 +756,10 @@ fn build_subagent_page_content(
 }
 
 fn rebuild_tool_burst_header(
-    header: &gtk::Box,
+    header: &adw::WrapBox,
     burst: &crate::ui::transcript_row::ToolBurstItemInit,
 ) {
-    clear_box_children(header);
+    header.remove_all();
 
     for (name, count) in &burst.category_counts {
         let pill_box = gtk::Box::new(gtk::Orientation::Horizontal, 4);
@@ -870,6 +875,7 @@ mod tests {
     use std::sync::Arc;
 
     use chrono::Utc;
+    use relm4::adw;
     use relm4::binding::Binding;
     use relm4::gtk;
     use relm4::gtk::prelude::*;
@@ -1567,6 +1573,34 @@ mod tests {
     }
 
     #[gtk::test]
+    fn tool_burst_header_uses_wrap_box_so_pills_can_wrap() {
+        let (sender, _receiver) = relm4::channel::<SessionDetailMsg>();
+        let mut burst = TranscriptItemData::from_init(
+            TranscriptItemInit::ToolBurst(tool_burst_init(false)),
+            sender,
+        );
+
+        let list_item: gtk::ListItem = gtk::glib::Object::builder().build();
+        let (_, mut widgets) = TranscriptItemData::setup(&list_item);
+        let mut root = gtk::Box::new(gtk::Orientation::Vertical, 0);
+
+        burst.bind(&mut widgets, &mut root);
+
+        let header_container = tool_burst_header_button(&widgets.tool_burst.root)
+            .child()
+            .expect("header row")
+            .downcast::<gtk::Box>()
+            .expect("header row box")
+            .last_child()
+            .expect("header pill container");
+        assert!(
+            header_container.is::<adw::WrapBox>(),
+            "tool burst pills must live in an AdwWrapBox so they wrap onto \
+             multiple lines instead of overflowing on narrow windows"
+        );
+    }
+
+    #[gtk::test]
     fn tool_burst_header_renders_category_pill_with_icon() {
         let (sender, _receiver) = relm4::channel::<SessionDetailMsg>();
         let mut burst = TranscriptItemData::from_init(
@@ -1582,7 +1616,7 @@ mod tests {
 
         let pill_box = widgets
             .tool_burst
-            .header_box
+            .header_wrap
             .first_child()
             .expect("category pill box")
             .downcast::<gtk::Box>()

--- a/src/ui/typed_transcript_row.rs
+++ b/src/ui/typed_transcript_row.rs
@@ -56,7 +56,7 @@ pub struct ToolBurstPageWidgets {
     root: gtk::Box,
     header_button: gtk::Button,
     arrow_icon: gtk::Image,
-    header_flow: gtk::FlowBox,
+    header_box: gtk::Box,
     revealer: gtk::Revealer,
     children: gtk::Box,
     reveal_binding: Option<gtk::glib::Binding>,
@@ -270,7 +270,7 @@ impl TranscriptItemData {
             return;
         };
 
-        rebuild_tool_burst_header(&widgets.header_flow, burst);
+        rebuild_tool_burst_header(&widgets.header_box, burst);
         widgets
             .header_button
             .update_property(&[gtk::accessible::Property::Label(
@@ -391,7 +391,7 @@ impl TranscriptItemData {
         if let Some(binding) = widgets.reveal_binding.take() {
             binding.unbind();
         }
-        clear_flow_box_children(&widgets.header_flow);
+        clear_box_children(&widgets.header_box);
         clear_box_children(&widgets.children);
         widgets.children_built_for.set(None);
         set_tool_burst_expanded_state(
@@ -531,15 +531,10 @@ fn build_tool_burst_page() -> ToolBurstPageWidgets {
     arrow_icon.add_css_class("tool-call-group-arrow");
     header_row.append(&arrow_icon);
 
-    let header_flow = gtk::FlowBox::new();
-    header_flow.set_selection_mode(gtk::SelectionMode::None);
-    header_flow.set_row_spacing(4);
-    header_flow.set_column_spacing(8);
-    header_flow.set_min_children_per_line(1);
-    header_flow.set_max_children_per_line(u32::MAX);
-    header_flow.set_hexpand(true);
-    header_flow.add_css_class("tool-call-group-header");
-    header_row.append(&header_flow);
+    let header_box = gtk::Box::new(gtk::Orientation::Horizontal, 8);
+    header_box.set_hexpand(true);
+    header_box.add_css_class("tool-call-group-header");
+    header_row.append(&header_box);
     header_button.set_child(Some(&header_row));
     root.append(&header_button);
 
@@ -553,7 +548,7 @@ fn build_tool_burst_page() -> ToolBurstPageWidgets {
         root,
         header_button,
         arrow_icon,
-        header_flow,
+        header_box,
         revealer,
         children,
         reveal_binding: None,
@@ -740,10 +735,10 @@ fn build_subagent_page_content(
 }
 
 fn rebuild_tool_burst_header(
-    flow: &gtk::FlowBox,
+    header: &gtk::Box,
     burst: &crate::ui::transcript_row::ToolBurstItemInit,
 ) {
-    clear_flow_box_children(flow);
+    clear_box_children(header);
 
     for (name, count) in &burst.category_counts {
         let pill_box = gtk::Box::new(gtk::Orientation::Horizontal, 4);
@@ -758,14 +753,14 @@ fn rebuild_tool_burst_header(
         let pill_label = gtk::Label::new(Some(&format!("{count} {name}")));
         pill_box.append(&pill_label);
 
-        flow.insert(&pill_box, -1);
+        header.append(&pill_box);
     }
 
     if let Some(ms) = burst.total_duration_ms {
         let duration = gtk::Label::new(Some(&format_duration_ms(ms)));
         duration.add_css_class("caption");
         duration.add_css_class("dim-label");
-        flow.insert(&duration, -1);
+        header.append(&duration);
     }
 
     if let Some(reasoning_label) = format_reasoning_burst_label(
@@ -780,13 +775,13 @@ fn rebuild_tool_burst_header(
         } else {
             badge.add_css_class("reasoning-pill-encrypted");
         }
-        flow.insert(&badge, -1);
+        header.append(&badge);
     }
 
     let total = gtk::Label::new(Some(&format!("{} tool calls", burst.tool_calls.len())));
     total.add_css_class("caption");
     total.add_css_class("dim-label");
-    flow.insert(&total, -1);
+    header.append(&total);
 
     if burst.error_count > 0 {
         let error_label = gtk::Label::new(Some(&format!(
@@ -800,7 +795,7 @@ fn rebuild_tool_burst_header(
         )));
         error_label.add_css_class("caption");
         error_label.add_css_class("status-error");
-        flow.insert(&error_label, -1);
+        header.append(&error_label);
     }
 
     let burst_match_count: usize = burst.child_match_counts.iter().sum();
@@ -812,7 +807,7 @@ fn rebuild_tool_burst_header(
         badge.update_property(&[gtk::accessible::Property::Label(
             &format_tool_burst_match_badge_accessible_label(burst_match_count),
         )]);
-        flow.insert(&badge, -1);
+        header.append(&badge);
     }
 }
 
@@ -850,12 +845,6 @@ fn disconnect_handlers(handlers: &mut Vec<(gtk::glib::Object, gtk::glib::SignalH
 fn clear_box_children(container: &gtk::Box) {
     while let Some(child) = container.first_child() {
         container.remove(&child);
-    }
-}
-
-fn clear_flow_box_children(flow: &gtk::FlowBox) {
-    while let Some(child) = flow.first_child() {
-        flow.remove(&child);
     }
 }
 
@@ -1449,13 +1438,9 @@ mod tests {
 
         let pill_box = widgets
             .tool_burst
-            .header_flow
+            .header_box
             .first_child()
-            .expect("category pill flowbox child")
-            .downcast::<gtk::FlowBoxChild>()
-            .expect("flowbox child")
-            .child()
-            .expect("pill box")
+            .expect("category pill box")
             .downcast::<gtk::Box>()
             .expect("pill box");
         assert!(pill_box.has_css_class("tool-call-group-pill"));

--- a/src/ui/typed_transcript_row.rs
+++ b/src/ui/typed_transcript_row.rs
@@ -181,7 +181,7 @@ impl TranscriptItemData {
             &widgets.content,
             &message.preview.content_preview,
             message.preview.role,
-            message.highlight_query.as_deref(),
+            self.highlight_query.as_deref(),
         );
 
         let can_expand = message.preview.is_truncated() && message.preview.role != Role::ToolResult;

--- a/src/ui/typed_transcript_row.rs
+++ b/src/ui/typed_transcript_row.rs
@@ -1000,6 +1000,14 @@ mod tests {
         let mut root = gtk::Box::new(gtk::Orientation::Vertical, 0);
 
         message.bind(&mut widgets, &mut root);
+
+        assert!(matches!(
+            gtk::glib::MainContext::default()
+                .block_on(receiver.recv())
+                .expect("row built"),
+            SessionDetailMsg::RowBuilt { .. }
+        ));
+
         message_reasoning_button(&widgets.message.root).emit_clicked();
 
         assert!(matches!(
@@ -1023,6 +1031,14 @@ mod tests {
         let mut root = gtk::Box::new(gtk::Orientation::Vertical, 0);
 
         message.bind(&mut widgets, &mut root);
+
+        assert!(matches!(
+            gtk::glib::MainContext::default()
+                .block_on(receiver.recv())
+                .expect("row built"),
+            SessionDetailMsg::RowBuilt { .. }
+        ));
+
         let expand_button = message_expand_button(&widgets.message.root);
 
         assert!(expand_button.is_visible());

--- a/src/ui/typed_transcript_row.rs
+++ b/src/ui/typed_transcript_row.rs
@@ -601,6 +601,7 @@ fn build_tool_call_page_content(
     name_label.set_halign(gtk::Align::Start);
     name_label.set_hexpand(false);
     name_label.set_xalign(0.0);
+    name_label.set_ellipsize(gtk::pango::EllipsizeMode::End);
     if let Some(query) = highlight_query {
         let (markup, _) = highlight::highlight_text(&init.tool_name, query);
         name_label.set_markup(&markup);
@@ -658,7 +659,7 @@ fn build_tool_call_page_content(
         preview_label.set_xalign(0.0);
         preview_label.set_margin_start(32);
         preview_label.set_margin_bottom(4);
-        preview_label.set_wrap(true);
+        preview_label.set_ellipsize(gtk::pango::EllipsizeMode::End);
         if let Some(query) = highlight_query {
             let (markup, _) = highlight::highlight_text(preview, query);
             preview_label.set_markup(&markup);
@@ -712,6 +713,7 @@ fn build_subagent_page_content(
     title.set_halign(gtk::Align::Start);
     title.set_hexpand(false);
     title.set_xalign(0.0);
+    title.set_ellipsize(gtk::pango::EllipsizeMode::End);
     root.append(&title);
 
     let reasoning_button = if init.reasoning_preview.has_visible_reasoning {
@@ -1289,6 +1291,62 @@ mod tests {
         assert!(name_label.uses_markup());
     }
 
+    #[gtk::test]
+    fn tool_call_name_and_preview_truncate_overflow() {
+        let (sender, receiver) = relm4::channel::<SessionDetailMsg>();
+        let mut tool_call = TranscriptItemData::from_init(
+            TranscriptItemInit::ToolCall(ToolCallItemInit {
+                tool_name: "VeryLongToolNameThatShouldNotOverflowTheRow".to_string(),
+                preview: Some("a very long preview that should stay on one line".to_string()),
+                ..tool_call_init()
+            }),
+            sender,
+        );
+
+        let list_item: gtk::ListItem = gtk::glib::Object::builder().build();
+        let (_, mut widgets) = TranscriptItemData::setup(&list_item);
+        let mut root = gtk::Box::new(gtk::Orientation::Vertical, 0);
+
+        tool_call.bind(&mut widgets, &mut root);
+        let _ = gtk::glib::MainContext::default().block_on(receiver.recv());
+
+        let content = widgets
+            .tool_call
+            .root
+            .first_child()
+            .expect("tool call content")
+            .downcast::<gtk::Box>()
+            .expect("tool call content box");
+        let row = content
+            .first_child()
+            .expect("tool call row")
+            .downcast::<gtk::Box>()
+            .expect("tool call row box");
+        let name_label = collect_box_children(&row)[1]
+            .clone()
+            .downcast::<gtk::Label>()
+            .expect("tool name label");
+        let preview_label = collect_box_children(&content)[1]
+            .clone()
+            .downcast::<gtk::Label>()
+            .expect("tool call preview label");
+
+        assert_eq!(
+            name_label.ellipsize(),
+            gtk::pango::EllipsizeMode::End,
+            "tool name must truncate instead of overflowing"
+        );
+        assert_eq!(
+            preview_label.ellipsize(),
+            gtk::pango::EllipsizeMode::End,
+            "tool preview must truncate instead of wrapping"
+        );
+        assert!(
+            !preview_label.wraps(),
+            "tool preview must stay on a single line"
+        );
+    }
+
     fn collect_box_children(container: &gtk::Box) -> Vec<gtk::Widget> {
         let mut children = Vec::new();
         let mut child = container.first_child();
@@ -1411,6 +1469,42 @@ mod tests {
         assert!(
             spacer.is::<gtk::Box>() && spacer.hexpands(),
             "a hexpanding spacer must sit just before the trailing inspect button"
+        );
+    }
+
+    #[gtk::test]
+    fn subagent_title_truncates_overflow() {
+        let (sender, _receiver) = relm4::channel::<SessionDetailMsg>();
+        let mut subagent = TranscriptItemData::from_init(
+            TranscriptItemInit::Subagent(SubagentItemInit {
+                title: "Very long subagent title that should not overflow the row".to_string(),
+                ..subagent_init()
+            }),
+            sender,
+        );
+
+        let list_item: gtk::ListItem = gtk::glib::Object::builder().build();
+        let (_, mut widgets) = TranscriptItemData::setup(&list_item);
+        let mut root = gtk::Box::new(gtk::Orientation::Vertical, 0);
+
+        subagent.bind(&mut widgets, &mut root);
+
+        let row = widgets
+            .subagent
+            .root
+            .first_child()
+            .expect("subagent content")
+            .downcast::<gtk::Box>()
+            .expect("subagent row box");
+        let title_label = collect_box_children(&row)[1]
+            .clone()
+            .downcast::<gtk::Label>()
+            .expect("subagent title label");
+
+        assert_eq!(
+            title_label.ellipsize(),
+            gtk::pango::EllipsizeMode::End,
+            "subagent title must truncate instead of overflowing"
         );
     }
 

--- a/src/ui/typed_transcript_row.rs
+++ b/src/ui/typed_transcript_row.rs
@@ -161,6 +161,14 @@ impl TranscriptItemData {
             button.add_css_class("flat");
             button.add_css_class("pill");
             button.add_css_class("reasoning-pill");
+            let sender = self.sender.clone();
+            let transcript_item_index = message.transcript_item_index;
+            let id = button.connect_clicked(move |_| {
+                sender.emit(SessionDetailMsg::InspectReasoning(transcript_item_index));
+            });
+            widgets
+                .connected_handlers
+                .push((button.clone().upcast(), id));
             widgets.reasoning_box.append(&button);
         } else if message.preview.reasoning_preview.encrypted_only {
             let label = gtk::Label::new(Some("Thinking (encrypted)"));
@@ -745,6 +753,16 @@ mod tests {
         }
     }
 
+    fn message_init_with_visible_reasoning() -> MessageItemInit {
+        let mut init = message_init();
+        init.preview.reasoning_preview = ReasoningPreview {
+            has_reasoning: true,
+            has_visible_reasoning: true,
+            encrypted_only: false,
+        };
+        init
+    }
+
     fn tool_call_init() -> ToolCallItemInit {
         ToolCallItemInit {
             item_index: 2,
@@ -817,6 +835,25 @@ mod tests {
             .expect("tool burst children")
             .downcast::<gtk::Box>()
             .expect("tool burst children box")
+    }
+
+    fn message_reasoning_button(root: &gtk::Box) -> gtk::Button {
+        let header = root
+            .first_child()
+            .expect("message header")
+            .downcast::<gtk::Box>()
+            .expect("message header box");
+        let reasoning_box = header
+            .last_child()
+            .expect("message reasoning box")
+            .downcast::<gtk::Box>()
+            .expect("message reasoning box");
+
+        reasoning_box
+            .first_child()
+            .expect("message reasoning button")
+            .downcast::<gtk::Button>()
+            .expect("message reasoning button")
     }
 
     #[test]
@@ -931,6 +968,29 @@ mod tests {
                 .expect("visible child")
                 .is_visible()
         );
+    }
+
+    #[gtk::test]
+    fn message_reasoning_button_emits_inspect_reasoning() {
+        let (sender, receiver) = relm4::channel::<SessionDetailMsg>();
+        let mut message = TranscriptItemData::from_init(
+            TranscriptItemInit::Message(message_init_with_visible_reasoning()),
+            sender,
+        );
+
+        let list_item: gtk::ListItem = gtk::glib::Object::builder().build();
+        let (_, mut widgets) = TranscriptItemData::setup(&list_item);
+        let mut root = gtk::Box::new(gtk::Orientation::Vertical, 0);
+
+        message.bind(&mut widgets, &mut root);
+        message_reasoning_button(&widgets.message.root).emit_clicked();
+
+        assert!(matches!(
+            gtk::glib::MainContext::default()
+                .block_on(receiver.recv())
+                .expect("reasoning inspect message"),
+            SessionDetailMsg::InspectReasoning(11)
+        ));
     }
 
     #[gtk::test]

--- a/src/ui/typed_transcript_row.rs
+++ b/src/ui/typed_transcript_row.rs
@@ -6,15 +6,18 @@ use gtk::prelude::*;
 use relm4::binding::Binding;
 use relm4::{gtk, typed_view::list::RelmListItem};
 
-use crate::models::Role;
+use crate::models::{Role, tool_name_icon};
 use crate::ui::format::{format_duration_ms, tool_status_css_class, tool_status_label};
 use crate::ui::highlight;
 use crate::ui::session_detail::SessionDetailMsg;
 use crate::ui::transcript_item_data::{TranscriptItemData, TranscriptItemKind};
 use crate::ui::transcript_row::{
-    TranscriptRowBuildKind, format_tool_burst_match_badge_accessible_label, model_label_text,
-    populate_tool_burst_children, render_content,
+    TOOL_ICONS, TranscriptRowBuildKind, format_tool_burst_match_badge_accessible_label,
+    model_label_text, populate_tool_burst_children, render_content,
 };
+
+const TOOL_BURST_ARROW_COLLAPSED: &str = "pan-end-symbolic";
+const TOOL_BURST_ARROW_EXPANDED: &str = "pan-down-symbolic";
 
 const MESSAGE_PAGE_NAME: &str = "message";
 const TOOL_CALL_PAGE_NAME: &str = "tool-call";
@@ -51,6 +54,7 @@ pub struct ToolCallPageWidgets {
 pub struct ToolBurstPageWidgets {
     root: gtk::Box,
     header_button: gtk::Button,
+    arrow_icon: gtk::Image,
     summary_label: gtk::Label,
     meta_box: gtk::Box,
     revealer: gtk::Revealer,
@@ -273,7 +277,11 @@ impl TranscriptItemData {
         rebuild_tool_burst_meta_box(&widgets.meta_box, burst);
         clear_box_children(&widgets.children);
         widgets.children_built_for.set(None);
-        set_tool_burst_expanded_state(&widgets.header_button, self.expanded.get());
+        set_tool_burst_expanded_state(
+            &widgets.header_button,
+            &widgets.arrow_icon,
+            self.expanded.get(),
+        );
 
         let notify_id = {
             let children = widgets.children.clone();
@@ -283,9 +291,10 @@ impl TranscriptItemData {
             let burst = burst_with_highlight_query(burst, self.highlight_query.as_deref());
             let item_index = self.item_index;
             let header_button = widgets.header_button.clone();
+            let arrow_icon = widgets.arrow_icon.clone();
             widgets.revealer.connect_reveal_child_notify(move |_| {
                 let expanded = revealer.reveals_child();
-                set_tool_burst_expanded_state(&header_button, expanded);
+                set_tool_burst_expanded_state(&header_button, &arrow_icon, expanded);
                 if expanded {
                     build_tool_burst_children_if_needed(
                         &children,
@@ -379,7 +388,11 @@ impl TranscriptItemData {
         }
         clear_box_children(&widgets.children);
         widgets.children_built_for.set(None);
-        set_tool_burst_expanded_state(&widgets.header_button, widgets.revealer.reveals_child());
+        set_tool_burst_expanded_state(
+            &widgets.header_button,
+            &widgets.arrow_icon,
+            widgets.revealer.reveals_child(),
+        );
     }
 
     pub(crate) fn unbind_subagent_page(&self, widgets: &mut SubagentPageWidgets) {
@@ -502,9 +515,16 @@ fn build_tool_burst_page() -> ToolBurstPageWidgets {
 
     let header_button = gtk::Button::new();
     header_button.add_css_class("flat");
+    header_button.add_css_class("tool-call-group-header-button");
     header_button.set_halign(gtk::Align::Fill);
 
     let header_row = gtk::Box::new(gtk::Orientation::Horizontal, 8);
+
+    let arrow_icon = gtk::Image::from_icon_name(TOOL_BURST_ARROW_COLLAPSED);
+    arrow_icon.set_valign(gtk::Align::Start);
+    arrow_icon.add_css_class("tool-call-group-arrow");
+    header_row.append(&arrow_icon);
+
     let summary_label = gtk::Label::new(None);
     summary_label.set_halign(gtk::Align::Start);
     summary_label.set_hexpand(true);
@@ -525,6 +545,7 @@ fn build_tool_burst_page() -> ToolBurstPageWidgets {
     ToolBurstPageWidgets {
         root,
         header_button,
+        arrow_icon,
         summary_label,
         meta_box,
         revealer,
@@ -561,6 +582,12 @@ fn build_tool_call_page_content(
     root.add_css_class("tool-call-row");
 
     let row = gtk::Box::new(gtk::Orientation::Horizontal, 8);
+
+    let icon = gtk::Image::new();
+    icon.set_icon_name(Some(tool_name_icon(&init.tool_name, &TOOL_ICONS)));
+    icon.set_pixel_size(16);
+    row.append(&icon);
+
     let name_label = gtk::Label::new(None);
     name_label.add_css_class("monospace");
     name_label.set_halign(gtk::Align::Start);
@@ -661,6 +688,11 @@ fn build_subagent_page_content(
     let root = gtk::Box::new(gtk::Orientation::Horizontal, 8);
     root.add_css_class("subagent-row");
 
+    let icon = gtk::Image::new();
+    icon.set_icon_name(Some(TOOL_ICONS.agent));
+    icon.set_pixel_size(16);
+    root.append(&icon);
+
     let title = gtk::Label::new(Some(&init.title));
     title.set_halign(gtk::Align::Start);
     title.set_hexpand(false);
@@ -754,8 +786,13 @@ fn rebuild_tool_burst_meta_box(
     }
 }
 
-fn set_tool_burst_expanded_state(button: &gtk::Button, expanded: bool) {
+fn set_tool_burst_expanded_state(button: &gtk::Button, arrow_icon: &gtk::Image, expanded: bool) {
     button.update_state(&[gtk::accessible::State::Expanded(Some(expanded))]);
+    arrow_icon.set_icon_name(Some(if expanded {
+        TOOL_BURST_ARROW_EXPANDED
+    } else {
+        TOOL_BURST_ARROW_COLLAPSED
+    }));
 }
 
 fn build_tool_burst_children_if_needed(
@@ -1194,7 +1231,7 @@ mod tests {
 
         tool_call.bind(&mut widgets, &mut root);
         let _ = gtk::glib::MainContext::default().block_on(receiver.recv());
-        let name_label = widgets
+        let row = widgets
             .tool_call
             .root
             .first_child()
@@ -1204,9 +1241,9 @@ mod tests {
             .first_child()
             .expect("tool call row")
             .downcast::<gtk::Box>()
-            .expect("tool call row box")
-            .first_child()
-            .expect("tool name label")
+            .expect("tool call row box");
+        let name_label = collect_box_children(&row)[1]
+            .clone()
             .downcast::<gtk::Label>()
             .expect("tool name label");
 
@@ -1258,7 +1295,12 @@ mod tests {
             .expect("tool call row box");
         let children = collect_box_children(&row);
 
-        let name_label = children[0]
+        assert!(
+            children[0].is::<gtk::Image>(),
+            "tool call row must lead with a category icon"
+        );
+
+        let name_label = children[1]
             .clone()
             .downcast::<gtk::Label>()
             .expect("tool name label");
@@ -1312,7 +1354,12 @@ mod tests {
             .expect("subagent row box");
         let children = collect_box_children(&row);
 
-        let title_label = children[0]
+        assert!(
+            children[0].is::<gtk::Image>(),
+            "subagent row must lead with the agent icon"
+        );
+
+        let title_label = children[1]
             .clone()
             .downcast::<gtk::Label>()
             .expect("subagent title label");
@@ -1326,6 +1373,28 @@ mod tests {
             spacer.is::<gtk::Box>() && spacer.hexpands(),
             "a hexpanding spacer must sit just before the trailing inspect button"
         );
+    }
+
+    #[gtk::test]
+    fn tool_burst_header_shows_and_toggles_expand_chevron() {
+        let (sender, _receiver) = relm4::channel::<SessionDetailMsg>();
+        let mut burst = TranscriptItemData::from_init(
+            TranscriptItemInit::ToolBurst(tool_burst_init(false)),
+            sender,
+        );
+
+        let list_item: gtk::ListItem = gtk::glib::Object::builder().build();
+        let (_, mut widgets) = TranscriptItemData::setup(&list_item);
+        let mut root = gtk::Box::new(gtk::Orientation::Vertical, 0);
+
+        burst.bind(&mut widgets, &mut root);
+
+        let arrow = &widgets.tool_burst.arrow_icon;
+        assert!(arrow.has_css_class("tool-call-group-arrow"));
+        assert_eq!(arrow.icon_name().as_deref(), Some("pan-end-symbolic"));
+
+        tool_burst_header_button(&widgets.tool_burst.root).emit_clicked();
+        assert_eq!(arrow.icon_name().as_deref(), Some("pan-down-symbolic"));
     }
 
     #[gtk::test]

--- a/src/ui/typed_transcript_row.rs
+++ b/src/ui/typed_transcript_row.rs
@@ -12,7 +12,8 @@ use crate::ui::highlight;
 use crate::ui::session_detail::SessionDetailMsg;
 use crate::ui::transcript_item_data::{TranscriptItemData, TranscriptItemKind};
 use crate::ui::transcript_row::{
-    TOOL_ICONS, TranscriptRowBuildKind, format_tool_burst_match_badge_accessible_label,
+    TOOL_ICONS, TranscriptRowBuildKind, format_reasoning_burst_label,
+    format_tool_burst_accessible_label, format_tool_burst_match_badge_accessible_label,
     model_label_text, populate_tool_burst_children, render_content,
 };
 
@@ -55,8 +56,7 @@ pub struct ToolBurstPageWidgets {
     root: gtk::Box,
     header_button: gtk::Button,
     arrow_icon: gtk::Image,
-    summary_label: gtk::Label,
-    meta_box: gtk::Box,
+    header_flow: gtk::FlowBox,
     revealer: gtk::Revealer,
     children: gtk::Box,
     reveal_binding: Option<gtk::glib::Binding>,
@@ -270,11 +270,16 @@ impl TranscriptItemData {
             return;
         };
 
-        widgets.summary_label.set_label(&format_tool_burst_summary(
-            &burst.category_counts,
-            burst.error_count,
-        ));
-        rebuild_tool_burst_meta_box(&widgets.meta_box, burst);
+        rebuild_tool_burst_header(&widgets.header_flow, burst);
+        widgets
+            .header_button
+            .update_property(&[gtk::accessible::Property::Label(
+                &format_tool_burst_accessible_label(
+                    &burst.category_counts,
+                    burst.tool_calls.len(),
+                    burst.error_count,
+                ),
+            )]);
         clear_box_children(&widgets.children);
         widgets.children_built_for.set(None);
         set_tool_burst_expanded_state(
@@ -386,6 +391,7 @@ impl TranscriptItemData {
         if let Some(binding) = widgets.reveal_binding.take() {
             binding.unbind();
         }
+        clear_flow_box_children(&widgets.header_flow);
         clear_box_children(&widgets.children);
         widgets.children_built_for.set(None);
         set_tool_burst_expanded_state(
@@ -525,14 +531,15 @@ fn build_tool_burst_page() -> ToolBurstPageWidgets {
     arrow_icon.add_css_class("tool-call-group-arrow");
     header_row.append(&arrow_icon);
 
-    let summary_label = gtk::Label::new(None);
-    summary_label.set_halign(gtk::Align::Start);
-    summary_label.set_hexpand(true);
-    summary_label.set_xalign(0.0);
-    header_row.append(&summary_label);
-
-    let meta_box = gtk::Box::new(gtk::Orientation::Horizontal, 4);
-    header_row.append(&meta_box);
+    let header_flow = gtk::FlowBox::new();
+    header_flow.set_selection_mode(gtk::SelectionMode::None);
+    header_flow.set_row_spacing(4);
+    header_flow.set_column_spacing(8);
+    header_flow.set_min_children_per_line(1);
+    header_flow.set_max_children_per_line(u32::MAX);
+    header_flow.set_hexpand(true);
+    header_flow.add_css_class("tool-call-group-header");
+    header_row.append(&header_flow);
     header_button.set_child(Some(&header_row));
     root.append(&header_button);
 
@@ -546,8 +553,7 @@ fn build_tool_burst_page() -> ToolBurstPageWidgets {
         root,
         header_button,
         arrow_icon,
-        summary_label,
-        meta_box,
+        header_flow,
         revealer,
         children,
         reveal_binding: None,
@@ -733,56 +739,80 @@ fn build_subagent_page_content(
     }
 }
 
-fn format_tool_burst_summary(category_counts: &[(String, usize)], error_count: usize) -> String {
-    let mut parts = vec![format!(
-        "{} tool calls",
-        category_counts
-            .iter()
-            .map(|(_, count)| count)
-            .sum::<usize>()
-    )];
-
-    if !category_counts.is_empty() {
-        parts.push(
-            category_counts
-                .iter()
-                .map(|(name, count)| format!("{count} {name}"))
-                .collect::<Vec<_>>()
-                .join(", "),
-        );
-    }
-
-    if error_count > 0 {
-        parts.push(format!(
-            "{error_count} {}",
-            if error_count == 1 { "error" } else { "errors" }
-        ));
-    }
-
-    parts.join(" - ")
-}
-
-fn rebuild_tool_burst_meta_box(
-    meta_box: &gtk::Box,
+fn rebuild_tool_burst_header(
+    flow: &gtk::FlowBox,
     burst: &crate::ui::transcript_row::ToolBurstItemInit,
 ) {
-    clear_box_children(meta_box);
+    clear_flow_box_children(flow);
+
+    for (name, count) in &burst.category_counts {
+        let pill_box = gtk::Box::new(gtk::Orientation::Horizontal, 4);
+        pill_box.add_css_class("pill");
+        pill_box.add_css_class("tool-call-group-pill");
+
+        let pill_icon = gtk::Image::new();
+        pill_icon.set_icon_name(Some(tool_name_icon(name, &TOOL_ICONS)));
+        pill_icon.set_pixel_size(12);
+        pill_box.append(&pill_icon);
+
+        let pill_label = gtk::Label::new(Some(&format!("{count} {name}")));
+        pill_box.append(&pill_label);
+
+        flow.insert(&pill_box, -1);
+    }
 
     if let Some(ms) = burst.total_duration_ms {
         let duration = gtk::Label::new(Some(&format_duration_ms(ms)));
         duration.add_css_class("caption");
         duration.add_css_class("dim-label");
-        meta_box.append(&duration);
+        flow.insert(&duration, -1);
     }
 
-    if burst.match_count > 0 {
-        let badge = gtk::Label::new(Some(&burst.match_count.to_string()));
+    if let Some(reasoning_label) = format_reasoning_burst_label(
+        burst.visible_reasoning_child_count,
+        burst.encrypted_only_child_count,
+    ) {
+        let badge = gtk::Label::new(Some(&reasoning_label));
+        badge.add_css_class("pill");
+        badge.add_css_class("tool-call-group-pill");
+        if burst.visible_reasoning_child_count > 0 {
+            badge.add_css_class("reasoning-pill");
+        } else {
+            badge.add_css_class("reasoning-pill-encrypted");
+        }
+        flow.insert(&badge, -1);
+    }
+
+    let total = gtk::Label::new(Some(&format!("{} tool calls", burst.tool_calls.len())));
+    total.add_css_class("caption");
+    total.add_css_class("dim-label");
+    flow.insert(&total, -1);
+
+    if burst.error_count > 0 {
+        let error_label = gtk::Label::new(Some(&format!(
+            "{} {}",
+            burst.error_count,
+            if burst.error_count == 1 {
+                "error"
+            } else {
+                "errors"
+            }
+        )));
+        error_label.add_css_class("caption");
+        error_label.add_css_class("status-error");
+        flow.insert(&error_label, -1);
+    }
+
+    let burst_match_count: usize = burst.child_match_counts.iter().sum();
+    if burst_match_count > 0 {
+        let badge = gtk::Label::new(Some(&format!("{burst_match_count} matches")));
         badge.add_css_class("pill");
         badge.add_css_class("accent");
+        badge.add_css_class("tool-call-group-pill");
         badge.update_property(&[gtk::accessible::Property::Label(
-            &format_tool_burst_match_badge_accessible_label(burst.match_count),
+            &format_tool_burst_match_badge_accessible_label(burst_match_count),
         )]);
-        meta_box.append(&badge);
+        flow.insert(&badge, -1);
     }
 }
 
@@ -820,6 +850,12 @@ fn disconnect_handlers(handlers: &mut Vec<(gtk::glib::Object, gtk::glib::SignalH
 fn clear_box_children(container: &gtk::Box) {
     while let Some(child) = container.first_child() {
         container.remove(&child);
+    }
+}
+
+fn clear_flow_box_children(flow: &gtk::FlowBox) {
+    while let Some(child) = flow.first_child() {
+        flow.remove(&child);
     }
 }
 
@@ -1395,6 +1431,44 @@ mod tests {
 
         tool_burst_header_button(&widgets.tool_burst.root).emit_clicked();
         assert_eq!(arrow.icon_name().as_deref(), Some("pan-down-symbolic"));
+    }
+
+    #[gtk::test]
+    fn tool_burst_header_renders_category_pill_with_icon() {
+        let (sender, _receiver) = relm4::channel::<SessionDetailMsg>();
+        let mut burst = TranscriptItemData::from_init(
+            TranscriptItemInit::ToolBurst(tool_burst_init(false)),
+            sender,
+        );
+
+        let list_item: gtk::ListItem = gtk::glib::Object::builder().build();
+        let (_, mut widgets) = TranscriptItemData::setup(&list_item);
+        let mut root = gtk::Box::new(gtk::Orientation::Vertical, 0);
+
+        burst.bind(&mut widgets, &mut root);
+
+        let pill_box = widgets
+            .tool_burst
+            .header_flow
+            .first_child()
+            .expect("category pill flowbox child")
+            .downcast::<gtk::FlowBoxChild>()
+            .expect("flowbox child")
+            .child()
+            .expect("pill box")
+            .downcast::<gtk::Box>()
+            .expect("pill box");
+        assert!(pill_box.has_css_class("tool-call-group-pill"));
+
+        let pill_icon = pill_box
+            .first_child()
+            .expect("pill icon")
+            .downcast::<gtk::Image>()
+            .expect("pill icon");
+        assert!(
+            pill_icon.icon_name().is_some(),
+            "category pill must carry a tool icon"
+        );
     }
 
     #[gtk::test]

--- a/src/ui/typed_transcript_row.rs
+++ b/src/ui/typed_transcript_row.rs
@@ -140,19 +140,16 @@ impl From<&TranscriptItemKind> for TranscriptRowBuildKind {
 
 fn build_message_page() -> MessagePageWidgets {
     let root = gtk::Box::new(gtk::Orientation::Vertical, 0);
-    root.set_visible(false);
     MessagePageWidgets { root }
 }
 
 fn build_tool_call_page() -> ToolCallPageWidgets {
     let root = gtk::Box::new(gtk::Orientation::Vertical, 0);
-    root.set_visible(false);
     ToolCallPageWidgets { root }
 }
 
 fn build_tool_burst_page() -> ToolBurstPageWidgets {
     let root = gtk::Box::new(gtk::Orientation::Vertical, 0);
-    root.set_visible(false);
     let children = gtk::Box::new(gtk::Orientation::Vertical, 0);
     root.append(&children);
     ToolBurstPageWidgets { root, children }
@@ -160,7 +157,6 @@ fn build_tool_burst_page() -> ToolBurstPageWidgets {
 
 fn build_subagent_page() -> SubagentPageWidgets {
     let root = gtk::Box::new(gtk::Orientation::Vertical, 0);
-    root.set_visible(false);
     SubagentPageWidgets { root }
 }
 
@@ -181,6 +177,7 @@ mod tests {
 
     use chrono::Utc;
     use relm4::gtk;
+    use relm4::gtk::prelude::*;
     use relm4::typed_view::list::RelmListItem;
 
     use crate::models::{MessagePreview, ReasoningPreview, Role, ToolCallStatus};
@@ -324,5 +321,30 @@ mod tests {
         let mut root = gtk::Box::new(gtk::Orientation::Vertical, 0);
         subagent.bind(&mut subagent_widgets, &mut root);
         subagent.unbind(&mut subagent_widgets, &mut root);
+    }
+
+    #[gtk::test]
+    fn bind_shows_selected_stack_page() {
+        let (sender, _receiver) = relm4::channel::<SessionDetailMsg>();
+        let mut message =
+            TranscriptItemData::from_init(TranscriptItemInit::Message(message_init()), sender);
+
+        let list_item: gtk::ListItem = gtk::glib::Object::builder().build();
+        let (_, mut widgets) = TranscriptItemData::setup(&list_item);
+        let mut root = gtk::Box::new(gtk::Orientation::Vertical, 0);
+
+        message.bind(&mut widgets, &mut root);
+
+        assert_eq!(
+            widgets.stack.visible_child_name().as_deref(),
+            Some("message")
+        );
+        assert!(
+            widgets
+                .stack
+                .visible_child()
+                .expect("visible child")
+                .is_visible()
+        );
     }
 }

--- a/src/ui/typed_transcript_row.rs
+++ b/src/ui/typed_transcript_row.rs
@@ -1,8 +1,18 @@
+use std::cell::Cell;
+use std::rc::Rc;
+
 use gtk::prelude::*;
+use relm4::binding::Binding;
 use relm4::{gtk, typed_view::list::RelmListItem};
 
+use crate::models::Role;
+use crate::ui::format::{format_duration_ms, tool_status_css_class, tool_status_label};
+use crate::ui::session_detail::SessionDetailMsg;
 use crate::ui::transcript_item_data::{TranscriptItemData, TranscriptItemKind};
-use crate::ui::transcript_row::TranscriptRowBuildKind;
+use crate::ui::transcript_row::{
+    TranscriptRowBuildKind, format_tool_burst_match_badge_accessible_label, model_label_text,
+    populate_tool_burst_children, render_content,
+};
 
 const MESSAGE_PAGE_NAME: &str = "message";
 const TOOL_CALL_PAGE_NAME: &str = "tool-call";
@@ -19,19 +29,37 @@ pub struct TranscriptRowWidgets {
 
 pub struct MessagePageWidgets {
     root: gtk::Box,
+    role_label: gtk::Label,
+    model_sep: gtk::Label,
+    model_label: gtk::Label,
+    ts_sep: gtk::Label,
+    ts_label: gtk::Label,
+    reasoning_box: gtk::Box,
+    content: gtk::Box,
+    expand_button: gtk::Button,
+    connected_handlers: Vec<(gtk::glib::Object, gtk::glib::SignalHandlerId)>,
 }
 
 pub struct ToolCallPageWidgets {
     root: gtk::Box,
+    connected_handlers: Vec<(gtk::glib::Object, gtk::glib::SignalHandlerId)>,
 }
 
 pub struct ToolBurstPageWidgets {
     root: gtk::Box,
+    header_button: gtk::Button,
+    summary_label: gtk::Label,
+    meta_box: gtk::Box,
+    revealer: gtk::Revealer,
     children: gtk::Box,
+    reveal_binding: Option<gtk::glib::Binding>,
+    children_built_for: Rc<Cell<Option<usize>>>,
+    connected_handlers: Vec<(gtk::glib::Object, gtk::glib::SignalHandlerId)>,
 }
 
 pub struct SubagentPageWidgets {
     root: gtk::Box,
+    connected_handlers: Vec<(gtk::glib::Object, gtk::glib::SignalHandlerId)>,
 }
 
 impl RelmListItem for TranscriptItemData {
@@ -99,21 +127,236 @@ impl RelmListItem for TranscriptItemData {
 }
 
 impl TranscriptItemData {
-    pub(crate) fn bind_message_page(&self, _widgets: &mut MessagePageWidgets) {}
+    pub(crate) fn bind_message_page(&self, widgets: &mut MessagePageWidgets) {
+        let TranscriptItemKind::Message(message) = &self.kind else {
+            return;
+        };
 
-    pub(crate) fn bind_tool_call_page(&self, _widgets: &mut ToolCallPageWidgets) {}
+        widgets
+            .role_label
+            .set_label(if message.preview.role == Role::Assistant {
+                "Assistant"
+            } else {
+                "You"
+            });
 
-    pub(crate) fn bind_tool_burst_page(&self, _widgets: &mut ToolBurstPageWidgets) {}
+        if let Some(model) =
+            model_label_text(message.preview.role, message.preview.model.as_deref())
+        {
+            widgets.model_sep.set_visible(true);
+            widgets.model_label.set_visible(true);
+            widgets.model_label.set_label(&model);
+        } else {
+            widgets.model_sep.set_visible(false);
+            widgets.model_label.set_visible(false);
+            widgets.model_label.set_label("");
+        }
 
-    pub(crate) fn bind_subagent_page(&self, _widgets: &mut SubagentPageWidgets) {}
+        widgets
+            .ts_label
+            .set_label(&message.preview.timestamp.format("%H:%M:%S").to_string());
+        clear_box_children(&widgets.reasoning_box);
+        if message.preview.reasoning_preview.has_visible_reasoning {
+            let button = gtk::Button::with_label("Thinking");
+            button.add_css_class("flat");
+            button.add_css_class("pill");
+            button.add_css_class("reasoning-pill");
+            widgets.reasoning_box.append(&button);
+        } else if message.preview.reasoning_preview.encrypted_only {
+            let label = gtk::Label::new(Some("Thinking (encrypted)"));
+            label.add_css_class("pill");
+            label.add_css_class("reasoning-pill-encrypted");
+            widgets.reasoning_box.append(&label);
+        }
 
-    pub(crate) fn unbind_message_page(&self, _widgets: &mut MessagePageWidgets) {}
+        render_content(
+            &widgets.content,
+            &message.preview.content_preview,
+            message.preview.role,
+            message.highlight_query.as_deref(),
+        );
 
-    pub(crate) fn unbind_tool_call_page(&self, _widgets: &mut ToolCallPageWidgets) {}
+        let can_expand = message.preview.is_truncated() && message.preview.role != Role::ToolResult;
+        widgets.expand_button.set_visible(can_expand);
+        widgets.expand_button.set_label(if self.expanded.get() {
+            "Collapse"
+        } else {
+            "Show full message"
+        });
 
-    pub(crate) fn unbind_tool_burst_page(&self, _widgets: &mut ToolBurstPageWidgets) {}
+        if can_expand {
+            let expanded = self.expanded.clone();
+            let button = widgets.expand_button.clone();
+            let id = widgets.expand_button.connect_clicked(move |_| {
+                let next = !expanded.get();
+                expanded.set(next);
+                button.set_label(if next {
+                    "Collapse"
+                } else {
+                    "Show full message"
+                });
+            });
+            widgets
+                .connected_handlers
+                .push((widgets.expand_button.clone().upcast(), id));
+        }
+    }
 
-    pub(crate) fn unbind_subagent_page(&self, _widgets: &mut SubagentPageWidgets) {}
+    pub(crate) fn bind_tool_call_page(&self, widgets: &mut ToolCallPageWidgets) {
+        let TranscriptItemKind::ToolCall(tool_call) = &self.kind else {
+            return;
+        };
+
+        clear_box_children(&widgets.root);
+        let refs = build_tool_call_page_content(tool_call);
+
+        if let Some(reasoning_button) = refs.reasoning_button {
+            let sender = self.sender.clone();
+            let transcript_item_index = tool_call.transcript_item_index;
+            let id = reasoning_button.connect_clicked(move |_| {
+                sender.emit(SessionDetailMsg::InspectReasoning(transcript_item_index));
+            });
+            widgets
+                .connected_handlers
+                .push((reasoning_button.upcast(), id));
+        }
+
+        let sender = self.sender.clone();
+        let tool_call_id = tool_call.tool_call_id.clone();
+        let id = refs.inspect_button.connect_clicked(move |_| {
+            sender.emit(SessionDetailMsg::InspectToolCall(tool_call_id.clone()));
+        });
+        widgets
+            .connected_handlers
+            .push((refs.inspect_button.clone().upcast(), id));
+
+        widgets.root.append(&refs.root);
+    }
+
+    pub(crate) fn bind_tool_burst_page(&self, widgets: &mut ToolBurstPageWidgets) {
+        let TranscriptItemKind::ToolBurst(burst) = &self.kind else {
+            return;
+        };
+
+        widgets.summary_label.set_label(&format_tool_burst_summary(
+            &burst.category_counts,
+            burst.error_count,
+        ));
+        rebuild_tool_burst_meta_box(&widgets.meta_box, burst);
+        clear_box_children(&widgets.children);
+        widgets.children_built_for.set(None);
+        set_tool_burst_expanded_state(&widgets.header_button, self.expanded.get());
+
+        let notify_id = {
+            let children = widgets.children.clone();
+            let revealer = widgets.revealer.clone();
+            let children_built_for = widgets.children_built_for.clone();
+            let sender = self.sender.clone();
+            let burst = burst.clone();
+            let item_index = self.item_index;
+            let header_button = widgets.header_button.clone();
+            widgets.revealer.connect_reveal_child_notify(move |_| {
+                let expanded = revealer.reveals_child();
+                set_tool_burst_expanded_state(&header_button, expanded);
+                if expanded {
+                    build_tool_burst_children_if_needed(
+                        &children,
+                        &children_built_for,
+                        &burst,
+                        &sender,
+                        item_index,
+                    );
+                }
+            })
+        };
+        widgets
+            .connected_handlers
+            .push((widgets.revealer.clone().upcast(), notify_id));
+
+        if self.expanded.get() {
+            build_tool_burst_children_if_needed(
+                &widgets.children,
+                &widgets.children_built_for,
+                burst,
+                &self.sender,
+                self.item_index,
+            );
+        }
+
+        widgets.reveal_binding = Some(
+            self.expanded
+                .bind_property("value", &widgets.revealer, "reveal-child")
+                .sync_create()
+                .build(),
+        );
+
+        let expanded = self.expanded.clone();
+        let id = widgets.header_button.connect_clicked(move |_| {
+            expanded.set(!expanded.get());
+        });
+        widgets
+            .connected_handlers
+            .push((widgets.header_button.clone().upcast(), id));
+    }
+
+    pub(crate) fn bind_subagent_page(&self, widgets: &mut SubagentPageWidgets) {
+        let TranscriptItemKind::Subagent(subagent) = &self.kind else {
+            return;
+        };
+
+        clear_box_children(&widgets.root);
+        let refs = build_subagent_page_content(subagent);
+
+        if let Some(reasoning_button) = refs.reasoning_button {
+            let sender = self.sender.clone();
+            let transcript_item_index = subagent.transcript_item_index;
+            let id = reasoning_button.connect_clicked(move |_| {
+                sender.emit(SessionDetailMsg::InspectReasoning(transcript_item_index));
+            });
+            widgets
+                .connected_handlers
+                .push((reasoning_button.upcast(), id));
+        }
+
+        let sender = self.sender.clone();
+        let subagent_id = subagent.subagent_id.clone();
+        let id = refs.inspect_button.connect_clicked(move |_| {
+            sender.emit(SessionDetailMsg::InspectSubagent(subagent_id.clone()));
+        });
+        widgets
+            .connected_handlers
+            .push((refs.inspect_button.clone().upcast(), id));
+
+        widgets.root.append(&refs.root);
+    }
+
+    pub(crate) fn unbind_message_page(&self, widgets: &mut MessagePageWidgets) {
+        disconnect_handlers(&mut widgets.connected_handlers);
+        clear_box_children(&widgets.reasoning_box);
+        clear_box_children(&widgets.content);
+        widgets.expand_button.set_visible(false);
+        widgets.expand_button.set_label("Show full message");
+    }
+
+    pub(crate) fn unbind_tool_call_page(&self, widgets: &mut ToolCallPageWidgets) {
+        disconnect_handlers(&mut widgets.connected_handlers);
+        clear_box_children(&widgets.root);
+    }
+
+    pub(crate) fn unbind_tool_burst_page(&self, widgets: &mut ToolBurstPageWidgets) {
+        disconnect_handlers(&mut widgets.connected_handlers);
+        if let Some(binding) = widgets.reveal_binding.take() {
+            binding.unbind();
+        }
+        clear_box_children(&widgets.children);
+        widgets.children_built_for.set(None);
+        set_tool_burst_expanded_state(&widgets.header_button, widgets.revealer.reveals_child());
+    }
+
+    pub(crate) fn unbind_subagent_page(&self, widgets: &mut SubagentPageWidgets) {
+        disconnect_handlers(&mut widgets.connected_handlers);
+        clear_box_children(&widgets.root);
+    }
 }
 
 impl TranscriptRowBuildKind {
@@ -140,28 +383,322 @@ impl From<&TranscriptItemKind> for TranscriptRowBuildKind {
 
 fn build_message_page() -> MessagePageWidgets {
     let root = gtk::Box::new(gtk::Orientation::Vertical, 0);
-    MessagePageWidgets { root }
+    root.set_spacing(4);
+
+    let header = gtk::Box::new(gtk::Orientation::Horizontal, 4);
+
+    let role_label = gtk::Label::new(None);
+    role_label.set_halign(gtk::Align::Start);
+    header.append(&role_label);
+
+    let model_sep = gtk::Label::new(Some("·"));
+    model_sep.add_css_class("caption");
+    model_sep.add_css_class("dim-label");
+    model_sep.set_visible(false);
+    header.append(&model_sep);
+
+    let model_label = gtk::Label::new(None);
+    model_label.add_css_class("caption");
+    model_label.add_css_class("dim-label");
+    model_label.add_css_class("monospace");
+    model_label.set_visible(false);
+    header.append(&model_label);
+
+    let ts_sep = gtk::Label::new(Some("·"));
+    ts_sep.add_css_class("caption");
+    ts_sep.add_css_class("dim-label");
+    header.append(&ts_sep);
+
+    let ts_label = gtk::Label::new(None);
+    ts_label.add_css_class("caption");
+    ts_label.add_css_class("dim-label");
+    header.append(&ts_label);
+
+    let reasoning_box = gtk::Box::new(gtk::Orientation::Horizontal, 4);
+    header.append(&reasoning_box);
+    root.append(&header);
+
+    let content = gtk::Box::new(gtk::Orientation::Vertical, 4);
+    root.append(&content);
+
+    let expand_button = gtk::Button::new();
+    expand_button.add_css_class("flat");
+    expand_button.add_css_class("caption");
+    expand_button.add_css_class("expand-toggle");
+    expand_button.set_halign(gtk::Align::Start);
+    expand_button.set_visible(false);
+    root.append(&expand_button);
+
+    MessagePageWidgets {
+        root,
+        role_label,
+        model_sep,
+        model_label,
+        ts_sep,
+        ts_label,
+        reasoning_box,
+        content,
+        expand_button,
+        connected_handlers: Vec::new(),
+    }
 }
 
 fn build_tool_call_page() -> ToolCallPageWidgets {
     let root = gtk::Box::new(gtk::Orientation::Vertical, 0);
-    ToolCallPageWidgets { root }
+    ToolCallPageWidgets {
+        root,
+        connected_handlers: Vec::new(),
+    }
 }
 
 fn build_tool_burst_page() -> ToolBurstPageWidgets {
     let root = gtk::Box::new(gtk::Orientation::Vertical, 0);
+
+    let header_button = gtk::Button::new();
+    header_button.add_css_class("flat");
+    header_button.set_halign(gtk::Align::Fill);
+
+    let header_row = gtk::Box::new(gtk::Orientation::Horizontal, 8);
+    let summary_label = gtk::Label::new(None);
+    summary_label.set_halign(gtk::Align::Start);
+    summary_label.set_hexpand(true);
+    summary_label.set_xalign(0.0);
+    header_row.append(&summary_label);
+
+    let meta_box = gtk::Box::new(gtk::Orientation::Horizontal, 4);
+    header_row.append(&meta_box);
+    header_button.set_child(Some(&header_row));
+    root.append(&header_button);
+
     let children = gtk::Box::new(gtk::Orientation::Vertical, 0);
-    root.append(&children);
-    ToolBurstPageWidgets { root, children }
+    let revealer = gtk::Revealer::new();
+    revealer.set_transition_type(gtk::RevealerTransitionType::SlideDown);
+    revealer.set_child(Some(&children));
+    root.append(&revealer);
+
+    ToolBurstPageWidgets {
+        root,
+        header_button,
+        summary_label,
+        meta_box,
+        revealer,
+        children,
+        reveal_binding: None,
+        children_built_for: Rc::new(Cell::new(None)),
+        connected_handlers: Vec::new(),
+    }
 }
 
 fn build_subagent_page() -> SubagentPageWidgets {
     let root = gtk::Box::new(gtk::Orientation::Vertical, 0);
-    SubagentPageWidgets { root }
+    SubagentPageWidgets {
+        root,
+        connected_handlers: Vec::new(),
+    }
 }
 
 fn cleanup_transcript_row_widgets(widgets: &mut TranscriptRowWidgets) {
     clear_box_children(&widgets.tool_burst.children);
+}
+
+struct ToolCallPageContentRefs {
+    root: gtk::Box,
+    inspect_button: gtk::Button,
+    reasoning_button: Option<gtk::Button>,
+}
+
+fn build_tool_call_page_content(
+    init: &crate::ui::transcript_row::ToolCallItemInit,
+) -> ToolCallPageContentRefs {
+    let root = gtk::Box::new(gtk::Orientation::Vertical, 4);
+    root.add_css_class("tool-call-row");
+
+    let row = gtk::Box::new(gtk::Orientation::Horizontal, 8);
+    let name_label = gtk::Label::new(Some(&init.tool_name));
+    name_label.add_css_class("monospace");
+    name_label.set_halign(gtk::Align::Start);
+    name_label.set_hexpand(true);
+    name_label.set_xalign(0.0);
+    row.append(&name_label);
+
+    let status_label = gtk::Label::new(Some(tool_status_label(init.status)));
+    status_label.add_css_class("caption");
+    status_label.add_css_class(tool_status_css_class(init.status));
+    row.append(&status_label);
+
+    if let Some(ms) = init.duration_ms {
+        let duration = gtk::Label::new(Some(&format_duration_ms(ms)));
+        duration.add_css_class("caption");
+        duration.add_css_class("dim-label");
+        row.append(&duration);
+    }
+
+    let reasoning_button = if init.reasoning_preview.has_visible_reasoning {
+        let button = gtk::Button::with_label("Thinking");
+        button.add_css_class("flat");
+        button.add_css_class("pill");
+        button.add_css_class("reasoning-pill");
+        row.append(&button);
+        Some(button)
+    } else if init.reasoning_preview.encrypted_only {
+        let label = gtk::Label::new(Some("Thinking (encrypted)"));
+        label.add_css_class("pill");
+        label.add_css_class("reasoning-pill-encrypted");
+        row.append(&label);
+        None
+    } else {
+        None
+    };
+
+    let inspect = gtk::Button::new();
+    inspect.set_icon_name("view-reveal-symbolic");
+    inspect.add_css_class("flat");
+    inspect.set_tooltip_text(Some("Inspect tool call"));
+    row.append(&inspect);
+    root.append(&row);
+
+    if let Some(preview) = init.displayed_preview() {
+        let preview_label = gtk::Label::new(Some(preview));
+        preview_label.add_css_class("caption");
+        preview_label.add_css_class("dim-label");
+        preview_label.set_halign(gtk::Align::Start);
+        preview_label.set_xalign(0.0);
+        preview_label.set_wrap(true);
+        root.append(&preview_label);
+    }
+
+    ToolCallPageContentRefs {
+        root,
+        inspect_button: inspect,
+        reasoning_button,
+    }
+}
+
+struct SubagentPageContentRefs {
+    root: gtk::Box,
+    inspect_button: gtk::Button,
+    reasoning_button: Option<gtk::Button>,
+}
+
+fn build_subagent_page_content(
+    init: &crate::ui::transcript_row::SubagentItemInit,
+) -> SubagentPageContentRefs {
+    let root = gtk::Box::new(gtk::Orientation::Horizontal, 8);
+    root.add_css_class("subagent-row");
+
+    let title = gtk::Label::new(Some(&init.title));
+    title.set_halign(gtk::Align::Start);
+    title.set_hexpand(true);
+    title.set_xalign(0.0);
+    root.append(&title);
+
+    let reasoning_button = if init.reasoning_preview.has_visible_reasoning {
+        let button = gtk::Button::with_label("Thinking");
+        button.add_css_class("flat");
+        button.add_css_class("pill");
+        button.add_css_class("reasoning-pill");
+        root.append(&button);
+        Some(button)
+    } else if init.reasoning_preview.encrypted_only {
+        let label = gtk::Label::new(Some("Thinking (encrypted)"));
+        label.add_css_class("pill");
+        label.add_css_class("reasoning-pill-encrypted");
+        root.append(&label);
+        None
+    } else {
+        None
+    };
+
+    let inspect = gtk::Button::new();
+    inspect.set_icon_name("view-reveal-symbolic");
+    inspect.add_css_class("flat");
+    inspect.set_tooltip_text(Some("Inspect subagent"));
+    root.append(&inspect);
+
+    SubagentPageContentRefs {
+        root,
+        inspect_button: inspect,
+        reasoning_button,
+    }
+}
+
+fn format_tool_burst_summary(category_counts: &[(String, usize)], error_count: usize) -> String {
+    let mut parts = vec![format!(
+        "{} tool calls",
+        category_counts
+            .iter()
+            .map(|(_, count)| count)
+            .sum::<usize>()
+    )];
+
+    if !category_counts.is_empty() {
+        parts.push(
+            category_counts
+                .iter()
+                .map(|(name, count)| format!("{count} {name}"))
+                .collect::<Vec<_>>()
+                .join(", "),
+        );
+    }
+
+    if error_count > 0 {
+        parts.push(format!(
+            "{error_count} {}",
+            if error_count == 1 { "error" } else { "errors" }
+        ));
+    }
+
+    parts.join(" - ")
+}
+
+fn rebuild_tool_burst_meta_box(
+    meta_box: &gtk::Box,
+    burst: &crate::ui::transcript_row::ToolBurstItemInit,
+) {
+    clear_box_children(meta_box);
+
+    if let Some(ms) = burst.total_duration_ms {
+        let duration = gtk::Label::new(Some(&format_duration_ms(ms)));
+        duration.add_css_class("caption");
+        duration.add_css_class("dim-label");
+        meta_box.append(&duration);
+    }
+
+    if burst.match_count > 0 {
+        let badge = gtk::Label::new(Some(&burst.match_count.to_string()));
+        badge.add_css_class("pill");
+        badge.add_css_class("accent");
+        badge.update_property(&[gtk::accessible::Property::Label(
+            &format_tool_burst_match_badge_accessible_label(burst.match_count),
+        )]);
+        meta_box.append(&badge);
+    }
+}
+
+fn set_tool_burst_expanded_state(button: &gtk::Button, expanded: bool) {
+    button.update_state(&[gtk::accessible::State::Expanded(Some(expanded))]);
+}
+
+fn build_tool_burst_children_if_needed(
+    children: &gtk::Box,
+    children_built_for: &Rc<Cell<Option<usize>>>,
+    burst: &crate::ui::transcript_row::ToolBurstItemInit,
+    sender: &relm4::Sender<SessionDetailMsg>,
+    item_index: usize,
+) {
+    if children_built_for.get() == Some(item_index) {
+        return;
+    }
+
+    clear_box_children(children);
+    populate_tool_burst_children(children, burst, sender, item_index);
+    children_built_for.set(Some(item_index));
+}
+
+fn disconnect_handlers(handlers: &mut Vec<(gtk::glib::Object, gtk::glib::SignalHandlerId)>) {
+    while let Some((object, id)) = handlers.pop() {
+        object.disconnect(id);
+    }
 }
 
 fn clear_box_children(container: &gtk::Box) {
@@ -176,6 +713,7 @@ mod tests {
     use std::sync::Arc;
 
     use chrono::Utc;
+    use relm4::binding::Binding;
     use relm4::gtk;
     use relm4::gtk::prelude::*;
     use relm4::typed_view::list::RelmListItem;
@@ -232,6 +770,53 @@ mod tests {
             title: "Explore".to_string(),
             reasoning_preview: ReasoningPreview::default(),
         }
+    }
+
+    fn tool_burst_init(default_expanded: bool) -> ToolBurstItemInit {
+        ToolBurstItemInit {
+            item_index: 4,
+            tool_calls: vec![tool_call_init()],
+            category_counts: vec![("Read".to_string(), 1)],
+            error_count: 0,
+            total_duration_ms: Some(15),
+            match_count: 2,
+            child_match_counts: vec![2],
+            visible_reasoning_child_count: 0,
+            encrypted_only_child_count: 0,
+            default_expanded,
+        }
+    }
+
+    fn count_box_children(container: &gtk::Box) -> usize {
+        let mut count = 0;
+        let mut child = container.first_child();
+        while let Some(current) = child {
+            count += 1;
+            child = current.next_sibling();
+        }
+        count
+    }
+
+    fn tool_burst_header_button(root: &gtk::Box) -> gtk::Button {
+        root.first_child()
+            .expect("tool burst header button")
+            .downcast::<gtk::Button>()
+            .expect("tool burst header button")
+    }
+
+    fn tool_burst_revealer(root: &gtk::Box) -> gtk::Revealer {
+        root.last_child()
+            .expect("tool burst revealer")
+            .downcast::<gtk::Revealer>()
+            .expect("tool burst revealer")
+    }
+
+    fn tool_burst_children_box(root: &gtk::Box) -> gtk::Box {
+        tool_burst_revealer(root)
+            .child()
+            .expect("tool burst children")
+            .downcast::<gtk::Box>()
+            .expect("tool burst children box")
     }
 
     #[test]
@@ -346,5 +931,87 @@ mod tests {
                 .expect("visible child")
                 .is_visible()
         );
+    }
+
+    #[gtk::test]
+    fn burst_bind_builds_children_only_when_expanded() {
+        let (sender, _receiver) = relm4::channel::<SessionDetailMsg>();
+        let list_item: gtk::ListItem = gtk::glib::Object::builder().build();
+
+        let mut collapsed = TranscriptItemData::from_init(
+            TranscriptItemInit::ToolBurst(tool_burst_init(false)),
+            sender.clone(),
+        );
+        let (_, mut collapsed_widgets) = TranscriptItemData::setup(&list_item);
+        let mut root = gtk::Box::new(gtk::Orientation::Vertical, 0);
+        collapsed.bind(&mut collapsed_widgets, &mut root);
+
+        let collapsed_root = &collapsed_widgets.tool_burst.root;
+        let collapsed_header = tool_burst_header_button(collapsed_root);
+        let collapsed_revealer = tool_burst_revealer(collapsed_root);
+        let collapsed_children = tool_burst_children_box(collapsed_root);
+
+        assert!(!collapsed.expanded.get());
+        assert!(!collapsed_revealer.reveals_child());
+        assert_eq!(count_box_children(&collapsed_children), 0);
+
+        collapsed_header.emit_clicked();
+
+        assert!(collapsed.expanded.get());
+        assert!(collapsed_revealer.reveals_child());
+        assert_eq!(count_box_children(&collapsed_children), 1);
+
+        let mut expanded = TranscriptItemData::from_init(
+            TranscriptItemInit::ToolBurst(tool_burst_init(true)),
+            sender,
+        );
+        let (_, mut expanded_widgets) = TranscriptItemData::setup(&list_item);
+        let mut root = gtk::Box::new(gtk::Orientation::Vertical, 0);
+        expanded.bind(&mut expanded_widgets, &mut root);
+
+        let expanded_root = &expanded_widgets.tool_burst.root;
+        let expanded_revealer = tool_burst_revealer(expanded_root);
+        let expanded_children = tool_burst_children_box(expanded_root);
+
+        assert!(expanded.expanded.get());
+        assert!(expanded_revealer.reveals_child());
+        assert_eq!(count_box_children(&expanded_children), 1);
+    }
+
+    #[gtk::test]
+    fn unbind_disconnects_handlers_and_reveal_binding() {
+        let (sender, _receiver) = relm4::channel::<SessionDetailMsg>();
+        let mut burst = TranscriptItemData::from_init(
+            TranscriptItemInit::ToolBurst(tool_burst_init(false)),
+            sender,
+        );
+
+        let list_item: gtk::ListItem = gtk::glib::Object::builder().build();
+        let (_, mut widgets) = TranscriptItemData::setup(&list_item);
+        let mut root = gtk::Box::new(gtk::Orientation::Vertical, 0);
+        burst.bind(&mut widgets, &mut root);
+
+        let burst_root = &widgets.tool_burst.root;
+        let header = tool_burst_header_button(burst_root);
+        let revealer = tool_burst_revealer(burst_root);
+        let children = tool_burst_children_box(burst_root);
+
+        header.emit_clicked();
+        assert!(burst.expanded.get());
+        assert!(revealer.reveals_child());
+        assert_eq!(count_box_children(&children), 1);
+
+        burst.unbind(&mut widgets, &mut root);
+
+        assert_eq!(count_box_children(&children), 0);
+
+        let reveal_after_unbind = revealer.reveals_child();
+        burst.expanded.set(false);
+        assert_eq!(revealer.reveals_child(), reveal_after_unbind);
+
+        let expanded_after_unbind = burst.expanded.get();
+        header.emit_clicked();
+        assert_eq!(burst.expanded.get(), expanded_after_unbind);
+        assert_eq!(count_box_children(&children), 0);
     }
 }

--- a/src/ui/typed_transcript_row.rs
+++ b/src/ui/typed_transcript_row.rs
@@ -193,16 +193,10 @@ impl TranscriptItemData {
         });
 
         if can_expand {
-            let expanded = self.expanded.clone();
-            let button = widgets.expand_button.clone();
+            let sender = self.sender.clone();
+            let item_index = self.item_index;
             let id = widgets.expand_button.connect_clicked(move |_| {
-                let next = !expanded.get();
-                expanded.set(next);
-                button.set_label(if next {
-                    "Collapse"
-                } else {
-                    "Show full message"
-                });
+                sender.emit(SessionDetailMsg::ToggleMessageExpand { item_index });
             });
             widgets
                 .connected_handlers
@@ -763,6 +757,12 @@ mod tests {
         init
     }
 
+    fn truncated_message_init() -> MessageItemInit {
+        let mut init = message_init();
+        init.preview.content_len = 64;
+        init
+    }
+
     fn tool_call_init() -> ToolCallItemInit {
         ToolCallItemInit {
             item_index: 2,
@@ -854,6 +854,13 @@ mod tests {
             .expect("message reasoning button")
             .downcast::<gtk::Button>()
             .expect("message reasoning button")
+    }
+
+    fn message_expand_button(root: &gtk::Box) -> gtk::Button {
+        root.last_child()
+            .expect("message expand button")
+            .downcast::<gtk::Button>()
+            .expect("message expand button")
     }
 
     #[test]
@@ -990,6 +997,36 @@ mod tests {
                 .block_on(receiver.recv())
                 .expect("reasoning inspect message"),
             SessionDetailMsg::InspectReasoning(11)
+        ));
+    }
+
+    #[gtk::test]
+    fn message_expand_button_emits_parent_toggle_message() {
+        let (sender, receiver) = relm4::channel::<SessionDetailMsg>();
+        let mut message = TranscriptItemData::from_init(
+            TranscriptItemInit::Message(truncated_message_init()),
+            sender,
+        );
+
+        let list_item: gtk::ListItem = gtk::glib::Object::builder().build();
+        let (_, mut widgets) = TranscriptItemData::setup(&list_item);
+        let mut root = gtk::Box::new(gtk::Orientation::Vertical, 0);
+
+        message.bind(&mut widgets, &mut root);
+        let expand_button = message_expand_button(&widgets.message.root);
+
+        assert!(expand_button.is_visible());
+        assert_eq!(expand_button.label().as_deref(), Some("Show full message"));
+
+        expand_button.emit_clicked();
+
+        assert!(!message.expanded.get());
+        assert_eq!(expand_button.label().as_deref(), Some("Show full message"));
+        assert!(matches!(
+            gtk::glib::MainContext::default()
+                .block_on(receiver.recv())
+                .expect("message expand toggle"),
+            SessionDetailMsg::ToggleMessageExpand { item_index: 1 }
         ));
     }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,1 +1,2 @@
 pub mod terminal;
+pub mod text_match;

--- a/src/utils/text_match.rs
+++ b/src/utils/text_match.rs
@@ -1,0 +1,104 @@
+//! Case-insensitive substring matching shared by the transcript highlighter
+//! and the session-detail search counter.
+//!
+//! Both must agree on what counts as an occurrence so the `X / Y` match
+//! counter stays equal to the number of spans the user sees highlighted.
+
+/// Returns the byte ranges of every non-overlapping, case-insensitive
+/// occurrence of `query` in `text`, in document order.
+///
+/// Matching folds case per Unicode rules (so a single source character may
+/// expand to several folded units, e.g. `İ`), and ranges index back into the
+/// original, unfolded `text`.
+pub fn find_case_insensitive_matches(text: &str, query: &str) -> Vec<(usize, usize)> {
+    let mut folded_units: Vec<(char, usize, usize)> = Vec::new();
+    for (start, ch) in text.char_indices() {
+        let end = start + ch.len_utf8();
+        for lower in ch.to_lowercase() {
+            folded_units.push((lower, start, end));
+        }
+    }
+
+    let query_chars = fold_query_chars(query);
+    find_in_folded_units(&folded_units, &query_chars)
+}
+
+/// Number of non-overlapping, case-insensitive occurrences of `query` in
+/// `text` — the count of spans [`find_case_insensitive_matches`] would mark.
+pub fn count_case_insensitive_matches(text: &str, query: &str) -> usize {
+    find_case_insensitive_matches(text, query).len()
+}
+
+fn fold_query_chars(query: &str) -> Vec<char> {
+    query.chars().flat_map(char::to_lowercase).collect()
+}
+
+fn find_in_folded_units(
+    folded_units: &[(char, usize, usize)],
+    query_chars: &[char],
+) -> Vec<(usize, usize)> {
+    if query_chars.is_empty() || folded_units.is_empty() || query_chars.len() > folded_units.len() {
+        return Vec::new();
+    }
+
+    let mut matches = Vec::new();
+    let mut i = 0usize;
+    while i + query_chars.len() <= folded_units.len() {
+        let is_match = folded_units[i..i + query_chars.len()]
+            .iter()
+            .zip(query_chars.iter())
+            .all(|((ch, _, _), q)| ch == q);
+
+        if is_match {
+            let start = folded_units[i].1;
+            let end = folded_units[i + query_chars.len() - 1].2;
+            matches.push((start, end));
+            i += query_chars.len();
+        } else {
+            i += 1;
+        }
+    }
+
+    matches
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_query_matches_nothing() {
+        assert!(find_case_insensitive_matches("Hello world", "").is_empty());
+        assert_eq!(count_case_insensitive_matches("Hello world", ""), 0);
+    }
+
+    #[test]
+    fn counts_case_insensitive_occurrences() {
+        assert_eq!(
+            count_case_insensitive_matches("Hello World WORLD", "world"),
+            2
+        );
+    }
+
+    #[test]
+    fn counts_adjacent_non_overlapping_occurrences() {
+        assert_eq!(count_case_insensitive_matches("aaa", "a"), 3);
+        assert_eq!(count_case_insensitive_matches("aaaa", "aa"), 2);
+    }
+
+    #[test]
+    fn ranges_index_into_original_text() {
+        let matches = find_case_insensitive_matches("a NEEDLE here", "needle");
+        assert_eq!(matches, vec![(2, 8)]);
+    }
+
+    #[test]
+    fn no_match_returns_empty() {
+        assert_eq!(count_case_insensitive_matches("Hello world", "missing"), 0);
+    }
+
+    #[test]
+    fn handles_unicode_case_folding_expansion() {
+        assert_eq!(count_case_insensitive_matches("İstanbul", "i"), 1);
+    }
+}

--- a/tests/search_sessions.rs
+++ b/tests/search_sessions.rs
@@ -403,6 +403,25 @@ fn find_session_match_positions_returns_ordered_message_matches() {
 }
 
 #[test]
+fn find_session_match_positions_emits_one_position_per_occurrence() {
+    let db = TempDatabase::new();
+    seed_match_session(&db, "session-occ", "claude_code", 100);
+    insert_message_item(&db, "session-occ", 0, 2, "needle once here");
+    insert_message_item(&db, "session-occ", 1, 5, "needle and needle and needle");
+
+    let positions = find_session_match_positions(&db.connection, "session-occ", "needle")
+        .expect("match position query should succeed");
+    let item_indexes: Vec<i64> = positions
+        .iter()
+        .map(|position| position.item_index)
+        .collect();
+
+    // The counter and Next/Previous step per highlighted occurrence: item 2
+    // contains "needle" once, item 5 contains it three times.
+    assert_eq!(item_indexes, vec![2, 5, 5, 5]);
+}
+
+#[test]
 fn find_session_match_positions_filters_by_session() {
     let db = TempDatabase::new();
     seed_match_session(&db, "session-one", "claude_code", 100);
@@ -421,7 +440,9 @@ fn find_session_match_positions_filters_by_session() {
 fn find_session_match_positions_retries_sanitized_invalid_query() {
     let db = TempDatabase::new();
     seed_match_session(&db, "session-sanitize", "claude_code", 100);
-    insert_message_item(&db, "session-sanitize", 0, 3, "alpha survives sanitization");
+    // The raw query `"alpha` is invalid FTS syntax; the sanitized retry (`alpha`)
+    // finds this message, and occurrences are then counted with the raw query.
+    insert_message_item(&db, "session-sanitize", 0, 3, "they typed \"alpha here");
 
     let positions = find_session_match_positions(&db.connection, "session-sanitize", "\"alpha")
         .expect("sanitized query should not surface an FTS syntax error");

--- a/tests/transcript_items_model.rs
+++ b/tests/transcript_items_model.rs
@@ -210,3 +210,24 @@ fn load_transcript_items_includes_reasoning_flags() {
     assert!(items[0].reasoning_preview.has_visible_reasoning);
     assert!(!items[0].reasoning_preview.encrypted_only);
 }
+
+#[test]
+fn load_all_transcript_items_returns_entire_ordered_session() {
+    let db = TempDatabase::new();
+    let sid = "test-full-session-loader";
+    db.insert_session(sid);
+
+    db.insert_message(sid, 0, "user", "first", None);
+    db.insert_message(sid, 1, "assistant", "second", Some("claude-sonnet"));
+    db.insert_message(sid, 2, "user", "third", None);
+    db.insert_transcript_item(sid, 0, "message", Some(0));
+    db.insert_transcript_item(sid, 1, "message", Some(1));
+    db.insert_transcript_item(sid, 2, "message", Some(2));
+
+    let items = sessions_chronicle::database::load_all_transcript_items(&db.path, sid, 2000)
+        .expect("Failed to load all transcript items");
+
+    let item_indexes: Vec<i64> = items.iter().map(|item| item.item_index).collect();
+    assert_eq!(item_indexes, vec![0, 1, 2]);
+    assert_eq!(items.len(), 3);
+}


### PR DESCRIPTION
## Summary
- Migrates the session detail transcript from factory rows/pagination to a typed `ListView` model.
- Restores typed transcript interactions for search navigation, message expansion, reasoning/tool inspection, row styling, and tool-burst expansion.
- Adds typed transcript row/data tests and full transcript loading coverage.

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --all -- -D warnings`
- `cargo test --all --no-fail-fast`
- `meson compile -C builddir`

## Notes
- Unrelated local files were left uncommitted and are not part of this PR.