### PR TITLE
feat: add date filter pill for session browsing

### DIFF
--- a/src/app/handlers/analytics.rs
+++ b/src/app/handlers/analytics.rs
@@ -46,7 +46,6 @@ impl App {
         .search_ui_visible
     }
 
-    #[allow(dead_code)] // used by DatePill header placement in Task 4
     pub(crate) fn is_date_filter_visible(&self) -> bool {
         workspace_header_visibility(
             self.active_workspace,

--- a/src/app/handlers/analytics.rs
+++ b/src/app/handlers/analytics.rs
@@ -46,6 +46,16 @@ impl App {
         .search_ui_visible
     }
 
+    #[allow(dead_code)] // used by DatePill header placement in Task 4
+    pub(crate) fn is_date_filter_visible(&self) -> bool {
+        workspace_header_visibility(
+            self.active_workspace,
+            self.detail_visible,
+            self.parent_session.is_some(),
+        )
+        .date_filter_visible
+    }
+
     pub(crate) fn is_pane_controls_visible(&self) -> bool {
         workspace_header_visibility(
             self.active_workspace,

--- a/src/app/helpers.rs
+++ b/src/app/helpers.rs
@@ -78,6 +78,7 @@ pub(super) fn workspace_header_visibility(
     if workspace.is_analytics() {
         WorkspaceHeaderVisibility {
             search_ui_visible: false,
+            date_filter_visible: false,
             pane_controls_visible: false,
             detail_actions_visible: false,
             indexing_progress_visible: true,
@@ -85,6 +86,7 @@ pub(super) fn workspace_header_visibility(
     } else {
         WorkspaceHeaderVisibility {
             search_ui_visible: true,
+            date_filter_visible: !detail_visible,
             pane_controls_visible: true,
             detail_actions_visible: detail_visible || parent_session_present,
             indexing_progress_visible: true,
@@ -297,5 +299,17 @@ mod tests {
         );
 
         assert!(target.is_none());
+    }
+
+    #[test]
+    fn workspace_header_visibility_shows_date_filter_only_on_sessions_list() {
+        let analytics = workspace_header_visibility(Workspace::Analytics, false, false);
+        assert!(!analytics.date_filter_visible);
+
+        let sessions_list = workspace_header_visibility(Workspace::Sessions, false, false);
+        assert!(sessions_list.date_filter_visible);
+
+        let sessions_detail = workspace_header_visibility(Workspace::Sessions, true, false);
+        assert!(!sessions_detail.date_filter_visible);
     }
 }

--- a/src/app/init.rs
+++ b/src/app/init.rs
@@ -19,6 +19,7 @@ use crate::ui::modals::{
 };
 use crate::ui::{
     analytics_view::{AnalyticsView, AnalyticsViewOutput},
+    date_pill::{DatePill, DatePillOutput},
     session_detail::{SessionDetail, SessionDetailOutput},
     session_list::{SessionList, SessionListMsg, SessionListOutput},
     sidebar::{Sidebar, SidebarOutput},
@@ -27,9 +28,9 @@ use crate::ui::{
 use super::helpers::workspace_allows_search;
 use super::types::Workspace;
 use super::{
-    AboutAction, App, AppMsg, EscapeAction, IndexingStatusAction, PreferencesAction, QuitAction,
-    ShortcutsAction, ShowSearchAction, ToggleFiltersAction, ToggleInspectorAction, TogglePinAction,
-    ToggleSidePaneAction, WindowActionGroup,
+    AboutAction, App, AppMsg, EscapeAction, IndexingStatusAction, OpenDateFilterAction,
+    PreferencesAction, QuitAction, ShortcutsAction, ShowSearchAction, ToggleFiltersAction,
+    ToggleInspectorAction, TogglePinAction, ToggleSidePaneAction, WindowActionGroup,
 };
 
 /// Holds all child controllers and workers created during init.
@@ -37,6 +38,7 @@ pub(super) struct ChildComponents {
     pub(super) session_list: Controller<SessionList>,
     pub(super) analytics_view: Controller<AnalyticsView>,
     pub(super) session_detail: Controller<SessionDetail>,
+    pub(super) date_pill: Controller<DatePill>,
     pub(super) sidebar: Controller<Sidebar>,
     pub(super) preferences_dialog: Controller<PreferencesDialog>,
     pub(super) indexing_worker: WorkerController<IndexingWorker>,
@@ -74,6 +76,12 @@ pub(super) fn init_child_components(
                 AppMsg::InspectorVisibilityChanged(visible)
             }
             SessionDetailOutput::OpenChildSession(id) => AppMsg::OpenChildSession(id),
+        });
+    let date_pill = DatePill::builder()
+        .launch(crate::models::DateFilter::AnyTime)
+        .forward(sender.input_sender(), |output| match output {
+            DatePillOutput::FilterChanged(filter) => AppMsg::DateFilterChanged(filter),
+            DatePillOutput::CountsRequested => AppMsg::DateCountsRequested,
         });
     let sidebar =
         Sidebar::builder()
@@ -125,6 +133,7 @@ pub(super) fn init_child_components(
         session_list,
         analytics_view,
         session_detail,
+        date_pill,
         sidebar,
         preferences_dialog,
         indexing_worker,
@@ -445,6 +454,13 @@ pub(super) fn register_actions(
         })
     };
 
+    let open_date_filter_action = {
+        let sender = sender.clone();
+        RelmAction::<OpenDateFilterAction>::new_stateless(move |_| {
+            sender.input(AppMsg::OpenDateFilterShortcut);
+        })
+    };
+
     let quit_action = {
         let sender = sender.clone();
         RelmAction::<QuitAction>::new_stateless(move |_| {
@@ -468,6 +484,7 @@ pub(super) fn register_actions(
     app.set_accelerators_for_action::<QuitAction>(&["<Control>q"]);
     app.set_accelerators_for_action::<ToggleSidePaneAction>(&["F9"]);
     app.set_accelerators_for_action::<TogglePinAction>(&["<Control>d"]);
+    app.set_accelerators_for_action::<OpenDateFilterAction>(&["<Control><Shift>d"]);
     app.set_accelerators_for_action::<ShowSearchAction>(&["<Control>f"]);
     app.set_accelerators_for_action::<ShortcutsAction>(&["<Control>question"]);
     app.set_accelerators_for_action::<IndexingStatusAction>(&["<Control><Shift>i"]);
@@ -483,6 +500,7 @@ pub(super) fn register_actions(
     actions.add_action(toggle_inspector_action);
     actions.add_action(toggle_side_pane_action);
     actions.add_action(toggle_pin_action);
+    actions.add_action(open_date_filter_action);
     actions.add_action(quit_action);
     actions.add_action(escape_action);
     actions.register_for_widget(main_window);

--- a/src/app/init.rs
+++ b/src/app/init.rs
@@ -78,7 +78,7 @@ pub(super) fn init_child_components(
             SessionDetailOutput::OpenChildSession(id) => AppMsg::OpenChildSession(id),
         });
     let date_pill = DatePill::builder()
-        .launch(crate::models::DateFilter::AnyTime)
+        .launch(())
         .forward(sender.input_sender(), |output| match output {
             DatePillOutput::FilterChanged(filter) => AppMsg::DateFilterChanged(filter),
             DatePillOutput::CountsRequested => AppMsg::DateCountsRequested,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -19,11 +19,11 @@ use std::{
 use crate::analytics_worker::AnalyticsWorker;
 use crate::config::{APP_ID, PROFILE};
 use crate::database::{
-    SessionIndexer, count_all_sessions, count_pinned_sessions, count_unassigned_sessions,
-    has_unassigned_sessions, load_projects,
+    SessionIndexer, count_all_sessions, count_pinned_sessions, count_sessions_per_date_preset,
+    count_unassigned_sessions, has_unassigned_sessions, load_projects,
 };
 use crate::indexing_worker::{IndexingWorker, IndexingWorkerInput};
-use crate::models::{ProjectFilter, ProjectInfo, session::AiAssistant};
+use crate::models::{DateFilter, ProjectFilter, ProjectInfo, session::AiAssistant};
 use crate::session_sources::{SessionSources, select_db_filename};
 use crate::ui::modals::{
     indexing_status::{IndexingStatusDialog, IndexingStatusMsg, IndexingStatusOutput},
@@ -142,6 +142,7 @@ pub(super) struct App {
     indexing: bool,
     pending_reindex_feedback: bool,
     active_workspace: Workspace,
+    selected_date_filter: DateFilter,
     banner: adw::Banner,
     banner_has_issues: bool,
 }
@@ -196,6 +197,10 @@ pub(super) enum AppMsg {
     AnalyticsRefreshRequested,
     AnalyticsLoaded(crate::models::AnalyticsData),
     AnalyticsLoadFailed(String),
+    #[allow(dead_code)] // wired by DatePill in Task 4
+    DateFilterChanged(DateFilter),
+    #[allow(dead_code)] // wired by DatePill in Task 4
+    DateCountsRequested,
 }
 
 relm4::new_action_group!(pub(super) WindowActionGroup, "win");
@@ -455,6 +460,7 @@ impl SimpleComponent for App {
             indexing: true,
             pending_reindex_feedback: false,
             active_workspace: Workspace::Sessions,
+            selected_date_filter: DateFilter::AnyTime,
             banner: adw::Banner::new(""),
             banner_has_issues: false,
         };
@@ -516,6 +522,10 @@ impl SimpleComponent for App {
             model.emit_session_list_filters();
         }
 
+        model.session_list.emit(SessionListMsg::DateFilterChanged(
+            model.selected_date_filter.clone(),
+        ));
+
         model.session_list.emit(SessionListMsg::SetIndexing(true));
         model
             .indexing_worker
@@ -547,6 +557,9 @@ impl SimpleComponent for App {
                 self.filter_state.project_filter = project_filter;
                 self.refresh_sidebar_projects();
                 self.emit_session_list_filters();
+                self.session_list.emit(SessionListMsg::DateFilterChanged(
+                    self.selected_date_filter.clone(),
+                ));
             }
             AppMsg::SessionSelected(id) => self.handle_session_selected(id),
             AppMsg::RequestNavigateBack => self.handle_request_navigate_back(),
@@ -601,6 +614,19 @@ impl SimpleComponent for App {
             }
             AppMsg::ReturnToParentSession => self.handle_return_to_parent_session(),
             AppMsg::Escape => self.handle_escape(&sender),
+            AppMsg::DateFilterChanged(date_filter) => {
+                self.selected_date_filter = date_filter.clone();
+                self.session_list
+                    .emit(SessionListMsg::DateFilterChanged(date_filter));
+            }
+            AppMsg::DateCountsRequested => {
+                let _counts = count_sessions_per_date_preset(
+                    &self.db_path,
+                    &self.filter_state.tools,
+                    &self.filter_state.project_filter,
+                    &self.search_query,
+                );
+            }
         }
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -78,14 +78,16 @@ struct SidebarProjectData {
 fn load_sidebar_project_data(
     db_path: &Path,
     tools: &[AiAssistant],
+    date_filter: &DateFilter,
 ) -> anyhow::Result<SidebarProjectData> {
-    let projects = load_projects(db_path, tools).context("load projects for sidebar")?;
-    let all_sessions_count =
-        count_all_sessions(db_path, tools).context("count all sessions for sidebar")?;
-    let unassigned_count = count_unassigned_sessions(db_path, tools)
+    let projects =
+        load_projects(db_path, tools, date_filter).context("load projects for sidebar")?;
+    let all_sessions_count = count_all_sessions(db_path, tools, date_filter)
+        .context("count all sessions for sidebar")?;
+    let unassigned_count = count_unassigned_sessions(db_path, tools, date_filter)
         .context("count unassigned sessions for sidebar")?;
-    let pinned_count =
-        count_pinned_sessions(db_path, tools).context("count pinned sessions for sidebar")?;
+    let pinned_count = count_pinned_sessions(db_path, tools, date_filter)
+        .context("count pinned sessions for sidebar")?;
     let show_unassigned =
         has_unassigned_sessions(db_path).context("determine unassigned sidebar visibility")?;
 
@@ -630,6 +632,7 @@ impl SimpleComponent for App {
             }
             AppMsg::DateFilterChanged(date_filter) => {
                 self.selected_date_filter = date_filter.clone();
+                self.refresh_sidebar_projects();
                 self.session_list
                     .emit(SessionListMsg::DateFilterChanged(date_filter));
             }
@@ -727,7 +730,8 @@ impl App {
 
     fn refresh_sidebar_projects(&mut self) -> bool {
         let tools = self.filter_state.tools.clone();
-        let sidebar_data = match load_sidebar_project_data(&self.db_path, &tools) {
+        let date_filter = self.selected_date_filter.clone();
+        let sidebar_data = match load_sidebar_project_data(&self.db_path, &tools, &date_filter) {
             Ok(data) => data,
             Err(err) => {
                 tracing::warn!("Failed to load sidebar project data: {err:#}");
@@ -1187,7 +1191,7 @@ mod tests {
     fn project_sidebar_refresh_data_returns_error_for_directory_path() {
         let db_path = std::env::temp_dir();
 
-        let result = load_sidebar_project_data(&db_path, AiAssistant::ALL);
+        let result = load_sidebar_project_data(&db_path, AiAssistant::ALL, &DateFilter::AnyTime);
 
         assert!(
             result.is_err(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -25,6 +25,7 @@ use crate::database::{
 use crate::indexing_worker::{IndexingWorker, IndexingWorkerInput};
 use crate::models::{DateFilter, ProjectFilter, ProjectInfo, session::AiAssistant};
 use crate::session_sources::{SessionSources, select_db_filename};
+use crate::ui::date_pill::{DatePill, DatePillInput};
 use crate::ui::modals::{
     indexing_status::{IndexingStatusDialog, IndexingStatusMsg, IndexingStatusOutput},
     preferences::PreferencesDialog,
@@ -123,6 +124,7 @@ pub(super) struct App {
     session_list: Controller<SessionList>,
     analytics_view: Controller<AnalyticsView>,
     session_detail: Controller<SessionDetail>,
+    date_pill: Controller<DatePill>,
     #[allow(dead_code)] // Controller must stay alive to keep the widget
     sidebar: Controller<Sidebar>,
     preferences_dialog: Controller<PreferencesDialog>,
@@ -183,6 +185,7 @@ pub(super) enum AppMsg {
     ReturnToParentSession,
     /// Esc key: close search → close inspector → navigate back.
     Escape,
+    OpenDateFilterShortcut,
     ShowPreferences,
     ShowIndexingStatus,
     ReindexRequested,
@@ -197,9 +200,7 @@ pub(super) enum AppMsg {
     AnalyticsRefreshRequested,
     AnalyticsLoaded(crate::models::AnalyticsData),
     AnalyticsLoadFailed(String),
-    #[allow(dead_code)] // wired by DatePill in Task 4
     DateFilterChanged(DateFilter),
-    #[allow(dead_code)] // wired by DatePill in Task 4
     DateCountsRequested,
 }
 
@@ -214,6 +215,7 @@ relm4::new_stateless_action!(ToggleInspectorAction, WindowActionGroup, "toggle-i
 // F9 dispatcher — toggles filters in list view, inspector in detail view.
 relm4::new_stateless_action!(ToggleSidePaneAction, WindowActionGroup, "toggle-side-pane");
 relm4::new_stateless_action!(TogglePinAction, WindowActionGroup, "toggle-pin");
+relm4::new_stateless_action!(OpenDateFilterAction, WindowActionGroup, "open-date-filter");
 relm4::new_stateless_action!(ShowSearchAction, WindowActionGroup, "show-search");
 relm4::new_stateless_action!(EscapeAction, WindowActionGroup, "escape");
 
@@ -442,6 +444,7 @@ impl SimpleComponent for App {
             session_list: components.session_list,
             analytics_view: components.analytics_view,
             session_detail: components.session_detail,
+            date_pill: components.date_pill,
             sidebar: components.sidebar,
             preferences_dialog: components.preferences_dialog,
             indexing_worker: components.indexing_worker,
@@ -467,6 +470,12 @@ impl SimpleComponent for App {
 
         // view_output!() must stay in the SimpleComponent impl (Relm4 macro requirement)
         let widgets = view_output!();
+
+        widgets.header_bar.pack_start(model.date_pill.widget());
+        model
+            .date_pill
+            .widget()
+            .set_visible(model.is_date_filter_visible());
 
         // Get the actual ToastOverlay from the root window's content
         if let Some(toast_overlay) = root
@@ -614,18 +623,30 @@ impl SimpleComponent for App {
             }
             AppMsg::ReturnToParentSession => self.handle_return_to_parent_session(),
             AppMsg::Escape => self.handle_escape(&sender),
+            AppMsg::OpenDateFilterShortcut => {
+                if self.is_date_filter_visible() {
+                    self.date_pill.emit(DatePillInput::OpenViaShortcut);
+                }
+            }
             AppMsg::DateFilterChanged(date_filter) => {
                 self.selected_date_filter = date_filter.clone();
+                self.date_pill
+                    .emit(DatePillInput::SetFilter(date_filter.clone()));
                 self.session_list
                     .emit(SessionListMsg::DateFilterChanged(date_filter));
             }
             AppMsg::DateCountsRequested => {
-                let _counts = count_sessions_per_date_preset(
+                match count_sessions_per_date_preset(
                     &self.db_path,
                     &self.filter_state.tools,
                     &self.filter_state.project_filter,
                     &self.search_query,
-                );
+                ) {
+                    Ok(counts) => self.date_pill.emit(DatePillInput::CountsReceived(counts)),
+                    Err(err) => {
+                        tracing::warn!("Failed to count sessions for date presets: {err:#}")
+                    }
+                }
             }
         }
     }
@@ -641,6 +662,10 @@ impl SimpleComponent for App {
         {
             widgets.search_bar.set_search_mode(self.search_visible);
         }
+
+        self.date_pill
+            .widget()
+            .set_visible(self.is_date_filter_visible());
     }
 
     fn shutdown(&mut self, widgets: &mut Self::Widgets, _output: relm4::Sender<Self::Output>) {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -630,8 +630,6 @@ impl SimpleComponent for App {
             }
             AppMsg::DateFilterChanged(date_filter) => {
                 self.selected_date_filter = date_filter.clone();
-                self.date_pill
-                    .emit(DatePillInput::SetFilter(date_filter.clone()));
                 self.session_list
                     .emit(SessionListMsg::DateFilterChanged(date_filter));
             }

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -83,6 +83,7 @@ mod tests {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) struct WorkspaceHeaderVisibility {
     pub(super) search_ui_visible: bool,
+    pub(super) date_filter_visible: bool,
     pub(super) pane_controls_visible: bool,
     pub(super) detail_actions_visible: bool,
     pub(super) indexing_progress_visible: bool,

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -3,7 +3,7 @@ pub mod indexer;
 pub mod schema;
 
 use anyhow::{Context, Result};
-use chrono::{TimeZone, Utc};
+use chrono::{DateTime, TimeZone, Utc};
 use rusqlite::{Connection, OptionalExtension, Row, ToSql};
 use std::collections::HashSet;
 use std::path::Path;
@@ -589,65 +589,21 @@ pub fn count_sessions_per_date_preset(
     project_filter: &ProjectFilter,
     query: &str,
 ) -> Result<DateCounts> {
-    Ok(DateCounts {
-        any_time: count_sessions_for_context(
-            db_path,
-            tools,
-            project_filter,
-            query,
-            &DateFilter::AnyTime,
-        )?,
-        today: count_sessions_for_context(
-            db_path,
-            tools,
-            project_filter,
-            query,
-            &DateFilter::Today,
-        )?,
-        last_7_days: count_sessions_for_context(
-            db_path,
-            tools,
-            project_filter,
-            query,
-            &DateFilter::Last7Days,
-        )?,
-        last_30_days: count_sessions_for_context(
-            db_path,
-            tools,
-            project_filter,
-            query,
-            &DateFilter::Last30Days,
-        )?,
-        this_year: count_sessions_for_context(
-            db_path,
-            tools,
-            project_filter,
-            query,
-            &DateFilter::ThisYear,
-        )?,
-    })
-}
-
-fn count_sessions_for_context(
-    db_path: &Path,
-    tools: &[AiAssistant],
-    project_filter: &ProjectFilter,
-    query: &str,
-    date_filter: &DateFilter,
-) -> Result<usize> {
     if !db_path.exists() || tools.is_empty() {
-        return Ok(0);
+        return Ok(DateCounts::default());
     }
 
     let db = open_connection(db_path)?;
+    let now = Utc::now();
+    let bounds = DatePresetBounds::resolve(now);
 
     let query = query.trim();
     if query.is_empty() {
-        return count_sessions_without_query(&db, tools, project_filter, date_filter);
+        return count_all_presets_without_query(&db, tools, project_filter, &bounds);
     }
 
-    match count_sessions_with_query(&db, tools, project_filter, query, date_filter) {
-        Ok(count) => Ok(count),
+    match count_all_presets_with_query(&db, tools, project_filter, query, &bounds) {
+        Ok(counts) => Ok(counts),
         Err(err) => {
             if let Some(sanitized) = sanitize_search_query(query) {
                 tracing::warn!(
@@ -655,16 +611,16 @@ fn count_sessions_for_context(
                     sanitized,
                     err
                 );
-                match count_sessions_with_query(&db, tools, project_filter, &sanitized, date_filter)
+                match count_all_presets_with_query(&db, tools, project_filter, &sanitized, &bounds)
                 {
-                    Ok(count) => Ok(count),
+                    Ok(counts) => Ok(counts),
                     Err(retry_err) => {
                         tracing::warn!(
                             "Sanitized date preset count query failed '{}': {}",
                             sanitized,
                             retry_err
                         );
-                        Ok(0)
+                        Ok(DateCounts::default())
                     }
                 }
             } else {
@@ -672,35 +628,119 @@ fn count_sessions_for_context(
                     "Date preset count query failed and could not be sanitized: {}",
                     err
                 );
-                Ok(0)
+                Ok(DateCounts::default())
             }
         }
     }
 }
 
-fn count_sessions_without_query(
+struct DatePresetBounds {
+    today: Option<(i64, i64)>,
+    last_7_days: Option<(i64, i64)>,
+    last_30_days: Option<(i64, i64)>,
+    this_year: Option<(i64, i64)>,
+}
+
+impl DatePresetBounds {
+    fn resolve(now: DateTime<Utc>) -> Self {
+        let to_ts = |filter: DateFilter| {
+            filter
+                .resolve(now)
+                .map(|(start, end)| (start.timestamp(), end.timestamp()))
+        };
+        Self {
+            today: to_ts(DateFilter::Today),
+            last_7_days: to_ts(DateFilter::Last7Days),
+            last_30_days: to_ts(DateFilter::Last30Days),
+            this_year: to_ts(DateFilter::ThisYear),
+        }
+    }
+
+    /// Returns the four presets in the order (today, last_7_days, last_30_days, this_year)
+    /// so SQL projection columns and `params` extension stay in lockstep.
+    fn ordered(&self) -> [Option<(i64, i64)>; 4] {
+        [
+            self.today,
+            self.last_7_days,
+            self.last_30_days,
+            self.this_year,
+        ]
+    }
+}
+
+fn preset_case_columns(prefix: &str, bounds: &DatePresetBounds) -> (String, Vec<i64>) {
+    let mut columns: Vec<String> = Vec::with_capacity(4);
+    let mut values: Vec<i64> = Vec::with_capacity(8);
+    for window in bounds.ordered() {
+        if let Some((start, end)) = window {
+            columns.push(format!(
+                "SUM(CASE WHEN {prefix}last_updated >= ? AND {prefix}last_updated < ? THEN 1 ELSE 0 END)"
+            ));
+            values.push(start);
+            values.push(end);
+        } else {
+            columns.push("0".to_string());
+        }
+    }
+    (columns.join(", "), values)
+}
+
+fn preset_distinct_case_columns(
+    prefix: &str,
+    id_expr: &str,
+    bounds: &DatePresetBounds,
+) -> (String, Vec<i64>) {
+    let mut columns: Vec<String> = Vec::with_capacity(4);
+    let mut values: Vec<i64> = Vec::with_capacity(8);
+    for window in bounds.ordered() {
+        if let Some((start, end)) = window {
+            columns.push(format!(
+                "COUNT(DISTINCT CASE WHEN {prefix}last_updated >= ? AND {prefix}last_updated < ? THEN {id_expr} END)"
+            ));
+            values.push(start);
+            values.push(end);
+        } else {
+            columns.push("0".to_string());
+        }
+    }
+    (columns.join(", "), values)
+}
+
+fn read_counts_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<DateCounts> {
+    // SUM(...) returns NULL when no rows match the WHERE clause.
+    let read = |idx: usize| -> rusqlite::Result<usize> {
+        Ok(row.get::<_, Option<i64>>(idx)?.unwrap_or(0).max(0) as usize)
+    };
+    Ok(DateCounts {
+        any_time: read(0)?,
+        today: read(1)?,
+        last_7_days: read(2)?,
+        last_30_days: read(3)?,
+        this_year: read(4)?,
+    })
+}
+
+fn count_all_presets_without_query(
     db: &Connection,
     tools: &[AiAssistant],
     project_filter: &ProjectFilter,
-    date_filter: &DateFilter,
-) -> Result<usize> {
-    let (date_clause, date_values) = date_filter_sql_clause(date_filter, "");
+    bounds: &DatePresetBounds,
+) -> Result<DateCounts> {
     let project_clause = match project_filter {
         ProjectFilter::AllSessions => String::new(),
         ProjectFilter::Pinned => " AND pinned_at IS NOT NULL".to_string(),
         ProjectFilter::Project(_) => " AND project_id = ?".to_string(),
         ProjectFilter::Unassigned => " AND project_id IS NULL".to_string(),
     };
+    let (preset_columns, preset_values) = preset_case_columns("", bounds);
 
     let (query_sql, tool_strings): (String, Vec<String>) = if tools.len() == AiAssistant::ALL.len()
     {
         (
             format!(
-                "SELECT COUNT(*)
+                "SELECT COUNT(*), {preset_columns}
                  FROM sessions
-                 WHERE is_subagent = 0
-                     {}{}",
-                project_clause, date_clause
+                 WHERE is_subagent = 0{project_clause}"
             ),
             vec![],
         )
@@ -709,21 +749,23 @@ fn count_sessions_without_query(
         let tool_strings: Vec<String> = tools.iter().map(|t| t.to_storage()).collect::<Vec<_>>();
         (
             format!(
-                "SELECT COUNT(*)
+                "SELECT COUNT(*), {preset_columns}
                  FROM sessions
                  WHERE tool IN ({})
-                   AND is_subagent = 0
-                     {}{}",
-                placeholders.join(","),
-                project_clause,
-                date_clause
+                   AND is_subagent = 0{project_clause}",
+                placeholders.join(",")
             ),
             tool_strings,
         )
     };
 
     let mut stmt = db.prepare(&query_sql)?;
-    let mut params: Vec<&dyn ToSql> = Vec::with_capacity(3 + tool_strings.len());
+    let mut params: Vec<&dyn ToSql> =
+        Vec::with_capacity(preset_values.len() + tool_strings.len() + 1);
+    // Preset window placeholders appear in the SELECT clause, which comes before WHERE.
+    for value in &preset_values {
+        params.push(value as &dyn ToSql);
+    }
     for tool in &tool_strings {
         params.push(tool as &dyn ToSql);
     }
@@ -734,41 +776,36 @@ fn count_sessions_without_query(
     if let Some(project_id) = project_id.as_ref() {
         params.push(project_id as &dyn ToSql);
     }
-    for value in &date_values {
-        params.push(value as &dyn ToSql);
-    }
 
-    let count: i64 = stmt.query_row(params.as_slice(), |row| row.get(0))?;
-    Ok(count.max(0) as usize)
+    let counts = stmt.query_row(params.as_slice(), read_counts_row)?;
+    Ok(counts)
 }
 
-fn count_sessions_with_query(
+fn count_all_presets_with_query(
     db: &Connection,
     tools: &[AiAssistant],
     project_filter: &ProjectFilter,
     query: &str,
-    date_filter: &DateFilter,
-) -> Result<usize> {
+    bounds: &DatePresetBounds,
+) -> Result<DateCounts> {
     let project_clause = match project_filter {
         ProjectFilter::AllSessions => String::new(),
         ProjectFilter::Pinned => " AND s.pinned_at IS NOT NULL".to_string(),
         ProjectFilter::Project(_) => " AND s.project_id = ?".to_string(),
         ProjectFilter::Unassigned => " AND s.project_id IS NULL".to_string(),
     };
-    let (date_clause, date_values) = date_filter_sql_clause(date_filter, "s.");
+    let (preset_columns, preset_values) = preset_distinct_case_columns("s.", "s.id", bounds);
 
     let (query_sql, tool_strings): (String, Vec<String>) = if tools.len() == AiAssistant::ALL.len()
     {
         (
             format!(
-                "SELECT COUNT(DISTINCT s.id)
+                "SELECT COUNT(DISTINCT s.id), {preset_columns}
                  FROM messages_fts
                  JOIN messages m ON m.id = messages_fts.rowid
                  JOIN sessions s ON s.id = m.session_id
                  WHERE messages_fts MATCH ?
-                   AND s.is_subagent = 0
-                     {}{}",
-                project_clause, date_clause
+                   AND s.is_subagent = 0{project_clause}"
             ),
             vec![],
         )
@@ -777,24 +814,26 @@ fn count_sessions_with_query(
         let tool_strings: Vec<String> = tools.iter().map(|t| t.to_storage()).collect::<Vec<_>>();
         (
             format!(
-                "SELECT COUNT(DISTINCT s.id)
+                "SELECT COUNT(DISTINCT s.id), {preset_columns}
                  FROM messages_fts
                  JOIN messages m ON m.id = messages_fts.rowid
                  JOIN sessions s ON s.id = m.session_id
                  WHERE messages_fts MATCH ?
                    AND s.tool IN ({})
-                   AND s.is_subagent = 0
-                     {}{}",
-                placeholders.join(","),
-                project_clause,
-                date_clause
+                   AND s.is_subagent = 0{project_clause}",
+                placeholders.join(",")
             ),
             tool_strings,
         )
     };
 
     let mut stmt = db.prepare(&query_sql)?;
-    let mut params: Vec<&dyn ToSql> = Vec::with_capacity(4 + tool_strings.len());
+    let mut params: Vec<&dyn ToSql> =
+        Vec::with_capacity(preset_values.len() + tool_strings.len() + 2);
+    // Preset window placeholders appear in the SELECT clause, which comes before WHERE.
+    for value in &preset_values {
+        params.push(value as &dyn ToSql);
+    }
     params.push(&query);
     for tool in &tool_strings {
         params.push(tool as &dyn ToSql);
@@ -806,12 +845,9 @@ fn count_sessions_with_query(
     if let Some(project_id) = project_id.as_ref() {
         params.push(project_id as &dyn ToSql);
     }
-    for value in &date_values {
-        params.push(value as &dyn ToSql);
-    }
 
-    let count: i64 = stmt.query_row(params.as_slice(), |row| row.get(0))?;
-    Ok(count.max(0) as usize)
+    let counts = stmt.query_row(params.as_slice(), read_counts_row)?;
+    Ok(counts)
 }
 
 pub fn load_projects(

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -639,12 +639,150 @@ fn count_sessions_for_context(
         return Ok(0);
     }
 
+    let db = open_connection(db_path)?;
+
     let query = query.trim();
     if query.is_empty() {
-        return Ok(load_sessions_for_filter(db_path, tools, project_filter, date_filter)?.len());
+        return count_sessions_without_query(&db, tools, project_filter, date_filter);
     }
 
-    Ok(search_sessions_for_filter(db_path, tools, project_filter, query, date_filter)?.len())
+    count_sessions_with_query(&db, tools, project_filter, query, date_filter)
+}
+
+fn count_sessions_without_query(
+    db: &Connection,
+    tools: &[AiAssistant],
+    project_filter: &ProjectFilter,
+    date_filter: &DateFilter,
+) -> Result<usize> {
+    let (date_clause, date_values) = date_filter_sql_clause(date_filter, "");
+    let project_clause = match project_filter {
+        ProjectFilter::AllSessions => String::new(),
+        ProjectFilter::Pinned => " AND pinned_at IS NOT NULL".to_string(),
+        ProjectFilter::Project(_) => " AND project_id = ?".to_string(),
+        ProjectFilter::Unassigned => " AND project_id IS NULL".to_string(),
+    };
+
+    let (query_sql, tool_strings): (String, Vec<String>) = if tools.len() == AiAssistant::ALL.len()
+    {
+        (
+            format!(
+                "SELECT COUNT(*)
+                 FROM sessions
+                 WHERE is_subagent = 0
+                     {}{}",
+                project_clause, date_clause
+            ),
+            vec![],
+        )
+    } else {
+        let placeholders: Vec<String> = tools.iter().map(|_| "?".to_string()).collect();
+        let tool_strings: Vec<String> = tools.iter().map(|t| t.to_storage()).collect::<Vec<_>>();
+        (
+            format!(
+                "SELECT COUNT(*)
+                 FROM sessions
+                 WHERE tool IN ({})
+                   AND is_subagent = 0
+                     {}{}",
+                placeholders.join(","),
+                project_clause,
+                date_clause
+            ),
+            tool_strings,
+        )
+    };
+
+    let mut stmt = db.prepare(&query_sql)?;
+    let mut params: Vec<&dyn ToSql> = Vec::with_capacity(3 + tool_strings.len());
+    for tool in &tool_strings {
+        params.push(tool as &dyn ToSql);
+    }
+    let project_id = match project_filter {
+        ProjectFilter::Project(id) => Some(*id),
+        _ => None,
+    };
+    if let Some(project_id) = project_id.as_ref() {
+        params.push(project_id as &dyn ToSql);
+    }
+    for value in &date_values {
+        params.push(value as &dyn ToSql);
+    }
+
+    let count: i64 = stmt.query_row(params.as_slice(), |row| row.get(0))?;
+    Ok(count.max(0) as usize)
+}
+
+fn count_sessions_with_query(
+    db: &Connection,
+    tools: &[AiAssistant],
+    project_filter: &ProjectFilter,
+    query: &str,
+    date_filter: &DateFilter,
+) -> Result<usize> {
+    let project_clause = match project_filter {
+        ProjectFilter::AllSessions => String::new(),
+        ProjectFilter::Pinned => " AND s.pinned_at IS NOT NULL".to_string(),
+        ProjectFilter::Project(_) => " AND s.project_id = ?".to_string(),
+        ProjectFilter::Unassigned => " AND s.project_id IS NULL".to_string(),
+    };
+    let (date_clause, date_values) = date_filter_sql_clause(date_filter, "s.");
+
+    let (query_sql, tool_strings): (String, Vec<String>) = if tools.len() == AiAssistant::ALL.len()
+    {
+        (
+            format!(
+                "SELECT COUNT(DISTINCT s.id)
+                 FROM messages_fts
+                 JOIN messages m ON m.id = messages_fts.rowid
+                 JOIN sessions s ON s.id = m.session_id
+                 WHERE messages_fts MATCH ?
+                   AND s.is_subagent = 0
+                     {}{}",
+                project_clause, date_clause
+            ),
+            vec![],
+        )
+    } else {
+        let placeholders: Vec<String> = tools.iter().map(|_| "?".to_string()).collect();
+        let tool_strings: Vec<String> = tools.iter().map(|t| t.to_storage()).collect::<Vec<_>>();
+        (
+            format!(
+                "SELECT COUNT(DISTINCT s.id)
+                 FROM messages_fts
+                 JOIN messages m ON m.id = messages_fts.rowid
+                 JOIN sessions s ON s.id = m.session_id
+                 WHERE messages_fts MATCH ?
+                   AND s.tool IN ({})
+                   AND s.is_subagent = 0
+                     {}{}",
+                placeholders.join(","),
+                project_clause,
+                date_clause
+            ),
+            tool_strings,
+        )
+    };
+
+    let mut stmt = db.prepare(&query_sql)?;
+    let mut params: Vec<&dyn ToSql> = Vec::with_capacity(4 + tool_strings.len());
+    params.push(&query);
+    for tool in &tool_strings {
+        params.push(tool as &dyn ToSql);
+    }
+    let project_id = match project_filter {
+        ProjectFilter::Project(id) => Some(*id),
+        _ => None,
+    };
+    if let Some(project_id) = project_id.as_ref() {
+        params.push(project_id as &dyn ToSql);
+    }
+    for value in &date_values {
+        params.push(value as &dyn ToSql);
+    }
+
+    let count: i64 = stmt.query_row(params.as_slice(), |row| row.get(0))?;
+    Ok(count.max(0) as usize)
 }
 
 pub fn load_projects(db_path: &Path, tools: &[AiAssistant]) -> Result<Vec<ProjectInfo>> {

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -708,6 +708,13 @@ fn preset_distinct_case_columns(
 
 fn read_counts_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<DateCounts> {
     // SUM(...) returns NULL when no rows match the WHERE clause.
+    //
+    // Column indices must match the projection order built by
+    // `preset_case_columns` / `preset_distinct_case_columns`:
+    //   0 = any_time (total), 1 = today, 2 = last_7_days,
+    //   3 = last_30_days, 4 = this_year.
+    // If a preset is added or reordered, update both this function
+    // and `DatePresetBounds::ordered()`.
     let read = |idx: usize| -> rusqlite::Result<usize> {
         Ok(row.get::<_, Option<i64>>(idx)?.unwrap_or(0).max(0) as usize)
     };

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -814,12 +814,18 @@ fn count_sessions_with_query(
     Ok(count.max(0) as usize)
 }
 
-pub fn load_projects(db_path: &Path, tools: &[AiAssistant]) -> Result<Vec<ProjectInfo>> {
+pub fn load_projects(
+    db_path: &Path,
+    tools: &[AiAssistant],
+    date_filter: &DateFilter,
+) -> Result<Vec<ProjectInfo>> {
     if !db_path.exists() {
         return Ok(Vec::new());
     }
 
     let db = open_connection(db_path)?;
+
+    let (date_clause, date_values) = date_filter_sql_clause(date_filter, "s.");
 
     let (query, tool_strings): (String, Vec<String>) = if tools.is_empty() {
         (
@@ -831,15 +837,16 @@ pub fn load_projects(db_path: &Path, tools: &[AiAssistant]) -> Result<Vec<Projec
         )
     } else if tools.len() == AiAssistant::ALL.len() {
         (
-            "SELECT p.id, p.name, p.path, COUNT(s.id) AS session_count, MAX(s.last_updated) AS project_last_updated
-             FROM projects p
-             LEFT JOIN sessions s ON s.project_id = p.id
-                                AND s.is_subagent = 0
-             GROUP BY p.id, p.name, p.path
-             ORDER BY CASE WHEN COUNT(s.id) > 0 THEN 0 ELSE 1 END,
-                      project_last_updated DESC,
-                       p.name COLLATE NOCASE ASC"
-                .to_string(),
+            format!(
+                "SELECT p.id, p.name, p.path, COUNT(s.id) AS session_count, MAX(s.last_updated) AS project_last_updated
+                 FROM projects p
+                 LEFT JOIN sessions s ON s.project_id = p.id
+                                    AND s.is_subagent = 0{date_clause}
+                 GROUP BY p.id, p.name, p.path
+                 ORDER BY CASE WHEN COUNT(s.id) > 0 THEN 0 ELSE 1 END,
+                          project_last_updated DESC,
+                           p.name COLLATE NOCASE ASC"
+            ),
             vec![],
         )
     } else {
@@ -851,7 +858,7 @@ pub fn load_projects(db_path: &Path, tools: &[AiAssistant]) -> Result<Vec<Projec
                  FROM projects p
                  LEFT JOIN sessions s ON s.project_id = p.id
                                     AND s.is_subagent = 0
-                                    AND s.tool IN ({})
+                                    AND s.tool IN ({}){date_clause}
                  GROUP BY p.id, p.name, p.path
                  ORDER BY CASE WHEN COUNT(s.id) > 0 THEN 0 ELSE 1 END,
                           project_last_updated DESC,
@@ -863,8 +870,14 @@ pub fn load_projects(db_path: &Path, tools: &[AiAssistant]) -> Result<Vec<Projec
     };
 
     let mut stmt = db.prepare(&query)?;
-    let tool_refs: Vec<&dyn ToSql> = tool_strings.iter().map(|s| s as &dyn ToSql).collect();
-    let mut rows = stmt.query(tool_refs.as_slice())?;
+    let mut params: Vec<&dyn ToSql> = tool_strings.iter().map(|s| s as &dyn ToSql).collect();
+    // Empty-tools branch returns zero counts unconditionally and has no placeholders.
+    if !tools.is_empty() {
+        for value in &date_values {
+            params.push(value as &dyn ToSql);
+        }
+    }
+    let mut rows = stmt.query(params.as_slice())?;
 
     let mut projects = Vec::new();
     while let Some(row) = rows.next()? {
@@ -880,7 +893,11 @@ pub fn load_projects(db_path: &Path, tools: &[AiAssistant]) -> Result<Vec<Projec
     Ok(projects)
 }
 
-pub fn count_all_sessions(db_path: &Path, tools: &[AiAssistant]) -> Result<usize> {
+pub fn count_all_sessions(
+    db_path: &Path,
+    tools: &[AiAssistant],
+    date_filter: &DateFilter,
+) -> Result<usize> {
     if !db_path.exists() {
         return Ok(0);
     }
@@ -891,9 +908,11 @@ pub fn count_all_sessions(db_path: &Path, tools: &[AiAssistant]) -> Result<usize
 
     let db = open_connection(db_path)?;
 
+    let (date_clause, date_values) = date_filter_sql_clause(date_filter, "");
+
     let (query, tool_strings): (String, Vec<String>) = if tools.len() == AiAssistant::ALL.len() {
         (
-            "SELECT COUNT(*) FROM sessions WHERE is_subagent = 0".to_string(),
+            format!("SELECT COUNT(*) FROM sessions WHERE is_subagent = 0{date_clause}"),
             vec![],
         )
     } else {
@@ -901,7 +920,7 @@ pub fn count_all_sessions(db_path: &Path, tools: &[AiAssistant]) -> Result<usize
         let tool_strings: Vec<String> = tools.iter().map(|t| t.to_storage()).collect::<Vec<_>>();
         (
             format!(
-                "SELECT COUNT(*) FROM sessions WHERE is_subagent = 0 AND tool IN ({})",
+                "SELECT COUNT(*) FROM sessions WHERE is_subagent = 0 AND tool IN ({}){date_clause}",
                 placeholders.join(",")
             ),
             tool_strings,
@@ -909,13 +928,20 @@ pub fn count_all_sessions(db_path: &Path, tools: &[AiAssistant]) -> Result<usize
     };
 
     let mut stmt = db.prepare(&query)?;
-    let tool_refs: Vec<&dyn ToSql> = tool_strings.iter().map(|s| s as &dyn ToSql).collect();
-    let count: i64 = stmt.query_row(tool_refs.as_slice(), |row| row.get(0))?;
+    let mut params: Vec<&dyn ToSql> = tool_strings.iter().map(|s| s as &dyn ToSql).collect();
+    for value in &date_values {
+        params.push(value as &dyn ToSql);
+    }
+    let count: i64 = stmt.query_row(params.as_slice(), |row| row.get(0))?;
 
     Ok(count.max(0) as usize)
 }
 
-pub fn count_pinned_sessions(db_path: &Path, tools: &[AiAssistant]) -> Result<usize> {
+pub fn count_pinned_sessions(
+    db_path: &Path,
+    tools: &[AiAssistant],
+    date_filter: &DateFilter,
+) -> Result<usize> {
     if !db_path.exists() {
         return Ok(0);
     }
@@ -926,12 +952,15 @@ pub fn count_pinned_sessions(db_path: &Path, tools: &[AiAssistant]) -> Result<us
 
     let db = open_connection(db_path)?;
 
+    let (date_clause, date_values) = date_filter_sql_clause(date_filter, "");
+
     let (query, tool_strings): (String, Vec<String>) = if tools.len() == AiAssistant::ALL.len() {
         (
-            "SELECT COUNT(*) FROM sessions
-             WHERE pinned_at IS NOT NULL
-               AND is_subagent = 0"
-                .to_string(),
+            format!(
+                "SELECT COUNT(*) FROM sessions
+                 WHERE pinned_at IS NOT NULL
+                   AND is_subagent = 0{date_clause}"
+            ),
             vec![],
         )
     } else {
@@ -945,7 +974,7 @@ pub fn count_pinned_sessions(db_path: &Path, tools: &[AiAssistant]) -> Result<us
                 "SELECT COUNT(*) FROM sessions
                  WHERE pinned_at IS NOT NULL
                    AND is_subagent = 0
-                   AND tool IN ({})",
+                   AND tool IN ({}){date_clause}",
                 placeholders.join(",")
             ),
             tool_strings,
@@ -953,16 +982,23 @@ pub fn count_pinned_sessions(db_path: &Path, tools: &[AiAssistant]) -> Result<us
     };
 
     let mut stmt = db.prepare(&query)?;
-    let tool_refs: Vec<&dyn ToSql> = tool_strings
+    let mut params: Vec<&dyn ToSql> = tool_strings
         .iter()
         .map(|value| value as &dyn ToSql)
         .collect();
-    let count: i64 = stmt.query_row(tool_refs.as_slice(), |row| row.get(0))?;
+    for value in &date_values {
+        params.push(value as &dyn ToSql);
+    }
+    let count: i64 = stmt.query_row(params.as_slice(), |row| row.get(0))?;
 
     Ok(count.max(0) as usize)
 }
 
-pub fn count_unassigned_sessions(db_path: &Path, tools: &[AiAssistant]) -> Result<usize> {
+pub fn count_unassigned_sessions(
+    db_path: &Path,
+    tools: &[AiAssistant],
+    date_filter: &DateFilter,
+) -> Result<usize> {
     if !db_path.exists() {
         return Ok(0);
     }
@@ -973,12 +1009,15 @@ pub fn count_unassigned_sessions(db_path: &Path, tools: &[AiAssistant]) -> Resul
 
     let db = open_connection(db_path)?;
 
+    let (date_clause, date_values) = date_filter_sql_clause(date_filter, "");
+
     let (query, tool_strings): (String, Vec<String>) = if tools.len() == AiAssistant::ALL.len() {
         (
-            "SELECT COUNT(*) FROM sessions
-             WHERE project_id IS NULL
-               AND is_subagent = 0"
-                .to_string(),
+            format!(
+                "SELECT COUNT(*) FROM sessions
+                 WHERE project_id IS NULL
+                   AND is_subagent = 0{date_clause}"
+            ),
             vec![],
         )
     } else {
@@ -989,7 +1028,7 @@ pub fn count_unassigned_sessions(db_path: &Path, tools: &[AiAssistant]) -> Resul
                 "SELECT COUNT(*) FROM sessions
                  WHERE project_id IS NULL
                    AND is_subagent = 0
-                   AND tool IN ({})",
+                   AND tool IN ({}){date_clause}",
                 placeholders.join(",")
             ),
             tool_strings,
@@ -997,8 +1036,11 @@ pub fn count_unassigned_sessions(db_path: &Path, tools: &[AiAssistant]) -> Resul
     };
 
     let mut stmt = db.prepare(&query)?;
-    let tool_refs: Vec<&dyn ToSql> = tool_strings.iter().map(|s| s as &dyn ToSql).collect();
-    let count: i64 = stmt.query_row(tool_refs.as_slice(), |row| row.get(0))?;
+    let mut params: Vec<&dyn ToSql> = tool_strings.iter().map(|s| s as &dyn ToSql).collect();
+    for value in &date_values {
+        params.push(value as &dyn ToSql);
+    }
+    let count: i64 = stmt.query_row(params.as_slice(), |row| row.get(0))?;
 
     Ok(count.max(0) as usize)
 }

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -646,7 +646,36 @@ fn count_sessions_for_context(
         return count_sessions_without_query(&db, tools, project_filter, date_filter);
     }
 
-    count_sessions_with_query(&db, tools, project_filter, query, date_filter)
+    match count_sessions_with_query(&db, tools, project_filter, query, date_filter) {
+        Ok(count) => Ok(count),
+        Err(err) => {
+            if let Some(sanitized) = sanitize_search_query(query) {
+                tracing::warn!(
+                    "Date preset count query failed, retrying with sanitized query '{}': {}",
+                    sanitized,
+                    err
+                );
+                match count_sessions_with_query(&db, tools, project_filter, &sanitized, date_filter)
+                {
+                    Ok(count) => Ok(count),
+                    Err(retry_err) => {
+                        tracing::warn!(
+                            "Sanitized date preset count query failed '{}': {}",
+                            sanitized,
+                            retry_err
+                        );
+                        Ok(0)
+                    }
+                }
+            } else {
+                tracing::warn!(
+                    "Date preset count query failed and could not be sanitized: {}",
+                    err
+                );
+                Ok(0)
+            }
+        }
+    }
 }
 
 fn count_sessions_without_query(

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -153,7 +153,7 @@ fn date_filter_sql_clause(date_filter: &DateFilter, session_prefix: &str) -> (St
     };
 
     (
-        format!(" AND {session_prefix}start_time >= ? AND {session_prefix}start_time < ?"),
+        format!(" AND {session_prefix}last_updated >= ? AND {session_prefix}last_updated < ?"),
         vec![start.timestamp(), end.timestamp()],
     )
 }

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -10,8 +10,9 @@ use std::path::Path;
 use std::time::Duration;
 
 use crate::models::{
-    AiAssistant, MessagePreview, ProjectFilter, ProjectInfo, ReasoningAttachment, ReasoningPreview,
-    Role, Session, Subagent, ToolCall, ToolCallStatus, TranscriptItem, TranscriptItemKind,
+    AiAssistant, DateCounts, DateFilter, MessagePreview, ProjectFilter, ProjectInfo,
+    ReasoningAttachment, ReasoningPreview, Role, Session, Subagent, ToolCall, ToolCallStatus,
+    TranscriptItem, TranscriptItemKind,
 };
 
 pub use indexer::{IndexingStats, SessionIndexer};
@@ -146,11 +147,23 @@ fn sanitize_search_query(raw: &str) -> Option<String> {
     }
 }
 
+fn date_filter_sql_clause(date_filter: &DateFilter, session_prefix: &str) -> (String, Vec<i64>) {
+    let Some((start, end)) = date_filter.resolve(Utc::now()) else {
+        return (String::new(), Vec::new());
+    };
+
+    (
+        format!(" AND {session_prefix}start_time >= ? AND {session_prefix}start_time < ?"),
+        vec![start.timestamp(), end.timestamp()],
+    )
+}
+
 pub fn search_sessions_for_filter(
     db_path: &Path,
     tools: &[AiAssistant],
     project_filter: &ProjectFilter,
     query: &str,
+    date_filter: &DateFilter,
 ) -> Result<Vec<Session>> {
     if !db_path.exists() {
         return Ok(Vec::new());
@@ -162,12 +175,12 @@ pub fn search_sessions_for_filter(
 
     let query = query.trim();
     if query.is_empty() {
-        return load_sessions_for_filter(db_path, tools, project_filter);
+        return load_sessions_for_filter(db_path, tools, project_filter, date_filter);
     }
 
     let db = open_connection(db_path)?;
 
-    match search_sessions_with_query(&db, tools, project_filter, query) {
+    match search_sessions_with_query(&db, tools, project_filter, query, date_filter) {
         Ok(sessions) => Ok(sessions),
         Err(err) => {
             let sanitized = sanitize_search_query(query);
@@ -177,7 +190,13 @@ pub fn search_sessions_for_filter(
                     sanitized,
                     err
                 );
-                match search_sessions_with_query(&db, tools, project_filter, &sanitized) {
+                match search_sessions_with_query(
+                    &db,
+                    tools,
+                    project_filter,
+                    &sanitized,
+                    date_filter,
+                ) {
                     Ok(sessions) => Ok(sessions),
                     Err(retry_err) => {
                         tracing::warn!(
@@ -201,6 +220,7 @@ pub fn load_session_by_id_for_filter(
     tools: &[AiAssistant],
     project_filter: &ProjectFilter,
     session_id: &str,
+    date_filter: &DateFilter,
 ) -> Result<Vec<Session>> {
     if !db_path.exists() {
         return Ok(Vec::new());
@@ -216,6 +236,7 @@ pub fn load_session_by_id_for_filter(
     }
 
     let db = open_connection(db_path)?;
+    let (date_clause, date_values) = date_filter_sql_clause(date_filter, "");
 
     let project_clause = match project_filter {
         ProjectFilter::AllSessions => String::new(),
@@ -231,9 +252,9 @@ pub fn load_session_by_id_for_filter(
                  FROM sessions
                  WHERE id = ?
                    AND is_subagent = 0
-                    {}
-                 ORDER BY last_updated DESC",
-                SESSION_SELECT_COLUMNS, project_clause
+                     {}{}
+                  ORDER BY last_updated DESC",
+                SESSION_SELECT_COLUMNS, project_clause, date_clause
             ),
             vec![],
         )
@@ -247,11 +268,12 @@ pub fn load_session_by_id_for_filter(
                  WHERE id = ?
                    AND tool IN ({})
                    AND is_subagent = 0
-                    {}
-                 ORDER BY last_updated DESC",
+                     {}{}
+                  ORDER BY last_updated DESC",
                 SESSION_SELECT_COLUMNS,
                 placeholders.join(","),
-                project_clause
+                project_clause,
+                date_clause
             ),
             tool_strings,
         )
@@ -259,7 +281,7 @@ pub fn load_session_by_id_for_filter(
 
     let mut stmt = db.prepare(&query)?;
 
-    let mut params: Vec<&dyn ToSql> = Vec::with_capacity(2 + tool_strings.len());
+    let mut params: Vec<&dyn ToSql> = Vec::with_capacity(4 + tool_strings.len());
     params.push(&session_id);
     for tool in &tool_strings {
         params.push(tool as &dyn ToSql);
@@ -270,6 +292,9 @@ pub fn load_session_by_id_for_filter(
     };
     if let Some(project_id) = project_id.as_ref() {
         params.push(project_id as &dyn ToSql);
+    }
+    for value in &date_values {
+        params.push(value as &dyn ToSql);
     }
 
     let sessions = stmt
@@ -385,6 +410,7 @@ fn search_sessions_with_query(
     tools: &[AiAssistant],
     project_filter: &ProjectFilter,
     query: &str,
+    date_filter: &DateFilter,
 ) -> Result<Vec<Session>> {
     let project_clause = match project_filter {
         ProjectFilter::AllSessions => String::new(),
@@ -392,6 +418,7 @@ fn search_sessions_with_query(
         ProjectFilter::Project(_) => " AND s.project_id = ?".to_string(),
         ProjectFilter::Unassigned => " AND s.project_id IS NULL".to_string(),
     };
+    let (date_clause, date_values) = date_filter_sql_clause(date_filter, "s.");
 
     let (query_sql, tool_strings): (String, Vec<String>) = if tools.len() == AiAssistant::ALL.len()
     {
@@ -408,9 +435,9 @@ fn search_sessions_with_query(
                  JOIN sessions s ON s.id = m.session_id
                  WHERE messages_fts MATCH ?
                    AND s.is_subagent = 0
-                    {}
-                 ORDER BY rank ASC, s.last_updated DESC",
-                project_clause
+                     {}{}
+                  ORDER BY rank ASC, s.last_updated DESC",
+                project_clause, date_clause
             ),
             vec![],
         )
@@ -431,17 +458,18 @@ fn search_sessions_with_query(
                  WHERE messages_fts MATCH ?
                    AND s.tool IN ({})
                    AND s.is_subagent = 0
-                    {}
-                 ORDER BY rank ASC, s.last_updated DESC",
+                     {}{}
+                  ORDER BY rank ASC, s.last_updated DESC",
                 placeholders.join(","),
-                project_clause
+                project_clause,
+                date_clause
             ),
             tool_strings,
         )
     };
 
     let mut stmt = db.prepare(&query_sql)?;
-    let mut params: Vec<&dyn ToSql> = Vec::with_capacity(2 + tool_strings.len());
+    let mut params: Vec<&dyn ToSql> = Vec::with_capacity(4 + tool_strings.len());
     params.push(&query);
     for tool in &tool_strings {
         params.push(tool as &dyn ToSql);
@@ -452,6 +480,9 @@ fn search_sessions_with_query(
     };
     if let Some(project_id) = project_id.as_ref() {
         params.push(project_id as &dyn ToSql);
+    }
+    for value in &date_values {
+        params.push(value as &dyn ToSql);
     }
 
     let mut rows = stmt
@@ -474,6 +505,7 @@ pub fn load_sessions_for_filter(
     db_path: &Path,
     tools: &[AiAssistant],
     project_filter: &ProjectFilter,
+    date_filter: &DateFilter,
 ) -> Result<Vec<Session>> {
     if !db_path.exists() {
         return Ok(Vec::new());
@@ -484,6 +516,7 @@ pub fn load_sessions_for_filter(
     }
 
     let db = open_connection(db_path)?;
+    let (date_clause, date_values) = date_filter_sql_clause(date_filter, "");
 
     let project_clause = match project_filter {
         ProjectFilter::AllSessions => String::new(),
@@ -498,9 +531,9 @@ pub fn load_sessions_for_filter(
                 "SELECT {}
                  FROM sessions
                  WHERE is_subagent = 0
-                    {}
-                 ORDER BY last_updated DESC",
-                SESSION_SELECT_COLUMNS, project_clause
+                     {}{}
+                  ORDER BY last_updated DESC",
+                SESSION_SELECT_COLUMNS, project_clause, date_clause
             ),
             vec![],
         )
@@ -513,11 +546,12 @@ pub fn load_sessions_for_filter(
                  FROM sessions
                  WHERE tool IN ({})
                    AND is_subagent = 0
-                    {}
-                 ORDER BY last_updated DESC",
+                     {}{}
+                  ORDER BY last_updated DESC",
                 SESSION_SELECT_COLUMNS,
                 placeholders.join(","),
-                project_clause
+                project_clause,
+                date_clause
             ),
             tool_strings,
         )
@@ -525,7 +559,7 @@ pub fn load_sessions_for_filter(
 
     let mut stmt = db.prepare(&query)?;
 
-    let mut params: Vec<&dyn ToSql> = Vec::with_capacity(1 + tool_strings.len());
+    let mut params: Vec<&dyn ToSql> = Vec::with_capacity(3 + tool_strings.len());
     for tool in &tool_strings {
         params.push(tool as &dyn ToSql);
     }
@@ -536,6 +570,9 @@ pub fn load_sessions_for_filter(
     if let Some(project_id) = project_id.as_ref() {
         params.push(project_id as &dyn ToSql);
     }
+    for value in &date_values {
+        params.push(value as &dyn ToSql);
+    }
 
     let sessions = stmt
         .query_map(params.as_slice(), session_from_row)
@@ -544,6 +581,70 @@ pub fn load_sessions_for_filter(
         .context("Failed to load sessions")?;
 
     Ok(sessions)
+}
+
+pub fn count_sessions_per_date_preset(
+    db_path: &Path,
+    tools: &[AiAssistant],
+    project_filter: &ProjectFilter,
+    query: &str,
+) -> Result<DateCounts> {
+    Ok(DateCounts {
+        any_time: count_sessions_for_context(
+            db_path,
+            tools,
+            project_filter,
+            query,
+            &DateFilter::AnyTime,
+        )?,
+        today: count_sessions_for_context(
+            db_path,
+            tools,
+            project_filter,
+            query,
+            &DateFilter::Today,
+        )?,
+        last_7_days: count_sessions_for_context(
+            db_path,
+            tools,
+            project_filter,
+            query,
+            &DateFilter::Last7Days,
+        )?,
+        last_30_days: count_sessions_for_context(
+            db_path,
+            tools,
+            project_filter,
+            query,
+            &DateFilter::Last30Days,
+        )?,
+        this_year: count_sessions_for_context(
+            db_path,
+            tools,
+            project_filter,
+            query,
+            &DateFilter::ThisYear,
+        )?,
+    })
+}
+
+fn count_sessions_for_context(
+    db_path: &Path,
+    tools: &[AiAssistant],
+    project_filter: &ProjectFilter,
+    query: &str,
+    date_filter: &DateFilter,
+) -> Result<usize> {
+    if !db_path.exists() || tools.is_empty() {
+        return Ok(0);
+    }
+
+    let query = query.trim();
+    if query.is_empty() {
+        return Ok(load_sessions_for_filter(db_path, tools, project_filter, date_filter)?.len());
+    }
+
+    Ok(search_sessions_for_filter(db_path, tools, project_filter, query, date_filter)?.len())
 }
 
 pub fn load_projects(db_path: &Path, tools: &[AiAssistant]) -> Result<Vec<ProjectInfo>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ pub mod utils;
 
 // Re-export commonly used types
 pub use models::{
-    AiAssistant, AnalyticsData, AnalyticsOverview, Message, ProjectFilter, ProjectInfo, Role,
-    Session,
+    AiAssistant, AnalyticsData, AnalyticsOverview, DateCounts, DateFilter, Message, ProjectFilter,
+    ProjectInfo, Role, Session,
 };
 pub use session_sources::SessionSources;

--- a/src/models/date_filter.rs
+++ b/src/models/date_filter.rs
@@ -1,0 +1,188 @@
+use chrono::{DateTime, Datelike, Days, Local, NaiveDate, TimeZone, Utc};
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum DateFilter {
+    #[default]
+    AnyTime,
+    Today,
+    Last7Days,
+    Last30Days,
+    ThisYear,
+    Custom {
+        from: NaiveDate,
+        to: NaiveDate,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct DateCounts {
+    pub any_time: usize,
+    pub today: usize,
+    pub last_7_days: usize,
+    pub last_30_days: usize,
+    pub this_year: usize,
+}
+
+impl DateFilter {
+    pub fn resolve(&self, now: DateTime<Utc>) -> Option<(DateTime<Utc>, DateTime<Utc>)> {
+        let local_now = now.with_timezone(&Local);
+        let today = local_now.date_naive();
+
+        let (start_date, end_date) = match self {
+            Self::AnyTime => return None,
+            Self::Today => (today, today.checked_add_days(Days::new(1))?),
+            Self::Last7Days => (
+                today.checked_sub_days(Days::new(6))?,
+                today.checked_add_days(Days::new(1))?,
+            ),
+            Self::Last30Days => (
+                today.checked_sub_days(Days::new(29))?,
+                today.checked_add_days(Days::new(1))?,
+            ),
+            Self::ThisYear => (
+                NaiveDate::from_ymd_opt(today.year(), 1, 1)?,
+                NaiveDate::from_ymd_opt(today.year() + 1, 1, 1)?,
+            ),
+            Self::Custom { from, to } => (*from, to.checked_add_days(Days::new(1))?),
+        };
+
+        let start = local_midnight(start_date)?;
+        let end = local_midnight(end_date)?;
+
+        Some((start.with_timezone(&Utc), end.with_timezone(&Utc)))
+    }
+
+    pub fn pill_label(&self) -> String {
+        match self {
+            Self::AnyTime => String::new(),
+            Self::Today => "Today".to_string(),
+            Self::Last7Days => "Last 7 days".to_string(),
+            Self::Last30Days => "Last 30 days".to_string(),
+            Self::ThisYear => "This year".to_string(),
+            Self::Custom { from, to } if from == to => format_date(*from),
+            Self::Custom { from, to } => format!("{} - {}", format_date(*from), format_date(*to)),
+        }
+    }
+
+    pub fn is_active(&self) -> bool {
+        !matches!(self, Self::AnyTime)
+    }
+}
+
+fn local_midnight(date: NaiveDate) -> Option<DateTime<Local>> {
+    let naive = date.and_hms_opt(0, 0, 0)?;
+    Local
+        .from_local_datetime(&naive)
+        .single()
+        .or_else(|| Local.from_local_datetime(&naive).earliest())
+}
+
+fn format_date(date: NaiveDate) -> String {
+    date.format("%b %-d").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{Datelike, TimeZone};
+
+    fn utc(y: i32, m: u32, d: u32, h: u32, min: u32, s: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(y, m, d, h, min, s).single().unwrap()
+    }
+
+    #[test]
+    fn any_time_resolves_to_no_window_and_empty_label() {
+        let filter = DateFilter::AnyTime;
+
+        assert_eq!(filter.resolve(utc(2026, 5, 27, 12, 0, 0)), None);
+        assert_eq!(filter.pill_label(), "");
+        assert!(!filter.is_active());
+    }
+
+    #[test]
+    fn today_resolves_to_local_day_window() {
+        let now = utc(2026, 5, 27, 12, 34, 56);
+        let (start, end) = DateFilter::Today.resolve(now).unwrap();
+
+        assert!(start <= now);
+        assert!(end > now);
+        assert_eq!((end - start).num_hours(), 24);
+    }
+
+    #[test]
+    fn last_7_days_includes_today_and_six_prior_days() {
+        let now = utc(2026, 5, 27, 12, 0, 0);
+        let (start, end) = DateFilter::Last7Days.resolve(now).unwrap();
+
+        assert!(start <= now);
+        assert!(end > now);
+        assert_eq!((end - start).num_days(), 7);
+        assert_eq!(DateFilter::Last7Days.pill_label(), "Last 7 days");
+    }
+
+    #[test]
+    fn last_30_days_includes_today_and_twenty_nine_prior_days() {
+        let now = utc(2026, 5, 27, 12, 0, 0);
+        let (start, end) = DateFilter::Last30Days.resolve(now).unwrap();
+
+        assert!(start <= now);
+        assert!(end > now);
+        assert_eq!((end - start).num_days(), 30);
+        assert_eq!(DateFilter::Last30Days.pill_label(), "Last 30 days");
+    }
+
+    #[test]
+    fn this_year_starts_on_january_first_and_ends_next_year() {
+        let now = utc(2026, 12, 31, 23, 30, 0);
+        let (start, end) = DateFilter::ThisYear.resolve(now).unwrap();
+        let local_year = now.with_timezone(&chrono::Local).date_naive().year();
+
+        assert_eq!(start.with_timezone(&chrono::Local).date_naive().month(), 1);
+        assert_eq!(start.with_timezone(&chrono::Local).date_naive().day(), 1);
+        assert_eq!(
+            end.with_timezone(&chrono::Local).date_naive().year(),
+            local_year + 1
+        );
+        assert_eq!(DateFilter::ThisYear.pill_label(), "This year");
+    }
+
+    #[test]
+    fn custom_range_is_inclusive_of_both_dates() {
+        let filter = DateFilter::Custom {
+            from: NaiveDate::from_ymd_opt(2024, 2, 28).unwrap(),
+            to: NaiveDate::from_ymd_opt(2024, 2, 29).unwrap(),
+        };
+        let (start, end) = filter.resolve(utc(2024, 2, 29, 12, 0, 0)).unwrap();
+
+        assert_eq!(
+            start.with_timezone(&chrono::Local).date_naive(),
+            NaiveDate::from_ymd_opt(2024, 2, 28).unwrap()
+        );
+        assert_eq!(
+            end.with_timezone(&chrono::Local).date_naive(),
+            NaiveDate::from_ymd_opt(2024, 3, 1).unwrap()
+        );
+    }
+
+    #[test]
+    fn custom_same_day_label_uses_single_date() {
+        let date = NaiveDate::from_ymd_opt(2026, 4, 5).unwrap();
+        let filter = DateFilter::Custom {
+            from: date,
+            to: date,
+        };
+
+        assert_eq!(filter.pill_label(), "Apr 5");
+        assert!(filter.is_active());
+    }
+
+    #[test]
+    fn custom_range_label_uses_short_month_day_range() {
+        let filter = DateFilter::Custom {
+            from: NaiveDate::from_ymd_opt(2026, 4, 5).unwrap(),
+            to: NaiveDate::from_ymd_opt(2026, 4, 17).unwrap(),
+        };
+
+        assert_eq!(filter.pill_label(), "Apr 5 - Apr 17");
+    }
+}

--- a/src/models/date_filter.rs
+++ b/src/models/date_filter.rs
@@ -43,7 +43,13 @@ impl DateFilter {
                 NaiveDate::from_ymd_opt(today.year(), 1, 1)?,
                 NaiveDate::from_ymd_opt(today.year() + 1, 1, 1)?,
             ),
-            Self::Custom { from, to } => (*from, to.checked_add_days(Days::new(1))?),
+            Self::Custom { from, to } => {
+                if from > to {
+                    return None;
+                }
+
+                (*from, to.checked_add_days(Days::new(1))?)
+            }
         };
 
         let start = local_midnight(start_date)?;
@@ -103,20 +109,36 @@ mod tests {
     fn today_resolves_to_local_day_window() {
         let now = utc(2026, 5, 27, 12, 34, 56);
         let (start, end) = DateFilter::Today.resolve(now).unwrap();
+        let local_today = now.with_timezone(&chrono::Local).date_naive();
 
         assert!(start <= now);
         assert!(end > now);
-        assert_eq!((end - start).num_hours(), 24);
+        assert_eq!(
+            start.with_timezone(&chrono::Local).date_naive(),
+            local_today
+        );
+        assert_eq!(
+            end.with_timezone(&chrono::Local).date_naive(),
+            local_today.checked_add_days(Days::new(1)).unwrap()
+        );
     }
 
     #[test]
     fn last_7_days_includes_today_and_six_prior_days() {
         let now = utc(2026, 5, 27, 12, 0, 0);
         let (start, end) = DateFilter::Last7Days.resolve(now).unwrap();
+        let local_today = now.with_timezone(&chrono::Local).date_naive();
 
         assert!(start <= now);
         assert!(end > now);
-        assert_eq!((end - start).num_days(), 7);
+        assert_eq!(
+            start.with_timezone(&chrono::Local).date_naive(),
+            local_today.checked_sub_days(Days::new(6)).unwrap()
+        );
+        assert_eq!(
+            end.with_timezone(&chrono::Local).date_naive(),
+            local_today.checked_add_days(Days::new(1)).unwrap()
+        );
         assert_eq!(DateFilter::Last7Days.pill_label(), "Last 7 days");
     }
 
@@ -124,10 +146,18 @@ mod tests {
     fn last_30_days_includes_today_and_twenty_nine_prior_days() {
         let now = utc(2026, 5, 27, 12, 0, 0);
         let (start, end) = DateFilter::Last30Days.resolve(now).unwrap();
+        let local_today = now.with_timezone(&chrono::Local).date_naive();
 
         assert!(start <= now);
         assert!(end > now);
-        assert_eq!((end - start).num_days(), 30);
+        assert_eq!(
+            start.with_timezone(&chrono::Local).date_naive(),
+            local_today.checked_sub_days(Days::new(29)).unwrap()
+        );
+        assert_eq!(
+            end.with_timezone(&chrono::Local).date_naive(),
+            local_today.checked_add_days(Days::new(1)).unwrap()
+        );
         assert_eq!(DateFilter::Last30Days.pill_label(), "Last 30 days");
     }
 
@@ -172,17 +202,29 @@ mod tests {
             to: date,
         };
 
-        assert_eq!(filter.pill_label(), "Apr 5");
+        assert_eq!(filter.pill_label(), format_date(date));
         assert!(filter.is_active());
     }
 
     #[test]
     fn custom_range_label_uses_short_month_day_range() {
+        let from = NaiveDate::from_ymd_opt(2026, 4, 5).unwrap();
+        let to = NaiveDate::from_ymd_opt(2026, 4, 17).unwrap();
+        let filter = DateFilter::Custom { from, to };
+
+        assert_eq!(
+            filter.pill_label(),
+            format!("{} - {}", format_date(from), format_date(to))
+        );
+    }
+
+    #[test]
+    fn custom_range_with_from_after_to_resolves_to_none() {
         let filter = DateFilter::Custom {
-            from: NaiveDate::from_ymd_opt(2026, 4, 5).unwrap(),
-            to: NaiveDate::from_ymd_opt(2026, 4, 17).unwrap(),
+            from: NaiveDate::from_ymd_opt(2026, 4, 17).unwrap(),
+            to: NaiveDate::from_ymd_opt(2026, 4, 5).unwrap(),
         };
 
-        assert_eq!(filter.pill_label(), "Apr 5 - Apr 17");
+        assert_eq!(filter.resolve(utc(2026, 4, 17, 12, 0, 0)), None);
     }
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,4 +1,5 @@
 pub mod analytics;
+pub mod date_filter;
 pub mod indexing_diagnostics;
 pub mod message;
 pub mod message_preview;
@@ -11,6 +12,7 @@ pub mod tool_call;
 pub mod transcript_item;
 
 pub use analytics::{AnalyticsData, AnalyticsOverview};
+pub use date_filter::{DateCounts, DateFilter};
 pub use indexing_diagnostics::{IndexingError, IndexingRunResult, PerSourceResult, SourceStatus};
 pub use message::{Message, Role};
 pub use message_preview::MessagePreview;

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -12,6 +12,7 @@ pub mod tool_call;
 pub mod transcript_item;
 
 pub use analytics::{AnalyticsData, AnalyticsOverview};
+#[allow(unused_imports)]
 pub use date_filter::{DateCounts, DateFilter};
 pub use indexing_diagnostics::{IndexingError, IndexingRunResult, PerSourceResult, SourceStatus};
 pub use message::{Message, Role};

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -12,7 +12,6 @@ pub mod tool_call;
 pub mod transcript_item;
 
 pub use analytics::{AnalyticsData, AnalyticsOverview};
-#[allow(unused_imports)]
 pub use date_filter::{DateCounts, DateFilter};
 pub use indexing_diagnostics::{IndexingError, IndexingRunResult, PerSourceResult, SourceStatus};
 pub use message::{Message, Role};

--- a/src/ui/date_pill.rs
+++ b/src/ui/date_pill.rs
@@ -253,7 +253,7 @@ impl SimpleComponent for DatePill {
             }
             DatePillInput::CustomRangeRowSelected => {
                 self.custom_revealed = true;
-                self.select_current_row();
+                self.select_custom_row();
             }
             DatePillInput::CustomFromPicked(date) => {
                 self.custom_revealed = true;
@@ -303,10 +303,15 @@ impl DatePill {
     }
 
     fn select_current_row(&self) {
-        let Some(row) = self
-            .listbox
-            .row_at_index(current_row_index(&self.current_filter))
-        else {
+        self.select_row(current_row_index(&self.current_filter));
+    }
+
+    fn select_custom_row(&self) {
+        self.select_row(5);
+    }
+
+    fn select_row(&self, row_index: i32) {
+        let Some(row) = self.listbox.row_at_index(row_index) else {
             return;
         };
 
@@ -459,6 +464,22 @@ mod tests {
         None
     }
 
+    fn find_revealer(widget: &gtk::Widget) -> Option<gtk::Revealer> {
+        if let Ok(revealer) = widget.clone().downcast::<gtk::Revealer>() {
+            return Some(revealer);
+        }
+
+        let mut child = widget.first_child();
+        while let Some(child_widget) = child {
+            if let Some(found) = find_revealer(&child_widget) {
+                return Some(found);
+            }
+            child = child_widget.next_sibling();
+        }
+
+        None
+    }
+
     #[test]
     fn valid_custom_filter_requires_both_dates_in_order() {
         let from = NaiveDate::from_ymd_opt(2026, 5, 1).unwrap();
@@ -517,5 +538,29 @@ mod tests {
 
         let selected_row = list_box.selected_row().expect("selected preset row");
         assert_eq!(selected_row.index(), 3);
+    }
+
+    #[gtk::test]
+    fn custom_range_activation_keeps_custom_row_selected() {
+        let controller = DatePill::builder().launch(());
+
+        let window = gtk::Window::new();
+        window.set_child(Some(controller.widget()));
+        window.present();
+
+        let root = controller.widget().clone().upcast::<gtk::Widget>();
+        let list_box = find_list_box(&root).expect("date pill preset list");
+        let revealer = find_revealer(&root).expect("custom range revealer");
+
+        controller.emit(DatePillInput::PresetSelected(DateFilter::Last30Days));
+        controller.emit(DatePillInput::CustomRangeRowSelected);
+
+        pump_main_context(|| {
+            list_box.selected_row().map(|row| row.index()) == Some(5) && revealer.reveals_child()
+        });
+
+        let selected_row = list_box.selected_row().expect("selected custom row");
+        assert_eq!(selected_row.index(), 5);
+        assert!(revealer.reveals_child());
     }
 }

--- a/src/ui/date_pill.rs
+++ b/src/ui/date_pill.rs
@@ -12,21 +12,21 @@ pub struct DatePill {
     draft_from: Option<NaiveDate>,
     draft_to: Option<NaiveDate>,
     custom_revealed: bool,
-    root: gtk::MenuButton,
+    listbox: gtk::ListBox,
     popover: gtk::Popover,
 }
 
 #[derive(Debug, Clone)]
 pub enum DatePillInput {
-    SetFilter(DateFilter),
+    PopoverOpened,
     CountsReceived(DateCounts),
     OpenViaShortcut,
     PresetSelected(DateFilter),
-    CustomRequested,
-    DraftFromSelected(Option<NaiveDate>),
-    DraftToSelected(Option<NaiveDate>),
-    ClearDraft,
-    ApplyDraft,
+    CustomRangeRowSelected,
+    CustomFromPicked(NaiveDate),
+    CustomToPicked(NaiveDate),
+    CustomApplyClicked,
+    CustomClearClicked,
 }
 
 #[derive(Debug, Clone)]
@@ -52,7 +52,7 @@ pub struct DatePillWidgets {
 }
 
 impl SimpleComponent for DatePill {
-    type Init = DateFilter;
+    type Init = ();
     type Input = DatePillInput;
     type Output = DatePillOutput;
     type Root = gtk::MenuButton;
@@ -63,7 +63,7 @@ impl SimpleComponent for DatePill {
     }
 
     fn init(
-        current_filter: Self::Init,
+        _init: Self::Init,
         root: Self::Root,
         sender: ComponentSender<Self>,
     ) -> ComponentParts<Self> {
@@ -76,7 +76,7 @@ impl SimpleComponent for DatePill {
         button_content.append(&label);
 
         root.set_child(Some(&button_content));
-        root.set_tooltip_text(Some(&tooltip_for_filter(&current_filter)));
+        root.set_tooltip_text(Some(&tooltip_for_filter(&DateFilter::AnyTime)));
         root.add_css_class("flat");
 
         let popover = gtk::Popover::new();
@@ -84,7 +84,7 @@ impl SimpleComponent for DatePill {
 
         let listbox = gtk::ListBox::new();
         listbox.add_css_class("boxed-list");
-        listbox.set_selection_mode(gtk::SelectionMode::None);
+        listbox.set_selection_mode(gtk::SelectionMode::Browse);
 
         let any_time_count = gtk::Label::new(Some("0"));
         let today_count = gtk::Label::new(Some("0"));
@@ -140,10 +140,10 @@ impl SimpleComponent for DatePill {
         content.append(&custom_revealer);
         popover.set_child(Some(&content));
 
-        let output_sender = sender.output_sender().clone();
+        let input_sender = sender.input_sender().clone();
         popover.connect_visible_notify(move |popover| {
             if popover.is_visible() {
-                output_sender.send(DatePillOutput::CountsRequested).ok();
+                input_sender.send(DatePillInput::PopoverOpened).ok();
             }
         });
 
@@ -165,46 +165,46 @@ impl SimpleComponent for DatePill {
                 4 => input_sender
                     .send(DatePillInput::PresetSelected(DateFilter::ThisYear))
                     .ok(),
-                5 => input_sender.send(DatePillInput::CustomRequested).ok(),
+                5 => input_sender
+                    .send(DatePillInput::CustomRangeRowSelected)
+                    .ok(),
                 _ => None,
             };
         });
 
         let input_sender = sender.input_sender().clone();
         from_calendar.connect_day_selected(move |calendar| {
-            input_sender
-                .send(DatePillInput::DraftFromSelected(calendar_to_naive_date(
-                    &calendar.date(),
-                )))
-                .ok();
+            if let Some(date) = calendar_to_naive_date(&calendar.date()) {
+                input_sender
+                    .send(DatePillInput::CustomFromPicked(date))
+                    .ok();
+            }
         });
 
         let input_sender = sender.input_sender().clone();
         to_calendar.connect_day_selected(move |calendar| {
-            input_sender
-                .send(DatePillInput::DraftToSelected(calendar_to_naive_date(
-                    &calendar.date(),
-                )))
-                .ok();
+            if let Some(date) = calendar_to_naive_date(&calendar.date()) {
+                input_sender.send(DatePillInput::CustomToPicked(date)).ok();
+            }
         });
 
         let input_sender = sender.input_sender().clone();
         clear_button.connect_clicked(move |_| {
-            input_sender.send(DatePillInput::ClearDraft).ok();
+            input_sender.send(DatePillInput::CustomClearClicked).ok();
         });
 
         let input_sender = sender.input_sender().clone();
         apply_button.connect_clicked(move |_| {
-            input_sender.send(DatePillInput::ApplyDraft).ok();
+            input_sender.send(DatePillInput::CustomApplyClicked).ok();
         });
 
         let model = Self {
-            current_filter,
+            current_filter: DateFilter::AnyTime,
             counts: DateCounts::default(),
             draft_from: None,
             draft_to: None,
             custom_revealed: false,
-            root: root.clone(),
+            listbox: listbox.clone(),
             popover: popover.clone(),
         };
 
@@ -233,42 +233,45 @@ impl SimpleComponent for DatePill {
 
     fn update(&mut self, message: Self::Input, sender: ComponentSender<Self>) {
         match message {
-            DatePillInput::SetFilter(filter) => {
-                self.current_filter = filter;
-                self.custom_revealed = matches!(self.current_filter, DateFilter::Custom { .. });
+            DatePillInput::PopoverOpened => {
+                self.select_current_row();
+                sender.output(DatePillOutput::CountsRequested).ok();
             }
             DatePillInput::CountsReceived(counts) => {
                 self.counts = counts;
             }
             DatePillInput::OpenViaShortcut => {
-                self.root.grab_focus();
                 self.popover.popup();
+                self.focus_current_row_when_ready();
             }
             DatePillInput::PresetSelected(filter) => {
                 self.current_filter = filter.clone();
                 self.custom_revealed = false;
+                self.select_current_row();
                 sender.output(DatePillOutput::FilterChanged(filter)).ok();
                 self.popover.popdown();
             }
-            DatePillInput::CustomRequested => {
+            DatePillInput::CustomRangeRowSelected => {
                 self.custom_revealed = true;
+                self.select_current_row();
             }
-            DatePillInput::DraftFromSelected(date) => {
+            DatePillInput::CustomFromPicked(date) => {
                 self.custom_revealed = true;
-                self.draft_from = date;
+                self.draft_from = Some(date);
             }
-            DatePillInput::DraftToSelected(date) => {
+            DatePillInput::CustomToPicked(date) => {
                 self.custom_revealed = true;
-                self.draft_to = date;
+                self.draft_to = Some(date);
             }
-            DatePillInput::ClearDraft => {
+            DatePillInput::CustomClearClicked => {
                 self.draft_from = None;
                 self.draft_to = None;
             }
-            DatePillInput::ApplyDraft => {
+            DatePillInput::CustomApplyClicked => {
                 if let Some(filter) = valid_custom_filter(self.draft_from, self.draft_to) {
                     self.current_filter = filter.clone();
                     self.custom_revealed = false;
+                    self.select_current_row();
                     sender.output(DatePillOutput::FilterChanged(filter)).ok();
                     self.popover.popdown();
                 }
@@ -284,6 +287,34 @@ impl SimpleComponent for DatePill {
 }
 
 impl DatePill {
+    fn focus_current_row_when_ready(&self) {
+        let listbox = self.listbox.clone();
+        let row_index = current_row_index(&self.current_filter);
+
+        glib::idle_add_local_once(move || {
+            let Some(row) = listbox.row_at_index(row_index) else {
+                return;
+            };
+
+            listbox.select_row(Some(&row));
+            listbox.grab_focus();
+            row.grab_focus();
+        });
+    }
+
+    fn select_current_row(&self) {
+        let Some(row) = self
+            .listbox
+            .row_at_index(current_row_index(&self.current_filter))
+        else {
+            return;
+        };
+
+        self.listbox.select_row(Some(&row));
+        self.listbox.grab_focus();
+        row.grab_focus();
+    }
+
     fn sync_button(&self, widgets: &DatePillWidgets) {
         let label = self.current_filter.pill_label();
         widgets.label.set_label(&label);
@@ -324,6 +355,17 @@ impl DatePill {
     }
 }
 
+fn current_row_index(filter: &DateFilter) -> i32 {
+    match filter {
+        DateFilter::AnyTime => 0,
+        DateFilter::Today => 1,
+        DateFilter::Last7Days => 2,
+        DateFilter::Last30Days => 3,
+        DateFilter::ThisYear => 4,
+        DateFilter::Custom { .. } => 5,
+    }
+}
+
 fn build_preset_row(title: &str, count_label: &gtk::Label) -> gtk::ListBoxRow {
     count_label.add_css_class("dim-label");
     count_label.set_xalign(1.0);
@@ -341,6 +383,7 @@ fn build_preset_row(title: &str, count_label: &gtk::Label) -> gtk::ListBoxRow {
 
     let row = gtk::ListBoxRow::new();
     row.set_activatable(true);
+    row.set_focusable(true);
     row.set_child(Some(&row_box));
     row
 }
@@ -379,6 +422,42 @@ fn calendar_to_naive_date(date: &glib::DateTime) -> Option<NaiveDate> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use relm4::{Component, ComponentController};
+    use std::time::{Duration, Instant};
+
+    fn pump_main_context(condition: impl Fn() -> bool) {
+        let context = glib::MainContext::default();
+        let deadline = Instant::now() + Duration::from_secs(2);
+
+        while !condition() {
+            assert!(
+                Instant::now() < deadline,
+                "condition not met before timeout"
+            );
+
+            while context.pending() {
+                context.iteration(false);
+            }
+
+            context.iteration(true);
+        }
+    }
+
+    fn find_list_box(widget: &gtk::Widget) -> Option<gtk::ListBox> {
+        if let Ok(list_box) = widget.clone().downcast::<gtk::ListBox>() {
+            return Some(list_box);
+        }
+
+        let mut child = widget.first_child();
+        while let Some(child_widget) = child {
+            if let Some(found) = find_list_box(&child_widget) {
+                return Some(found);
+            }
+            child = child_widget.next_sibling();
+        }
+
+        None
+    }
 
     #[test]
     fn valid_custom_filter_requires_both_dates_in_order() {
@@ -409,5 +488,34 @@ mod tests {
             tooltip_for_filter(&custom),
             format!("Date: {}", custom.pill_label())
         );
+    }
+
+    #[gtk::test]
+    fn preset_list_is_selectable_for_shortcut_navigation() {
+        let controller = DatePill::builder().launch(());
+        let root = controller.widget().clone().upcast::<gtk::Widget>();
+        let list_box = find_list_box(&root).expect("date pill preset list");
+
+        assert_eq!(list_box.selection_mode(), gtk::SelectionMode::Browse);
+    }
+
+    #[gtk::test]
+    fn open_via_shortcut_selects_current_preset_row() {
+        let controller = DatePill::builder().launch(());
+
+        let window = gtk::Window::new();
+        window.set_child(Some(controller.widget()));
+        window.present();
+
+        let root = controller.widget().clone().upcast::<gtk::Widget>();
+        let list_box = find_list_box(&root).expect("date pill preset list");
+
+        controller.emit(DatePillInput::PresetSelected(DateFilter::Last30Days));
+        controller.emit(DatePillInput::OpenViaShortcut);
+
+        pump_main_context(|| list_box.selected_row().map(|row| row.index()) == Some(3));
+
+        let selected_row = list_box.selected_row().expect("selected preset row");
+        assert_eq!(selected_row.index(), 3);
     }
 }

--- a/src/ui/date_pill.rs
+++ b/src/ui/date_pill.rs
@@ -234,7 +234,7 @@ impl SimpleComponent for DatePill {
     fn update(&mut self, message: Self::Input, sender: ComponentSender<Self>) {
         match message {
             DatePillInput::PopoverOpened => {
-                self.select_current_row();
+                self.focus_current_row_when_ready();
                 sender.output(DatePillOutput::CountsRequested).ok();
             }
             DatePillInput::CountsReceived(counts) => {

--- a/src/ui/date_pill.rs
+++ b/src/ui/date_pill.rs
@@ -1,0 +1,413 @@
+use chrono::NaiveDate;
+use relm4::{ComponentParts, ComponentSender, SimpleComponent, gtk};
+
+use gtk::glib;
+use gtk::prelude::*;
+
+use crate::models::{DateCounts, DateFilter};
+
+pub struct DatePill {
+    current_filter: DateFilter,
+    counts: DateCounts,
+    draft_from: Option<NaiveDate>,
+    draft_to: Option<NaiveDate>,
+    custom_revealed: bool,
+    root: gtk::MenuButton,
+    popover: gtk::Popover,
+}
+
+#[derive(Debug, Clone)]
+pub enum DatePillInput {
+    SetFilter(DateFilter),
+    CountsReceived(DateCounts),
+    OpenViaShortcut,
+    PresetSelected(DateFilter),
+    CustomRequested,
+    DraftFromSelected(Option<NaiveDate>),
+    DraftToSelected(Option<NaiveDate>),
+    ClearDraft,
+    ApplyDraft,
+}
+
+#[derive(Debug, Clone)]
+pub enum DatePillOutput {
+    FilterChanged(DateFilter),
+    CountsRequested,
+}
+
+pub struct DatePillWidgets {
+    root: gtk::MenuButton,
+    popover: gtk::Popover,
+    label: gtk::Label,
+    custom_revealer: gtk::Revealer,
+    from_calendar: gtk::Calendar,
+    to_calendar: gtk::Calendar,
+    info_label: gtk::Label,
+    apply_button: gtk::Button,
+    any_time_count: gtk::Label,
+    today_count: gtk::Label,
+    last_7_days_count: gtk::Label,
+    last_30_days_count: gtk::Label,
+    this_year_count: gtk::Label,
+}
+
+impl SimpleComponent for DatePill {
+    type Init = DateFilter;
+    type Input = DatePillInput;
+    type Output = DatePillOutput;
+    type Root = gtk::MenuButton;
+    type Widgets = DatePillWidgets;
+
+    fn init_root() -> Self::Root {
+        gtk::MenuButton::new()
+    }
+
+    fn init(
+        current_filter: Self::Init,
+        root: Self::Root,
+        sender: ComponentSender<Self>,
+    ) -> ComponentParts<Self> {
+        let icon = gtk::Image::from_icon_name("x-office-calendar-symbolic");
+        let label = gtk::Label::new(None);
+        label.set_visible(false);
+
+        let button_content = gtk::Box::new(gtk::Orientation::Horizontal, 6);
+        button_content.append(&icon);
+        button_content.append(&label);
+
+        root.set_child(Some(&button_content));
+        root.set_tooltip_text(Some(&tooltip_for_filter(&current_filter)));
+        root.add_css_class("flat");
+
+        let popover = gtk::Popover::new();
+        root.set_popover(Some(&popover));
+
+        let listbox = gtk::ListBox::new();
+        listbox.add_css_class("boxed-list");
+        listbox.set_selection_mode(gtk::SelectionMode::None);
+
+        let any_time_count = gtk::Label::new(Some("0"));
+        let today_count = gtk::Label::new(Some("0"));
+        let last_7_days_count = gtk::Label::new(Some("0"));
+        let last_30_days_count = gtk::Label::new(Some("0"));
+        let this_year_count = gtk::Label::new(Some("0"));
+
+        listbox.append(&build_preset_row("Any time", &any_time_count));
+        listbox.append(&build_preset_row("Today", &today_count));
+        listbox.append(&build_preset_row("Last 7 days", &last_7_days_count));
+        listbox.append(&build_preset_row("Last 30 days", &last_30_days_count));
+        listbox.append(&build_preset_row("This year", &this_year_count));
+        listbox.append(&build_preset_row("Custom range...", &gtk::Label::new(None)));
+
+        let from_calendar = gtk::Calendar::new();
+        let to_calendar = gtk::Calendar::new();
+
+        let calendars = gtk::Box::new(gtk::Orientation::Horizontal, 12);
+        calendars.append(&from_calendar);
+        calendars.append(&to_calendar);
+
+        let info_label = gtk::Label::new(Some(&custom_info_text(None, None)));
+        info_label.set_xalign(0.0);
+        info_label.set_wrap(true);
+
+        let clear_button = gtk::Button::with_label("Clear");
+        let apply_button = gtk::Button::with_label("Apply");
+        apply_button.add_css_class("suggested-action");
+        apply_button.set_sensitive(false);
+
+        let actions = gtk::Box::new(gtk::Orientation::Horizontal, 6);
+        actions.set_halign(gtk::Align::End);
+        actions.append(&clear_button);
+        actions.append(&apply_button);
+
+        let custom_box = gtk::Box::new(gtk::Orientation::Vertical, 12);
+        custom_box.set_margin_top(12);
+        custom_box.append(&calendars);
+        custom_box.append(&info_label);
+        custom_box.append(&actions);
+
+        let custom_revealer = gtk::Revealer::new();
+        custom_revealer.set_transition_type(gtk::RevealerTransitionType::SlideDown);
+        custom_revealer.set_child(Some(&custom_box));
+        custom_revealer.set_reveal_child(false);
+
+        let content = gtk::Box::new(gtk::Orientation::Vertical, 0);
+        content.set_margin_top(12);
+        content.set_margin_bottom(12);
+        content.set_margin_start(12);
+        content.set_margin_end(12);
+        content.append(&listbox);
+        content.append(&custom_revealer);
+        popover.set_child(Some(&content));
+
+        let output_sender = sender.output_sender().clone();
+        popover.connect_visible_notify(move |popover| {
+            if popover.is_visible() {
+                output_sender.send(DatePillOutput::CountsRequested).ok();
+            }
+        });
+
+        let input_sender = sender.input_sender().clone();
+        listbox.connect_row_activated(move |_list, row| {
+            match row.index() {
+                0 => input_sender
+                    .send(DatePillInput::PresetSelected(DateFilter::AnyTime))
+                    .ok(),
+                1 => input_sender
+                    .send(DatePillInput::PresetSelected(DateFilter::Today))
+                    .ok(),
+                2 => input_sender
+                    .send(DatePillInput::PresetSelected(DateFilter::Last7Days))
+                    .ok(),
+                3 => input_sender
+                    .send(DatePillInput::PresetSelected(DateFilter::Last30Days))
+                    .ok(),
+                4 => input_sender
+                    .send(DatePillInput::PresetSelected(DateFilter::ThisYear))
+                    .ok(),
+                5 => input_sender.send(DatePillInput::CustomRequested).ok(),
+                _ => None,
+            };
+        });
+
+        let input_sender = sender.input_sender().clone();
+        from_calendar.connect_day_selected(move |calendar| {
+            input_sender
+                .send(DatePillInput::DraftFromSelected(calendar_to_naive_date(
+                    &calendar.date(),
+                )))
+                .ok();
+        });
+
+        let input_sender = sender.input_sender().clone();
+        to_calendar.connect_day_selected(move |calendar| {
+            input_sender
+                .send(DatePillInput::DraftToSelected(calendar_to_naive_date(
+                    &calendar.date(),
+                )))
+                .ok();
+        });
+
+        let input_sender = sender.input_sender().clone();
+        clear_button.connect_clicked(move |_| {
+            input_sender.send(DatePillInput::ClearDraft).ok();
+        });
+
+        let input_sender = sender.input_sender().clone();
+        apply_button.connect_clicked(move |_| {
+            input_sender.send(DatePillInput::ApplyDraft).ok();
+        });
+
+        let model = Self {
+            current_filter,
+            counts: DateCounts::default(),
+            draft_from: None,
+            draft_to: None,
+            custom_revealed: false,
+            root: root.clone(),
+            popover: popover.clone(),
+        };
+
+        let widgets = DatePillWidgets {
+            root,
+            popover,
+            label,
+            custom_revealer,
+            from_calendar,
+            to_calendar,
+            info_label,
+            apply_button,
+            any_time_count,
+            today_count,
+            last_7_days_count,
+            last_30_days_count,
+            this_year_count,
+        };
+
+        model.sync_button(&widgets);
+        model.sync_counts(&widgets);
+        model.sync_custom_state(&widgets);
+
+        ComponentParts { model, widgets }
+    }
+
+    fn update(&mut self, message: Self::Input, sender: ComponentSender<Self>) {
+        match message {
+            DatePillInput::SetFilter(filter) => {
+                self.current_filter = filter;
+                self.custom_revealed = matches!(self.current_filter, DateFilter::Custom { .. });
+            }
+            DatePillInput::CountsReceived(counts) => {
+                self.counts = counts;
+            }
+            DatePillInput::OpenViaShortcut => {
+                self.root.grab_focus();
+                self.popover.popup();
+            }
+            DatePillInput::PresetSelected(filter) => {
+                self.current_filter = filter.clone();
+                self.custom_revealed = false;
+                sender.output(DatePillOutput::FilterChanged(filter)).ok();
+                self.popover.popdown();
+            }
+            DatePillInput::CustomRequested => {
+                self.custom_revealed = true;
+            }
+            DatePillInput::DraftFromSelected(date) => {
+                self.custom_revealed = true;
+                self.draft_from = date;
+            }
+            DatePillInput::DraftToSelected(date) => {
+                self.custom_revealed = true;
+                self.draft_to = date;
+            }
+            DatePillInput::ClearDraft => {
+                self.draft_from = None;
+                self.draft_to = None;
+            }
+            DatePillInput::ApplyDraft => {
+                if let Some(filter) = valid_custom_filter(self.draft_from, self.draft_to) {
+                    self.current_filter = filter.clone();
+                    self.custom_revealed = false;
+                    sender.output(DatePillOutput::FilterChanged(filter)).ok();
+                    self.popover.popdown();
+                }
+            }
+        }
+    }
+
+    fn update_view(&self, widgets: &mut Self::Widgets, _sender: ComponentSender<Self>) {
+        self.sync_button(widgets);
+        self.sync_counts(widgets);
+        self.sync_custom_state(widgets);
+    }
+}
+
+impl DatePill {
+    fn sync_button(&self, widgets: &DatePillWidgets) {
+        let label = self.current_filter.pill_label();
+        widgets.label.set_label(&label);
+        widgets.label.set_visible(self.current_filter.is_active());
+        widgets
+            .root
+            .set_tooltip_text(Some(&tooltip_for_filter(&self.current_filter)));
+    }
+
+    fn sync_counts(&self, widgets: &DatePillWidgets) {
+        widgets
+            .any_time_count
+            .set_label(&self.counts.any_time.to_string());
+        widgets
+            .today_count
+            .set_label(&self.counts.today.to_string());
+        widgets
+            .last_7_days_count
+            .set_label(&self.counts.last_7_days.to_string());
+        widgets
+            .last_30_days_count
+            .set_label(&self.counts.last_30_days.to_string());
+        widgets
+            .this_year_count
+            .set_label(&self.counts.this_year.to_string());
+    }
+
+    fn sync_custom_state(&self, widgets: &DatePillWidgets) {
+        widgets
+            .custom_revealer
+            .set_reveal_child(self.custom_revealed);
+        widgets
+            .info_label
+            .set_label(&custom_info_text(self.draft_from, self.draft_to));
+        widgets
+            .apply_button
+            .set_sensitive(valid_custom_filter(self.draft_from, self.draft_to).is_some());
+    }
+}
+
+fn build_preset_row(title: &str, count_label: &gtk::Label) -> gtk::ListBoxRow {
+    count_label.add_css_class("dim-label");
+    count_label.set_xalign(1.0);
+
+    let title_label = gtk::Label::new(Some(title));
+    title_label.set_xalign(0.0);
+
+    let row_box = gtk::Box::new(gtk::Orientation::Horizontal, 12);
+    row_box.set_margin_top(8);
+    row_box.set_margin_bottom(8);
+    row_box.set_margin_start(12);
+    row_box.set_margin_end(12);
+    row_box.append(&title_label);
+    row_box.append(count_label);
+
+    let row = gtk::ListBoxRow::new();
+    row.set_activatable(true);
+    row.set_child(Some(&row_box));
+    row
+}
+
+fn tooltip_for_filter(filter: &DateFilter) -> String {
+    if filter.is_active() {
+        format!("Date: {}", filter.pill_label())
+    } else {
+        "Filter by date (Ctrl+Shift+D)".to_string()
+    }
+}
+
+fn valid_custom_filter(from: Option<NaiveDate>, to: Option<NaiveDate>) -> Option<DateFilter> {
+    match (from, to) {
+        (Some(from), Some(to)) if from <= to => Some(DateFilter::Custom { from, to }),
+        _ => None,
+    }
+}
+
+fn custom_info_text(from: Option<NaiveDate>, to: Option<NaiveDate>) -> String {
+    match (from, to) {
+        (Some(from), Some(to)) if from <= to => DateFilter::Custom { from, to }.pill_label(),
+        (Some(_), Some(_)) => "Start date must be on or before end date".to_string(),
+        _ => "Choose a start and end date to apply a custom range".to_string(),
+    }
+}
+
+fn calendar_to_naive_date(date: &glib::DateTime) -> Option<NaiveDate> {
+    NaiveDate::from_ymd_opt(
+        date.year(),
+        u32::try_from(date.month()).ok()?,
+        u32::try_from(date.day_of_month()).ok()?,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_custom_filter_requires_both_dates_in_order() {
+        let from = NaiveDate::from_ymd_opt(2026, 5, 1).unwrap();
+        let to = NaiveDate::from_ymd_opt(2026, 5, 7).unwrap();
+
+        assert_eq!(valid_custom_filter(None, Some(to)), None);
+        assert_eq!(valid_custom_filter(Some(from), None), None);
+        assert_eq!(valid_custom_filter(Some(to), Some(from)), None);
+        assert_eq!(
+            valid_custom_filter(Some(from), Some(to)),
+            Some(DateFilter::Custom { from, to })
+        );
+    }
+
+    #[test]
+    fn tooltip_reflects_active_filter() {
+        let custom = DateFilter::Custom {
+            from: NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
+            to: NaiveDate::from_ymd_opt(2026, 5, 7).unwrap(),
+        };
+
+        assert_eq!(
+            tooltip_for_filter(&DateFilter::AnyTime),
+            "Filter by date (Ctrl+Shift+D)"
+        );
+        assert_eq!(
+            tooltip_for_filter(&custom),
+            format!("Date: {}", custom.pill_label())
+        );
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,6 +1,7 @@
 pub mod activity_bar;
 pub mod analytics_heatmap;
 pub mod analytics_view;
+pub mod date_pill;
 pub mod format;
 pub mod highlight;
 pub mod markdown;

--- a/src/ui/modals/shortcuts.rs
+++ b/src/ui/modals/shortcuts.rs
@@ -46,6 +46,10 @@ impl SimpleComponent for ShortcutsDialog {
         // Search section
         let search = adw::ShortcutsSection::new(Some(&gettext("Search")));
         search.add(adw::ShortcutsItem::new(&gettext("Search"), "<Control>f"));
+        search.add(adw::ShortcutsItem::new(
+            &gettext("Filter by date"),
+            "<Control><Shift>d",
+        ));
         widgets.add(search);
 
         // View section

--- a/src/ui/session_list.rs
+++ b/src/ui/session_list.rs
@@ -28,6 +28,7 @@ pub struct SessionList {
     db_path: PathBuf,
     active_tools: Vec<AiAssistant>,
     project_filter: ProjectFilter,
+    date_filter: DateFilter,
     search_query: String,
     all_tools_selected: bool,
     indexing: bool,
@@ -47,6 +48,7 @@ pub enum SessionListMsg {
         project_filter: ProjectFilter,
     },
     SetSearchQuery(String),
+    DateFilterChanged(DateFilter),
     Reload,
     ReloadAfterIndexing {
         assistants: Vec<AiAssistant>,
@@ -532,7 +534,14 @@ impl SimpleComponent for SessionList {
         ];
         let search_query = String::new();
         let project_filter = ProjectFilter::AllSessions;
-        let fetched = Self::fetch_sessions(&db_path, &active_tools, &project_filter, &search_query);
+        let date_filter = DateFilter::AnyTime;
+        let fetched = Self::fetch_sessions(
+            &db_path,
+            &active_tools,
+            &project_filter,
+            &date_filter,
+            &search_query,
+        );
 
         let sessions: FactoryVecDeque<SessionRow> = FactoryVecDeque::builder()
             .launch_default()
@@ -547,6 +556,7 @@ impl SimpleComponent for SessionList {
             db_path,
             active_tools,
             project_filter,
+            date_filter,
             search_query,
             all_tools_selected: true,
             indexing: false,
@@ -626,6 +636,14 @@ impl SimpleComponent for SessionList {
                 }
 
                 self.search_query = query;
+                self.reload_sessions();
+            }
+            SessionListMsg::DateFilterChanged(date_filter) => {
+                if self.date_filter == date_filter {
+                    return;
+                }
+
+                self.date_filter = date_filter;
                 self.reload_sessions();
             }
             SessionListMsg::Reload => {
@@ -815,21 +833,16 @@ impl SessionList {
         db_path: &Path,
         tools: &[AiAssistant],
         project_filter: &ProjectFilter,
+        date_filter: &DateFilter,
         query: &str,
     ) -> Vec<Session> {
         let query = query.trim();
         let sessions = if query.is_empty() {
-            load_sessions_for_filter(db_path, tools, project_filter, &DateFilter::AnyTime)
+            load_sessions_for_filter(db_path, tools, project_filter, date_filter)
         } else if let Some(session_id) = parse_session_id_query(query) {
-            load_session_by_id_for_filter(
-                db_path,
-                tools,
-                project_filter,
-                session_id,
-                &DateFilter::AnyTime,
-            )
+            load_session_by_id_for_filter(db_path, tools, project_filter, session_id, date_filter)
         } else {
-            search_sessions_for_filter(db_path, tools, project_filter, query, &DateFilter::AnyTime)
+            search_sessions_for_filter(db_path, tools, project_filter, query, date_filter)
         };
 
         match sessions {
@@ -1182,6 +1195,7 @@ impl SessionList {
             &self.db_path,
             &self.active_tools,
             &self.project_filter,
+            &self.date_filter,
             &self.search_query,
         );
         let fetch_duration = fetch_started_at.elapsed();
@@ -1230,6 +1244,7 @@ impl SessionList {
             &self.db_path,
             &self.active_tools,
             &self.project_filter,
+            &self.date_filter,
             &self.search_query,
         );
 
@@ -1256,7 +1271,7 @@ impl SessionList {
 mod tests {
     use super::*;
     use crate::database::schema::initialize_database;
-    use crate::models::ProjectFilter;
+    use crate::models::{DateFilter, ProjectFilter};
     use gtk::glib::prelude::ObjectExt;
     use relm4::Component;
     use relm4::ComponentController;
@@ -2733,6 +2748,27 @@ mod tests {
                 .iter()
                 .any(|output| matches!(output, SessionListOutput::SessionSelected(_)))
         );
+    }
+
+    #[gtk::test]
+    fn date_filter_changed_reloads_visible_rows() {
+        let temp_db = TempDatabase::new();
+        temp_db.seed_project_sidebar_fixture();
+
+        let controller = SessionList::builder().launch(temp_db.path.clone());
+
+        controller.emit(SessionListMsg::DateFilterChanged(DateFilter::Custom {
+            from: chrono::NaiveDate::from_ymd_opt(2000, 1, 1).unwrap(),
+            to: chrono::NaiveDate::from_ymd_opt(2000, 1, 1).unwrap(),
+        }));
+
+        pump_main_context(|| {
+            let parts = controller.state().get();
+            parts.model.sessions.is_empty()
+        });
+
+        let parts = controller.state().get();
+        assert!(parts.model.sessions.is_empty());
     }
 
     fn make_test_session(id: &str) -> Session {

--- a/src/ui/session_list.rs
+++ b/src/ui/session_list.rs
@@ -18,7 +18,9 @@ use std::{
 use crate::database::{
     load_session_by_id_for_filter, load_sessions_for_filter, search_sessions_for_filter,
 };
-use crate::models::{AiAssistant, PerSourceResult, ProjectFilter, Session, SourceStatus};
+use crate::models::{
+    AiAssistant, DateFilter, PerSourceResult, ProjectFilter, Session, SourceStatus,
+};
 use crate::ui::session_row::{SessionRow, SessionRowInit, SessionRowOutput};
 
 #[derive(Debug)]
@@ -817,11 +819,17 @@ impl SessionList {
     ) -> Vec<Session> {
         let query = query.trim();
         let sessions = if query.is_empty() {
-            load_sessions_for_filter(db_path, tools, project_filter)
+            load_sessions_for_filter(db_path, tools, project_filter, &DateFilter::AnyTime)
         } else if let Some(session_id) = parse_session_id_query(query) {
-            load_session_by_id_for_filter(db_path, tools, project_filter, session_id)
+            load_session_by_id_for_filter(
+                db_path,
+                tools,
+                project_filter,
+                session_id,
+                &DateFilter::AnyTime,
+            )
         } else {
-            search_sessions_for_filter(db_path, tools, project_filter, query)
+            search_sessions_for_filter(db_path, tools, project_filter, query, &DateFilter::AnyTime)
         };
 
         match sessions {

--- a/tests/date_filter.rs
+++ b/tests/date_filter.rs
@@ -267,6 +267,26 @@ fn count_sessions_per_date_preset_query_counts_distinct_sessions() {
 }
 
 #[test]
+fn count_sessions_per_date_preset_sanitizes_invalid_query() {
+    let db = TempDatabase::new("date-filter-counts-invalid-query");
+    seed_date_dataset(&db);
+
+    let counts = count_sessions_per_date_preset(
+        &db.path,
+        &[AiAssistant::ClaudeCode],
+        &ProjectFilter::Project(1),
+        "\"alpha",
+    )
+    .expect("date counts should succeed with sanitized query");
+
+    assert_eq!(counts.any_time, 5);
+    assert_eq!(counts.today, 2);
+    assert_eq!(counts.last_7_days, 3);
+    assert_eq!(counts.last_30_days, 5);
+    assert!(counts.this_year >= counts.last_30_days);
+}
+
+#[test]
 fn custom_date_bounds_include_both_ends() {
     let db = TempDatabase::new("date-filter-inclusive");
     let from = NaiveDate::from_ymd_opt(2025, 1, 10).unwrap();

--- a/tests/date_filter.rs
+++ b/tests/date_filter.rs
@@ -1,6 +1,6 @@
 mod helpers;
 
-use chrono::{Days, Local, NaiveDate, TimeZone, Utc};
+use chrono::{Days, Duration, Local, NaiveDate, TimeZone, Utc};
 use helpers::TempDatabase;
 use sessions_chronicle::database::{
     count_sessions_per_date_preset, load_session_by_id_for_filter, load_sessions_for_filter,
@@ -9,21 +9,21 @@ use sessions_chronicle::database::{
 use sessions_chronicle::models::{AiAssistant, DateFilter, ProjectFilter};
 
 fn seed_date_dataset(db: &TempDatabase) {
-    let now = Utc::now();
-    let local_today = now.with_timezone(&Local).date_naive();
-    let today_ts = now.timestamp();
-    let two_days_ago_ts = now
-        .checked_sub_days(Days::new(2))
-        .expect("timestamp for 2 days ago")
-        .timestamp();
-    let ten_days_ago_ts = now
-        .checked_sub_days(Days::new(10))
-        .expect("timestamp for 10 days ago")
-        .timestamp();
-    let forty_days_ago_ts = now
-        .checked_sub_days(Days::new(40))
-        .expect("timestamp for 40 days ago")
-        .timestamp();
+    let local_today = Local::now().date_naive();
+    let today_midday = Local
+        .from_local_datetime(
+            &local_today
+                .and_hms_opt(12, 0, 0)
+                .expect("midday local time should exist"),
+        )
+        .earliest()
+        .expect("local conversion for today")
+        .with_timezone(&Utc);
+
+    let today_ts = today_midday.timestamp();
+    let two_days_ago_ts = (today_midday - Duration::days(2)).timestamp();
+    let ten_days_ago_ts = (today_midday - Duration::days(10)).timestamp();
+    let forty_days_ago_ts = (today_midday - Duration::days(40)).timestamp();
 
     db.insert_project(1, "/projects/alpha", "alpha");
     db.insert_project(2, "/projects/beta", "beta");
@@ -89,6 +89,26 @@ fn seed_date_dataset(db: &TempDatabase) {
         custom_ts,
     );
     db.insert_message("custom-edge", 0, "alpha edge", custom_ts);
+
+    db.insert_session(
+        "moved-today",
+        "claude_code",
+        Some("/projects/alpha"),
+        Some(1),
+        ten_days_ago_ts,
+        today_ts,
+    );
+    db.insert_message("moved-today", 0, "alpha moved", today_ts);
+
+    db.insert_session(
+        "started-today-stale",
+        "claude_code",
+        Some("/projects/alpha"),
+        Some(1),
+        today_ts,
+        ten_days_ago_ts,
+    );
+    db.insert_message("started-today-stale", 0, "alpha stale", ten_days_ago_ts);
 }
 
 #[test]
@@ -104,8 +124,22 @@ fn load_sessions_for_filter_applies_date_presets() {
     )
     .expect("today filter query should succeed");
 
-    assert_eq!(today_sessions.len(), 1);
-    assert_eq!(today_sessions[0].id, "today-alpha");
+    assert_eq!(today_sessions.len(), 2);
+    assert!(
+        today_sessions
+            .iter()
+            .any(|session| session.id == "today-alpha")
+    );
+    assert!(
+        today_sessions
+            .iter()
+            .any(|session| session.id == "moved-today")
+    );
+    assert!(
+        today_sessions
+            .iter()
+            .all(|session| session.id != "started-today-stale")
+    );
 
     let last_7_sessions = load_sessions_for_filter(
         &db.path,
@@ -130,9 +164,7 @@ fn custom_date_bounds_are_inclusive_and_compose_with_project_and_query() {
     let db = TempDatabase::new("date-filter-custom");
     seed_date_dataset(&db);
 
-    let now = Utc::now();
-    let custom_day = now
-        .with_timezone(&Local)
+    let custom_day = Local::now()
         .date_naive()
         .checked_sub_days(Days::new(2))
         .expect("custom day should exist");
@@ -194,10 +226,10 @@ fn count_sessions_per_date_preset_uses_same_filter_context() {
     )
     .expect("date counts should succeed");
 
-    assert_eq!(counts.any_time, 3);
-    assert_eq!(counts.today, 1);
-    assert_eq!(counts.last_7_days, 2);
-    assert_eq!(counts.last_30_days, 3);
+    assert_eq!(counts.any_time, 5);
+    assert_eq!(counts.today, 2);
+    assert_eq!(counts.last_7_days, 3);
+    assert_eq!(counts.last_30_days, 5);
     assert!(counts.this_year >= counts.last_30_days);
 }
 

--- a/tests/date_filter.rs
+++ b/tests/date_filter.rs
@@ -234,6 +234,39 @@ fn count_sessions_per_date_preset_uses_same_filter_context() {
 }
 
 #[test]
+fn count_sessions_per_date_preset_query_counts_distinct_sessions() {
+    let db = TempDatabase::new("date-filter-counts-distinct");
+    seed_date_dataset(&db);
+
+    let local_today = Local::now().date_naive();
+    let today_midday_ts = Local
+        .from_local_datetime(
+            &local_today
+                .and_hms_opt(12, 0, 0)
+                .expect("midday local time should exist"),
+        )
+        .earliest()
+        .expect("local conversion for today")
+        .with_timezone(&Utc)
+        .timestamp();
+
+    db.insert_message("today-alpha", 1, "alpha repeated", today_midday_ts);
+
+    let counts = count_sessions_per_date_preset(
+        &db.path,
+        &[AiAssistant::ClaudeCode],
+        &ProjectFilter::Project(1),
+        "alpha",
+    )
+    .expect("date counts should succeed");
+
+    assert_eq!(counts.any_time, 5);
+    assert_eq!(counts.today, 2);
+    assert_eq!(counts.last_7_days, 3);
+    assert_eq!(counts.last_30_days, 5);
+}
+
+#[test]
 fn custom_date_bounds_include_both_ends() {
     let db = TempDatabase::new("date-filter-inclusive");
     let from = NaiveDate::from_ymd_opt(2025, 1, 10).unwrap();

--- a/tests/date_filter.rs
+++ b/tests/date_filter.rs
@@ -1,0 +1,239 @@
+mod helpers;
+
+use chrono::{Days, Local, NaiveDate, TimeZone, Utc};
+use helpers::TempDatabase;
+use sessions_chronicle::database::{
+    count_sessions_per_date_preset, load_session_by_id_for_filter, load_sessions_for_filter,
+    search_sessions_for_filter,
+};
+use sessions_chronicle::models::{AiAssistant, DateFilter, ProjectFilter};
+
+fn seed_date_dataset(db: &TempDatabase) {
+    let now = Utc::now();
+    let local_today = now.with_timezone(&Local).date_naive();
+    let today_ts = now.timestamp();
+    let two_days_ago_ts = now
+        .checked_sub_days(Days::new(2))
+        .expect("timestamp for 2 days ago")
+        .timestamp();
+    let ten_days_ago_ts = now
+        .checked_sub_days(Days::new(10))
+        .expect("timestamp for 10 days ago")
+        .timestamp();
+    let forty_days_ago_ts = now
+        .checked_sub_days(Days::new(40))
+        .expect("timestamp for 40 days ago")
+        .timestamp();
+
+    db.insert_project(1, "/projects/alpha", "alpha");
+    db.insert_project(2, "/projects/beta", "beta");
+
+    db.insert_session(
+        "today-alpha",
+        "claude_code",
+        Some("/projects/alpha"),
+        Some(1),
+        today_ts,
+        today_ts,
+    );
+    db.insert_session(
+        "recent-beta",
+        "claude_code",
+        Some("/projects/beta"),
+        Some(2),
+        two_days_ago_ts,
+        two_days_ago_ts,
+    );
+    db.insert_session(
+        "older-alpha",
+        "claude_code",
+        Some("/projects/alpha"),
+        Some(1),
+        ten_days_ago_ts,
+        ten_days_ago_ts,
+    );
+    db.insert_session(
+        "old-unassigned",
+        "claude_code",
+        None,
+        None,
+        forty_days_ago_ts,
+        forty_days_ago_ts,
+    );
+
+    db.insert_message("today-alpha", 0, "alpha needle", today_ts);
+    db.insert_message("recent-beta", 0, "beta needle", two_days_ago_ts);
+    db.insert_message("older-alpha", 0, "alpha needle", ten_days_ago_ts);
+    db.insert_message("old-unassigned", 0, "legacy needle", forty_days_ago_ts);
+
+    let custom_day = local_today
+        .checked_sub_days(Days::new(2))
+        .expect("custom day should exist");
+    let custom_ts = Local
+        .from_local_datetime(
+            &custom_day
+                .and_hms_opt(12, 0, 0)
+                .expect("midday local time should exist"),
+        )
+        .earliest()
+        .expect("local conversion for custom day")
+        .with_timezone(&Utc)
+        .timestamp();
+
+    db.insert_session(
+        "custom-edge",
+        "claude_code",
+        Some("/projects/alpha"),
+        Some(1),
+        custom_ts,
+        custom_ts,
+    );
+    db.insert_message("custom-edge", 0, "alpha edge", custom_ts);
+}
+
+#[test]
+fn load_sessions_for_filter_applies_date_presets() {
+    let db = TempDatabase::new("date-filter-presets");
+    seed_date_dataset(&db);
+
+    let today_sessions = load_sessions_for_filter(
+        &db.path,
+        &[AiAssistant::ClaudeCode],
+        &ProjectFilter::AllSessions,
+        &DateFilter::Today,
+    )
+    .expect("today filter query should succeed");
+
+    assert_eq!(today_sessions.len(), 1);
+    assert_eq!(today_sessions[0].id, "today-alpha");
+
+    let last_7_sessions = load_sessions_for_filter(
+        &db.path,
+        &[AiAssistant::ClaudeCode],
+        &ProjectFilter::AllSessions,
+        &DateFilter::Last7Days,
+    )
+    .expect("last-7-days filter query should succeed");
+
+    let ids: Vec<&str> = last_7_sessions
+        .iter()
+        .map(|session| session.id.as_str())
+        .collect();
+    assert!(ids.contains(&"today-alpha"));
+    assert!(ids.contains(&"recent-beta"));
+    assert!(ids.contains(&"custom-edge"));
+    assert!(!ids.contains(&"older-alpha"));
+}
+
+#[test]
+fn custom_date_bounds_are_inclusive_and_compose_with_project_and_query() {
+    let db = TempDatabase::new("date-filter-custom");
+    seed_date_dataset(&db);
+
+    let now = Utc::now();
+    let custom_day = now
+        .with_timezone(&Local)
+        .date_naive()
+        .checked_sub_days(Days::new(2))
+        .expect("custom day should exist");
+    let custom = DateFilter::Custom {
+        from: custom_day,
+        to: custom_day,
+    };
+
+    let sessions = search_sessions_for_filter(
+        &db.path,
+        &[AiAssistant::ClaudeCode],
+        &ProjectFilter::Project(1),
+        "alpha",
+        &custom,
+    )
+    .expect("composed date/project/query search should succeed");
+
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0].id, "custom-edge");
+}
+
+#[test]
+fn session_id_lookup_respects_date_filter() {
+    let db = TempDatabase::new("date-filter-id");
+    seed_date_dataset(&db);
+
+    let sessions = load_session_by_id_for_filter(
+        &db.path,
+        &[AiAssistant::ClaudeCode],
+        &ProjectFilter::AllSessions,
+        "older-alpha",
+        &DateFilter::Today,
+    )
+    .expect("session-id lookup should succeed");
+    assert!(sessions.is_empty());
+
+    let any_time_sessions = load_session_by_id_for_filter(
+        &db.path,
+        &[AiAssistant::ClaudeCode],
+        &ProjectFilter::AllSessions,
+        "older-alpha",
+        &DateFilter::AnyTime,
+    )
+    .expect("session-id lookup with any-time should succeed");
+    assert_eq!(any_time_sessions.len(), 1);
+    assert_eq!(any_time_sessions[0].id, "older-alpha");
+}
+
+#[test]
+fn count_sessions_per_date_preset_uses_same_filter_context() {
+    let db = TempDatabase::new("date-filter-counts");
+    seed_date_dataset(&db);
+
+    let counts = count_sessions_per_date_preset(
+        &db.path,
+        &[AiAssistant::ClaudeCode],
+        &ProjectFilter::Project(1),
+        "alpha",
+    )
+    .expect("date counts should succeed");
+
+    assert_eq!(counts.any_time, 3);
+    assert_eq!(counts.today, 1);
+    assert_eq!(counts.last_7_days, 2);
+    assert_eq!(counts.last_30_days, 3);
+    assert!(counts.this_year >= counts.last_30_days);
+}
+
+#[test]
+fn custom_date_bounds_include_both_ends() {
+    let db = TempDatabase::new("date-filter-inclusive");
+    let from = NaiveDate::from_ymd_opt(2025, 1, 10).unwrap();
+    let to = NaiveDate::from_ymd_opt(2025, 1, 11).unwrap();
+
+    let from_ts = Local
+        .from_local_datetime(&from.and_hms_opt(0, 0, 0).unwrap())
+        .earliest()
+        .unwrap()
+        .with_timezone(&Utc)
+        .timestamp();
+    let to_end_ts = Local
+        .from_local_datetime(&to.and_hms_opt(23, 59, 59).unwrap())
+        .earliest()
+        .unwrap()
+        .with_timezone(&Utc)
+        .timestamp();
+
+    db.insert_session("from-bound", "claude_code", None, None, from_ts, from_ts);
+    db.insert_message("from-bound", 0, "boundary", from_ts);
+    db.insert_session("to-bound", "claude_code", None, None, to_end_ts, to_end_ts);
+    db.insert_message("to-bound", 0, "boundary", to_end_ts);
+
+    let sessions = load_sessions_for_filter(
+        &db.path,
+        &[AiAssistant::ClaudeCode],
+        &ProjectFilter::AllSessions,
+        &DateFilter::Custom { from, to },
+    )
+    .expect("custom range query should succeed");
+
+    let ids: Vec<&str> = sessions.iter().map(|session| session.id.as_str()).collect();
+    assert!(ids.contains(&"from-bound"));
+    assert!(ids.contains(&"to-bound"));
+}

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -171,6 +171,68 @@ impl TempDatabase {
             )
             .expect("Failed to insert message for alpha claude session");
     }
+
+    #[allow(dead_code)]
+    pub fn insert_project(&self, id: i64, path: &str, name: &str) {
+        self.connection
+            .execute(
+                "INSERT INTO projects (id, path, name) VALUES (?1, ?2, ?3)",
+                rusqlite::params![id, path, name],
+            )
+            .expect("Failed to insert project");
+    }
+
+    #[allow(dead_code)]
+    pub fn insert_session(
+        &self,
+        id: &str,
+        tool: &str,
+        project_path: Option<&str>,
+        project_id: Option<i64>,
+        start_time: i64,
+        last_updated: i64,
+    ) {
+        self.connection
+            .execute(
+                "INSERT INTO sessions (id, tool, project_path, project_id, start_time, message_count, file_path, last_updated)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                rusqlite::params![
+                    id,
+                    tool,
+                    project_path,
+                    project_id,
+                    start_time,
+                    1_i64,
+                    format!("/tmp/{id}.jsonl"),
+                    last_updated,
+                ],
+            )
+            .expect("Failed to insert session");
+    }
+
+    #[allow(dead_code)]
+    pub fn insert_message(
+        &self,
+        session_id: &str,
+        message_index: i64,
+        content: &str,
+        timestamp: i64,
+    ) {
+        self.connection
+            .execute(
+                "INSERT INTO messages (session_id, message_index, role, content, timestamp, model)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                rusqlite::params![
+                    session_id,
+                    message_index,
+                    "user",
+                    content,
+                    timestamp,
+                    Option::<String>::None,
+                ],
+            )
+            .expect("Failed to insert message");
+    }
 }
 
 impl Drop for TempDatabase {

--- a/tests/opencode_search.rs
+++ b/tests/opencode_search.rs
@@ -4,7 +4,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use sessions_chronicle::database::SessionIndexer;
 use sessions_chronicle::database::search_sessions_for_filter;
-use sessions_chronicle::models::{AiAssistant, ProjectFilter};
+use sessions_chronicle::models::{AiAssistant, DateFilter, ProjectFilter};
 
 struct TempDatabase {
     path: PathBuf,
@@ -57,6 +57,7 @@ fn opencode_search_finds_text_part_content() {
         &[AiAssistant::OpenCode],
         &ProjectFilter::AllSessions,
         "I can help you with that task",
+        &DateFilter::AnyTime,
     )
     .expect("Search failed");
 
@@ -97,6 +98,7 @@ fn opencode_search_excludes_tool_output() {
         &[AiAssistant::OpenCode],
         &ProjectFilter::AllSessions,
         "total",
+        &DateFilter::AnyTime,
     )
     .expect("Search failed");
 
@@ -122,6 +124,7 @@ fn opencode_search_respects_tool_filter() {
         &[AiAssistant::ClaudeCode],
         &ProjectFilter::AllSessions,
         "Hello OpenCode",
+        &DateFilter::AnyTime,
     )
     .expect("Search failed");
 
@@ -148,6 +151,7 @@ fn opencode_dual_read_sqlite_only_session_is_searchable() {
         &[AiAssistant::OpenCode],
         &ProjectFilter::AllSessions,
         "This session only exists in SQLite",
+        &DateFilter::AnyTime,
     )
     .expect("Search failed");
 

--- a/tests/pinned_sessions.rs
+++ b/tests/pinned_sessions.rs
@@ -4,7 +4,7 @@ use helpers::TempDatabase;
 use sessions_chronicle::database::{
     count_pinned_sessions, load_sessions_for_filter, search_sessions_for_filter, toggle_pin,
 };
-use sessions_chronicle::models::{AiAssistant, ProjectFilter};
+use sessions_chronicle::models::{AiAssistant, DateFilter, ProjectFilter};
 
 fn insert_session(db: &TempDatabase, id: &str, tool: &str, pinned_at: Option<i64>) {
     db.connection
@@ -58,8 +58,13 @@ fn load_sessions_for_filter_uses_pinned_project_filter() {
     insert_session(&db, "b", "claude_code", None);
     insert_session(&db, "c", "opencode", None);
 
-    let pinned =
-        load_sessions_for_filter(&db.path, AiAssistant::ALL, &ProjectFilter::Pinned).unwrap();
+    let pinned = load_sessions_for_filter(
+        &db.path,
+        AiAssistant::ALL,
+        &ProjectFilter::Pinned,
+        &DateFilter::AnyTime,
+    )
+    .unwrap();
 
     assert_eq!(
         pinned
@@ -91,9 +96,14 @@ fn search_sessions_for_filter_uses_pinned_project_filter() {
         )
         .unwrap();
 
-    let sessions =
-        search_sessions_for_filter(&db.path, AiAssistant::ALL, &ProjectFilter::Pinned, "needle")
-            .unwrap();
+    let sessions = search_sessions_for_filter(
+        &db.path,
+        AiAssistant::ALL,
+        &ProjectFilter::Pinned,
+        "needle",
+        &DateFilter::AnyTime,
+    )
+    .unwrap();
 
     let pinned_ids: Vec<String> = sessions.into_iter().map(|session| session.id).collect();
     assert_eq!(pinned_ids, vec!["a"]);
@@ -168,8 +178,13 @@ fn pinned_filter_returns_sessions_across_all_projects() {
         )
         .unwrap();
 
-    let sessions =
-        load_sessions_for_filter(&db.path, AiAssistant::ALL, &ProjectFilter::Pinned).unwrap();
+    let sessions = load_sessions_for_filter(
+        &db.path,
+        AiAssistant::ALL,
+        &ProjectFilter::Pinned,
+        &DateFilter::AnyTime,
+    )
+    .unwrap();
 
     let ids: Vec<&str> = sessions.iter().map(|session| session.id.as_str()).collect();
     assert_eq!(ids, vec!["beta-pin", "alpha-pin"]);

--- a/tests/pinned_sessions.rs
+++ b/tests/pinned_sessions.rs
@@ -42,11 +42,11 @@ fn count_pinned_sessions_respects_tool_filter() {
     insert_session(&db, "open-unpinned", "opencode", None);
 
     assert_eq!(
-        count_pinned_sessions(&db.path, AiAssistant::ALL).unwrap(),
+        count_pinned_sessions(&db.path, AiAssistant::ALL, &DateFilter::AnyTime).unwrap(),
         2
     );
     assert_eq!(
-        count_pinned_sessions(&db.path, &[AiAssistant::ClaudeCode]).unwrap(),
+        count_pinned_sessions(&db.path, &[AiAssistant::ClaudeCode], &DateFilter::AnyTime).unwrap(),
         1
     );
 }

--- a/tests/project_sidebar_filtering.rs
+++ b/tests/project_sidebar_filtering.rs
@@ -123,8 +123,8 @@ fn load_projects_orders_by_activity_and_keeps_zero_count_rows() {
         )
         .expect("Failed to insert project aardvark");
 
-    let projects =
-        load_projects(&db.path, &[AiAssistant::ClaudeCode]).expect("Load projects failed");
+    let projects = load_projects(&db.path, &[AiAssistant::ClaudeCode], &DateFilter::AnyTime)
+        .expect("Load projects failed");
     let names: Vec<&str> = projects
         .iter()
         .map(|project| project.name.as_str())
@@ -137,7 +137,8 @@ fn load_projects_orders_by_activity_and_keeps_zero_count_rows() {
     assert_eq!(names, vec!["alpha", "aardvark", "beta", "Delta", "gamma"]);
     assert_eq!(counts, vec![2, 0, 0, 0, 0]);
 
-    let all_projects = load_projects(&db.path, AiAssistant::ALL).expect("Load all projects failed");
+    let all_projects = load_projects(&db.path, AiAssistant::ALL, &DateFilter::AnyTime)
+        .expect("Load all projects failed");
     let all_names: Vec<&str> = all_projects
         .iter()
         .map(|project| project.name.as_str())
@@ -153,7 +154,8 @@ fn load_projects_orders_by_activity_and_keeps_zero_count_rows() {
     );
     assert_eq!(all_counts, vec![1, 2, 0, 0, 0]);
 
-    let empty_projects = load_projects(&db.path, &[]).expect("Load empty tool projects failed");
+    let empty_projects = load_projects(&db.path, &[], &DateFilter::AnyTime)
+        .expect("Load empty tool projects failed");
     let empty_names: Vec<&str> = empty_projects
         .iter()
         .map(|project| project.name.as_str())
@@ -175,27 +177,29 @@ fn project_sidebar_counts_include_unassigned_visibility_flag() {
     let db = TempDatabase::new("project-sidebar");
     db.seed();
 
-    let all_count = count_all_sessions(&db.path, &[AiAssistant::ClaudeCode])
+    let all_count = count_all_sessions(&db.path, &[AiAssistant::ClaudeCode], &DateFilter::AnyTime)
         .expect("Count all sessions failed");
     assert_eq!(all_count, 3);
 
-    let all_tools_count = count_all_sessions(&db.path, AiAssistant::ALL)
+    let all_tools_count = count_all_sessions(&db.path, AiAssistant::ALL, &DateFilter::AnyTime)
         .expect("Count all sessions with all tools failed");
     assert_eq!(all_tools_count, 4);
 
-    let no_tools_count =
-        count_all_sessions(&db.path, &[]).expect("Count all sessions with empty tools failed");
+    let no_tools_count = count_all_sessions(&db.path, &[], &DateFilter::AnyTime)
+        .expect("Count all sessions with empty tools failed");
     assert_eq!(no_tools_count, 0);
 
-    let unassigned_count = count_unassigned_sessions(&db.path, &[AiAssistant::ClaudeCode])
-        .expect("Count unassigned sessions failed");
+    let unassigned_count =
+        count_unassigned_sessions(&db.path, &[AiAssistant::ClaudeCode], &DateFilter::AnyTime)
+            .expect("Count unassigned sessions failed");
     assert_eq!(unassigned_count, 1);
 
-    let all_tools_unassigned = count_unassigned_sessions(&db.path, AiAssistant::ALL)
-        .expect("Count unassigned sessions with all tools failed");
+    let all_tools_unassigned =
+        count_unassigned_sessions(&db.path, AiAssistant::ALL, &DateFilter::AnyTime)
+            .expect("Count unassigned sessions with all tools failed");
     assert_eq!(all_tools_unassigned, 1);
 
-    let no_tools_unassigned = count_unassigned_sessions(&db.path, &[])
+    let no_tools_unassigned = count_unassigned_sessions(&db.path, &[], &DateFilter::AnyTime)
         .expect("Count unassigned sessions with empty tools failed");
     assert_eq!(no_tools_unassigned, 0);
 

--- a/tests/project_sidebar_filtering.rs
+++ b/tests/project_sidebar_filtering.rs
@@ -5,7 +5,7 @@ use sessions_chronicle::database::{
     count_all_sessions, count_unassigned_sessions, has_unassigned_sessions, load_projects,
     load_sessions_for_filter, search_sessions_for_filter,
 };
-use sessions_chronicle::models::{AiAssistant, ProjectFilter};
+use sessions_chronicle::models::{AiAssistant, DateFilter, ProjectFilter};
 
 impl TempDatabase {
     /// Seed the broader multi-project fixture used by count and ordering tests.
@@ -212,6 +212,7 @@ fn load_sessions_for_filter_returns_project_and_tool_intersection() {
         &db.path,
         &[AiAssistant::ClaudeCode],
         &ProjectFilter::Project(1),
+        &DateFilter::AnyTime,
     )
     .expect("load sessions");
 
@@ -229,6 +230,7 @@ fn search_sessions_for_filter_returns_only_unassigned_matches() {
         &[AiAssistant::ClaudeCode],
         &ProjectFilter::Unassigned,
         "lonely",
+        &DateFilter::AnyTime,
     )
     .expect("search sessions");
 

--- a/tests/search_sessions.rs
+++ b/tests/search_sessions.rs
@@ -6,7 +6,7 @@ use sessions_chronicle::database::schema::initialize_database;
 use sessions_chronicle::database::{
     find_session_match_positions, load_session_by_id_for_filter, search_sessions_for_filter,
 };
-use sessions_chronicle::models::{AiAssistant, ProjectFilter};
+use sessions_chronicle::models::{AiAssistant, DateFilter, ProjectFilter};
 
 struct TempDatabase {
     path: PathBuf,
@@ -209,6 +209,7 @@ fn search_sessions_orders_by_relevance() {
         &[AiAssistant::ClaudeCode, AiAssistant::OpenCode],
         &ProjectFilter::AllSessions,
         "alpha",
+        &DateFilter::AnyTime,
     )
     .expect("Search failed");
     let ids: Vec<&str> = sessions.iter().map(|session| session.id.as_str()).collect();
@@ -227,6 +228,7 @@ fn search_sessions_respects_tool_filter() {
         &[AiAssistant::OpenCode],
         &ProjectFilter::AllSessions,
         "alpha",
+        &DateFilter::AnyTime,
     )
     .expect("Search failed");
 
@@ -245,6 +247,7 @@ fn search_sessions_sanitizes_invalid_query() {
         &[AiAssistant::ClaudeCode],
         &ProjectFilter::AllSessions,
         "\"alpha",
+        &DateFilter::AnyTime,
     )
     .expect("Search failed");
 
@@ -263,6 +266,7 @@ fn load_session_by_id_for_filter_matches_exact_id() {
         &AiAssistant::ALL,
         &ProjectFilter::AllSessions,
         "session-b",
+        &DateFilter::AnyTime,
     )
     .expect("Session ID lookup failed");
     let ids: Vec<&str> = sessions.iter().map(|session| session.id.as_str()).collect();
@@ -280,6 +284,7 @@ fn load_session_by_id_for_filter_requires_exact_id() {
         &AiAssistant::ALL,
         &ProjectFilter::AllSessions,
         "session",
+        &DateFilter::AnyTime,
     )
     .expect("Session ID lookup failed");
 
@@ -296,6 +301,7 @@ fn load_session_by_id_for_filter_respects_tool_filter() {
         &[AiAssistant::OpenCode],
         &ProjectFilter::AllSessions,
         "session-b",
+        &DateFilter::AnyTime,
     )
     .expect("Session ID lookup with matching tool failed");
     let blocked = load_session_by_id_for_filter(
@@ -303,6 +309,7 @@ fn load_session_by_id_for_filter_respects_tool_filter() {
         &[AiAssistant::ClaudeCode],
         &ProjectFilter::AllSessions,
         "session-b",
+        &DateFilter::AnyTime,
     )
     .expect("Session ID lookup with blocked tool failed");
 
@@ -321,6 +328,7 @@ fn load_session_by_id_for_filter_respects_project_filter() {
         &AiAssistant::ALL,
         &ProjectFilter::Project(2),
         "session-b",
+        &DateFilter::AnyTime,
     )
     .expect("Session ID lookup with matching project failed");
     let blocked = load_session_by_id_for_filter(
@@ -328,6 +336,7 @@ fn load_session_by_id_for_filter_respects_project_filter() {
         &AiAssistant::ALL,
         &ProjectFilter::Project(1),
         "session-b",
+        &DateFilter::AnyTime,
     )
     .expect("Session ID lookup with blocked project failed");
 
@@ -352,6 +361,7 @@ fn load_session_by_id_for_filter_respects_pinned_filter() {
         &AiAssistant::ALL,
         &ProjectFilter::Pinned,
         "session-b",
+        &DateFilter::AnyTime,
     )
     .expect("Pinned session ID lookup failed");
     let blocked = load_session_by_id_for_filter(
@@ -359,6 +369,7 @@ fn load_session_by_id_for_filter_respects_pinned_filter() {
         &AiAssistant::ALL,
         &ProjectFilter::Pinned,
         "session-a",
+        &DateFilter::AnyTime,
     )
     .expect("Unpinned session ID lookup failed");
 
@@ -377,6 +388,7 @@ fn load_session_by_id_for_filter_returns_empty_for_unknown_id() {
         &AiAssistant::ALL,
         &ProjectFilter::AllSessions,
         "missing-session",
+        &DateFilter::AnyTime,
     )
     .expect("Unknown session ID lookup failed");
 


### PR DESCRIPTION
Closes #85 

## Summary
- Add `DateFilter` model (`All`, `Today`, `Yesterday`, `ThisWeek`, `ThisMonth`, `CustomRange`) with `resolve()`, `pill_label()`, `is_active()`, and `DateCounts` for badge display
- Extend database layer with date-filter SQL clauses, `count_sessions_per_date_preset()` (5 SQL COUNT queries), and FTS query sanitization for count paths mirroring the search path
- Wire date filter through `SessionList`/`App` state: `selected_date_filter`, `DateFilterChanged`, `DateCountsRequested`, and `WorkspaceHeaderVisibility.date_filter_visible`
- Implement `DatePill` Relm4 component: `MenuButton` → `Popover` with `ListBox` (presets + counts), `Calendar`-based custom range, Clear/Apply buttons; `Ctrl+Shift+D` shortcut with "Filter by date" in shortcuts dialog
- Date filter composes with existing AI-assistant, project, and search filters via AND

## Test Plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all -- -D warnings` passes
- [x] `cargo test --all --no-fail-fast` passes (682+ tests, 0 failures)
- [x] Unit tests for DateFilter model (resolve, pill_label, edge cases)
- [x] Integration tests for date-filter SQL, composition with search/project, and count accuracy
- [x] Regression test for invalid FTS query sanitization in count paths
- [x] Manual UI verification with `--sessions-dir tests/fixtures`

