### PR TITLE
Update parsers for refreshed assistant session formats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a0aeaff4ff1a90589618835a598e545176939b97874f7abc7851caa0618f203"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -802,6 +804,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1324,6 +1336,7 @@ dependencies = [
  "tracing-subscriber",
  "walkdir",
  "which",
+ "zstd",
 ]
 
 [[package]]
@@ -1982,6 +1995,34 @@ name = "zmij"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fc5a66a20078bf1251bde995aa2fdcc4b800c70b5d92dd2c62abc5c60f679f8"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "zvariant"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ pulldown-cmark = { version = "0.13", default-features = false, features = ["simd
 regex = "1"
 similar = "3.1.1"
 sourceview5 = "0.11.0"
+zstd = "0.13.3"
 
 [build-dependencies]
 relm4-icons-build = "0.11.0"

--- a/docs/SESSION_FORMAT_ANALYSIS.md
+++ b/docs/SESSION_FORMAT_ANALYSIS.md
@@ -23,6 +23,7 @@ Cross-tool comparison of Claude Code, Codex, OpenCode, and Mistral Vibe session 
 - ✅ Mistral Vibe parser implemented
 - ✅ OpenCode parent-child detection implemented (`parentID` sessions are indexed as subagents)
 - ✅ Codex collab/thread-spawn linkage implemented (child sessions + parent-side subagent rows)
+- ✅ Mistral Vibe `task`/`agents/` subagent linkage implemented (child sessions + parent-side subagent rows)
 - ✅ Tool-call wire formats documented for Claude, OpenCode, Mistral Vibe, and Codex rollouts
 - ✅ LLM model metadata availability mapped (per message vs per turn vs per session)
 - ✅ Current parser behavior: tool-call/tool-result content is indexed (Phase 6 delivered)
@@ -36,7 +37,7 @@ Cross-tool comparison of Claude Code, Codex, OpenCode, and Mistral Vibe session 
 | **Claude Code** | `~/.claude/` | Project-specific directories<br>Main session: `~/.claude/projects/-Users-alexm-Repository-<project>/UUID.jsonl`<br>Subagent transcripts appear under `<session-id>/subagents/agent-*.jsonl`, each with an `agent-*.meta.json` metadata sidecar (observed v2.1.148)<br>Large materialized tool outputs can also appear under `<session-id>/tool-results/` |
 | **Codex** | `~/.codex/sessions/`<br>`~/.codex/archived_sessions/` | Active sessions: date-sharded `YYYY/MM/DD/rollout-*.jsonl`<br>Archived sessions: flat `rollout-*.jsonl` or cold `rollout-*.jsonl.zst` |
 | **OpenCode** | `~/.local/share/opencode/` | **New (≥ 2026-02-14)**: SQLite WAL-mode DB, usually `opencode.db` and channel-specific `opencode-<channel>.db` for non-default channels; tables: `session`, `message`, `part`, `project`, `todo`, `permission`, `session_share`.<br>**Legacy (pre-migration)**: Multi-directory JSON under `storage/`: `session/<project>/ses_xxx.json`, `message/ses_xxx/`, `part/msg_xxx/`, `session_diff/ses_xxx.json`. Files are retained post-migration (no auto-cleanup). |
-| **Mistral Vibe** | `~/.vibe/logs/session/` | One directory per session:<br>`session_YYYYMMDD_HHMMSS_<shortid>/`<br>Contains `meta.json` + `messages.jsonl`.<br>Default can be overridden via `VIBE_HOME` or `session_logging.save_dir` in `config.toml`. |
+| **Mistral Vibe** | `~/.vibe/logs/session/` | One directory per session:<br>`session_YYYYMMDD_HHMMSS_<shortid>/`<br>Contains `meta.json` + `messages.jsonl`.<br>Subagent traces created by `task` are child session directories under `<parent>/agents/<agent>_YYYYMMDD_HHMMSS_<shortid>/`.<br>Default can be overridden via `VIBE_HOME` or `session_logging.save_dir` in `config.toml`. |
 
 ---
 
@@ -88,7 +89,7 @@ Cross-tool comparison of Claude Code, Codex, OpenCode, and Mistral Vibe session 
 - **Claude Code**: Tree structure via `uuid`/`parentUuid` + `isSidechain` flag; some newer compaction events also include `logicalParentUuid`
 - **Codex**: Thread-based rollouts (`session_meta.payload.id` thread id); source provenance now comes from structured `session_meta.payload.source` (`cli`, `vscode`, `exec`, custom, or structured `subAgent` variants), with additional child-thread linkage visible in collab events (`collab_agent_spawn_*`, `collab_agent_interaction_*`, `collab_waiting_*`, `collab_close_*`, `collab_resume_*`) or local response-item tool calls such as `spawn_agent`
 - **OpenCode**: Parent-child sessions via `parentID` (subagent sessions)
-- **Mistral Vibe**: Linear message list in `messages.jsonl`; tool calls are embedded in assistant messages and resolved by subsequent `tool` role messages
+- **Mistral Vibe**: Linear message list within each `messages.jsonl`; tool calls are embedded in assistant messages and resolved by subsequent `tool` role messages. A `task` tool call creates a separate child transcript under `<parent>/agents/`; the child does not persist the parent tool-call id, so repeated same-profile calls require chronological best-effort pairing
 
 **Metadata Storage:**
 - **Claude Code**: Rich per-event metadata (`cwd`, `gitBranch`, `version`, `sessionId`, `entrypoint`, `slug`) plus assistant-level model slug at `message.model`; user turns can also include `promptId`, and subagent transcripts include `agentId`; recent logs (v2.1.148) add `attributionSkill` on `assistant` events and `sourceToolAssistantUUID` on some tool-result `user` events
@@ -163,7 +164,9 @@ Goal: determine whether model information is available per message, per turn, an
   when present, not message-level; **token usage is available when
   `meta.json.stats` is present** (session totals + last-turn metrics); assistant
   messages from reasoning-capable models can include `reasoning_content` and
-  `reasoning_signature` fields (currently not indexed by the parser)
+  `reasoning_signature` fields. Subagents launched through `task` are persisted
+  as separate child sessions under `<parent>/agents/`; Sessions Chronicle
+  indexes them and surfaces the parent `task` call as a subagent row
 - **Mistral Vibe skills**: Two patterns were observed locally. Exact
   `/<skill-name>` invocation is expanded client-side into a `role == "user"`
   message containing the full `SKILL.md` body. Free-form or slash-with-args
@@ -300,11 +303,12 @@ Each tool can persist token usage metrics, but **the granularity and presence ar
 - [Mistral Vibe Repository](https://github.com/mistralai/mistral-vibe)
 - [Mistral Vibe Configuration Docs](https://docs.mistral.ai/mistral-vibe/introduction/configuration)
 - [Mistral Vibe session logger](https://github.com/mistralai/mistral-vibe/blob/main/vibe/core/session/session_logger.py)
+- [Mistral Vibe `task` tool](https://github.com/mistralai/mistral-vibe/blob/main/vibe/core/tools/builtins/task.py)
 - [Mistral Vibe message/session models](https://github.com/mistralai/mistral-vibe/blob/main/vibe/core/types.py)
 - [Mistral Vibe system prompt skill section](https://github.com/mistralai/mistral-vibe/blob/main/vibe/core/system_prompt.py)
 - [Mistral Vibe CLI skill slash-command handler](https://github.com/mistralai/mistral-vibe/blob/main/vibe/cli/textual_ui/app.py)
 
 ---
 
-**Last Updated**: 2026-05-22
-**Status**: Claude Code docs refreshed from real-session sampling (v2.1.148 logs): new `attachment`, `permission-mode`, and `last-prompt` event types, new `attributionSkill` / `sourceToolAssistantUUID` fields, `isSnapshotUpdate` on file-history snapshots, and the `agent-*.meta.json` subagent metadata sidecar; parser skips the new event types without error, so no parser change is justified yet. Earlier refresh (2026-03-31) covered v2.1.87-era subagent naming (`Agent`), `turn_duration`/`compact_boundary` system events, and `tool-results/` side files. Mistral Vibe docs updated for v2.7.0: new `meta.json` fields (`username`, `title`, `total_messages`, `system_prompt`), new optional `LLMMessage` fields (`message_id`, `reasoning_content`, `reasoning_signature`), system message placement corrected. Mistral Vibe docs refreshed again from upstream source through v2.14.0 (2026-06-08 watch pass): new `SessionMetadata` fields (`parent_session_id`, `title_source`, `loops`, `experiments`), new `LLMMessage` fields (`images`, `injected`, `reasoning_state`, `reasoning_message_id`), expanded `AgentStats` (tool-call counters, performance metrics, per-million pricing), and the new `read`/`edit` tool-call format noted; filenames `meta.json`/`messages.jsonl` confirmed unchanged, parser reads `meta.json` leniently so no parser change is justified yet.
+**Last Updated**: 2026-06-09
+**Status**: Claude Code docs refreshed from real-session sampling (v2.1.148 logs): new `attachment`, `permission-mode`, and `last-prompt` event types, new `attributionSkill` / `sourceToolAssistantUUID` fields, `isSnapshotUpdate` on file-history snapshots, and the `agent-*.meta.json` subagent metadata sidecar; parser skips the new event types without error, so no parser change is justified yet. Earlier refresh (2026-03-31) covered v2.1.87-era subagent naming (`Agent`), `turn_duration`/`compact_boundary` system events, and `tool-results/` side files. Mistral Vibe docs updated for v2.7.0: new `meta.json` fields (`username`, `title`, `total_messages`, `system_prompt`), new optional `LLMMessage` fields (`message_id`, `reasoning_content`, `reasoning_signature`), system message placement corrected. Mistral Vibe docs refreshed again from upstream source through v2.14.1 (2026-06-09 watch pass): new `SessionMetadata` fields (`parent_session_id`, `title_source`, `loops`, `experiments`), new `LLMMessage` fields (`images`, `injected`, `reasoning_state`, `reasoning_message_id`), expanded `AgentStats` (tool-call counters, performance metrics, per-million pricing), the new `read`/`edit` tool-call format, and directory-based `task` subagent traces under `<parent>/agents/`. The parser's subagent behavior matches upstream; same-profile parallel call-to-child pairing remains best-effort because child metadata contains no parent tool-call id.

--- a/docs/session-formats/mistral-vibe.md
+++ b/docs/session-formats/mistral-vibe.md
@@ -55,7 +55,7 @@ Session-level metadata:
 | Field | Description |
 |-------|-------------|
 | `session_id` | UUID |
-| `parent_session_id` | Present but **always `null`** in observed sessions (including sub-agent children); parent linkage is directory-based instead — see [Threading](#threading) |
+| `parent_session_id` | Optional generic session-lineage field used by Vibe for flows such as forks/resets. Sub-agent children created by the `task` tool do **not** set it; their parent linkage is directory-based instead — see [Threading](#threading) |
 | `start_time` | ISO-8601 string |
 | `end_time` | ISO-8601 string |
 | `environment.working_directory` | Working directory |
@@ -225,20 +225,36 @@ JSON arguments carry the agent name and the delegated prompt:
 }
 ```
 
+The `agent` argument is optional in upstream `TaskArgs`; when omitted, Vibe uses
+the built-in `explore` subagent.
+
 The sub-agent's final response comes back as the matching `tool` result
 (`tool_call_id == "YuV7lzFC6"`), while its **full transcript** is logged as a
 separate child session directory under `<parent>/agents/<agent>_*/`.
+The persisted tool-result content is Vibe's plain-text rendering of `TaskResult`
+(`response`, `turns_used`, and `completed`); Sessions Chronicle stores that full
+content as the subagent result summary.
 
-Linkage is entirely **directory- and name-based**; `meta.json.parent_session_id`
-is `null` on both sides and carries no linkage:
+For sub-agents created by `task`, linkage is **directory- and name-based**;
+`meta.json.parent_session_id` is not set on the child and carries no sub-agent
+linkage:
 
 - The child knows its parent because it lives under `<parent>/agents/`.
 - A parent `task` call is paired to a child by matching the call's `agent`
-  argument against the child's `agent_profile.name`, in chronological order when
-  the same agent is invoked more than once.
+  argument against the child's `agent_profile.name`.
+
+Vibe does not persist the parent tool-call id in the child metadata. Sessions
+Chronicle therefore pairs repeated calls to the same agent profile with child
+directories in chronological order. This is deterministic for sequential calls,
+but remains a best-effort heuristic when same-profile `task` calls execute in
+parallel.
 
 No inline sub-agent transcript model exists within a single `messages.jsonl`;
 the child transcript is always a distinct session file.
+
+The generic `parent_session_id` field has a separate meaning in upstream Vibe:
+it can identify lineage for forked or reset sessions. Sessions Chronicle does
+not treat that field alone as proof that a session is a sub-agent.
 
 ---
 
@@ -332,8 +348,9 @@ It does **not** contain the full assistant/tool transcript.
 Current implementation: `src/parsers/mistral_vibe.rs`
 
 - Indexes `role == user|assistant` text
-- Skips `role == tool` records
-- Skips assistant records that only contain `tool_calls` with empty text
+- Uses `role == tool` records to complete matching tool calls or subagent results,
+  but does not render them as standalone messages
+- Indexes assistant `tool_calls` even when assistant text is empty
 
 **Title extraction:** First `messages.jsonl` entry where `role == "user"` and `content` is non-empty.
 
@@ -372,8 +389,12 @@ fn extract_vibe_content(event: &Value) -> Option<String> {
 - A `task` tool call is surfaced as a navigable **subagent** transcript item
   (not a plain tool call). Its `child_session_id` is resolved at parse time by
   pairing the call's `agent` argument with a child under `agents/`
-  (by `agent_profile.name`, chronological for repeats); the `tool` result is
-  captured as the subagent's `result_summary`.
+  (by `agent_profile.name`, chronological best-effort pairing for repeats); the
+  `tool` result is captured as the subagent's `result_summary`.
+- A missing `task.agent` argument is normalized to upstream's default
+  subagent, `explore`.
+- Generic `meta.json.parent_session_id` lineage is not interpreted as subagent
+  linkage.
 
 **Streaming:** Use `BufReader` line-by-line iteration on `messages.jsonl` —
 do not load entire JSONL into memory.
@@ -384,9 +405,10 @@ do not load entire JSONL into memory.
 
 - [Mistral Vibe Repository](https://github.com/mistralai/mistral-vibe)
 - [Mistral Vibe session logger (`meta.json` + `messages.jsonl` + config dump)](https://github.com/mistralai/mistral-vibe/blob/main/vibe/core/session/session_logger.py)
+- [Mistral Vibe `task` tool (subagent trace location and agent-prefixed directory naming)](https://github.com/mistralai/mistral-vibe/blob/main/vibe/core/tools/builtins/task.py)
 - [Mistral Vibe session loader (filename constants `METADATA_FILENAME` = `meta.json`, `MESSAGES_FILENAME` = `messages.jsonl`)](https://github.com/mistralai/mistral-vibe/blob/main/vibe/core/session/session_loader.py)
 - [Mistral Vibe message/session models (`SessionMetadata`, `LLMMessage`, `AgentStats`)](https://github.com/mistralai/mistral-vibe/blob/main/vibe/core/types.py)
-- [Mistral Vibe CHANGELOG (verified through 2.14.0, 2026-06-04)](https://github.com/mistralai/mistral-vibe/blob/main/CHANGELOG.md)
+- [Mistral Vibe CHANGELOG (verified through 2.14.1, 2026-06-08)](https://github.com/mistralai/mistral-vibe/blob/main/CHANGELOG.md)
 - [Mistral Vibe Configuration Docs](https://docs.mistral.ai/mistral-vibe/introduction/configuration)
 - [Mistral Vibe system prompt skill section (`<available_skills>`)](https://github.com/mistralai/mistral-vibe/blob/main/vibe/core/system_prompt.py)
 - [Mistral Vibe CLI skill slash-command handler](https://github.com/mistralai/mistral-vibe/blob/main/vibe/cli/textual_ui/app.py)

--- a/docs/session-formats/mistral-vibe.md
+++ b/docs/session-formats/mistral-vibe.md
@@ -33,8 +33,18 @@ The default path can be overridden via:
 ```
 session_YYYYMMDD_HHMMSS_<shortid>/
 ├── meta.json        # Session-level metadata, timestamps, config snapshot
-└── messages.jsonl   # OpenAI-style chat transcript (one message per line)
+├── messages.jsonl   # OpenAI-style chat transcript (one message per line)
+└── agents/          # Present only when the session spawned sub-agents
+    └── <agent>_YYYYMMDD_HHMMSS_<shortid>/
+        ├── meta.json
+        └── messages.jsonl
 ```
+
+Each spawned sub-agent (via the `task` tool) is logged as its **own**
+self-contained session directory under the parent's `agents/` folder, named
+with the agent profile as prefix (for example `comique_20260609_121044_57ffdbcd/`).
+The parent/child relationship is encoded by this directory layout, **not** by a
+metadata field. See [Threading](#threading).
 
 ---
 
@@ -45,7 +55,7 @@ Session-level metadata:
 | Field | Description |
 |-------|-------------|
 | `session_id` | UUID |
-| `parent_session_id` | Optional id of a parent session (sub-session linkage); see [Threading](#threading) |
+| `parent_session_id` | Present but **always `null`** in observed sessions (including sub-agent children); parent linkage is directory-based instead — see [Threading](#threading) |
 | `start_time` | ISO-8601 string |
 | `end_time` | ISO-8601 string |
 | `environment.working_directory` | Working directory |
@@ -58,7 +68,7 @@ Session-level metadata:
 | `stats` | Token usage, tool call counters, other session metrics |
 | `tools_available` | Set of tools available to the agent for the session |
 | `config` | Optional config snapshot: `active_model`, `providers`, `models` arrays |
-| `agent_profile` | Optional selected profile/override metadata |
+| `agent_profile` | Optional selected profile/override metadata. On sub-agent child sessions, `agent_profile.name` holds the agent name (e.g. `"comique"`) used to pair the child with the parent's `task` call — see [Threading](#threading) |
 | `system_prompt` | System message object (`{"role": "system", "content": "..."}`) — moved here from `messages.jsonl` |
 | `loops` | Optional; agent loop metadata (added conditionally) |
 | `experiments` | Optional; experiment flags (added conditionally) |
@@ -194,11 +204,41 @@ Arguments are stored as JSON-encoded strings (`tool_calls[*].function.arguments`
 Linear message list in `messages.jsonl`.
 Tool calls are embedded in assistant messages and resolved by subsequent `tool` role messages.
 
-`meta.json` now carries an optional `parent_session_id` field, which links a
-session to a parent session (sub-session linkage). The exact on-disk shape from a
-captured real session has not yet been confirmed, and the Sessions Chronicle
-parser does not currently read it (the model field is set to `None`). No inline
-subagent transcript model has been observed within a single `messages.jsonl`.
+### Sub-agents
+
+A session delegates work to a sub-agent through the **`task` tool call**, whose
+JSON arguments carry the agent name and the delegated prompt:
+
+```json
+{
+  "role": "assistant",
+  "tool_calls": [
+    {
+      "id": "YuV7lzFC6",
+      "type": "function",
+      "function": {
+        "name": "task",
+        "arguments": "{\"task\": \"Review the README\", \"agent\": \"comique\"}"
+      }
+    }
+  ]
+}
+```
+
+The sub-agent's final response comes back as the matching `tool` result
+(`tool_call_id == "YuV7lzFC6"`), while its **full transcript** is logged as a
+separate child session directory under `<parent>/agents/<agent>_*/`.
+
+Linkage is entirely **directory- and name-based**; `meta.json.parent_session_id`
+is `null` on both sides and carries no linkage:
+
+- The child knows its parent because it lives under `<parent>/agents/`.
+- A parent `task` call is paired to a child by matching the call's `agent`
+  argument against the child's `agent_profile.name`, in chronological order when
+  the same agent is invoked more than once.
+
+No inline sub-agent transcript model exists within a single `messages.jsonl`;
+the child transcript is always a distinct session file.
 
 ---
 
@@ -321,6 +361,19 @@ fn extract_vibe_content(event: &Value) -> Option<String> {
 - Arguments are stored as JSON-encoded strings (`tool_calls[*].function.arguments`)
 - Current parser behavior: indexes assistant `tool_calls[]` entries and correlates
   `role == "tool"` outputs by `tool_call_id`; uncorrelated outputs are skipped
+
+**Sub-agent handling:**
+
+- A child session is detected when its directory's parent is named `agents/`;
+  `parent_session_id` is then derived from the grandparent `meta.json` and the
+  session is marked `is_subagent`.
+- The indexer descends into `<session>/agents/` so each child is indexed as its
+  own (hidden) session.
+- A `task` tool call is surfaced as a navigable **subagent** transcript item
+  (not a plain tool call). Its `child_session_id` is resolved at parse time by
+  pairing the call's `agent` argument with a child under `agents/`
+  (by `agent_profile.name`, chronological for repeats); the `tool` result is
+  captured as the subagent's `result_summary`.
 
 **Streaming:** Use `BufReader` line-by-line iteration on `messages.jsonl` —
 do not load entire JSONL into memory.

--- a/src/database/indexer.rs
+++ b/src/database/indexer.rs
@@ -53,15 +53,6 @@ pub(crate) fn opencode_source_available(storage_root: &Path, db_paths: &[PathBuf
     storage_root.exists() || db_paths.iter().any(|path| path.exists())
 }
 
-/// Escape the SQL `LIKE` metacharacters in `value` so it can be used as a
-/// literal prefix with `ESCAPE '\'`.
-fn escape_like_pattern(value: &str) -> String {
-    value
-        .replace('\\', "\\\\")
-        .replace('%', "\\%")
-        .replace('_', "\\_")
-}
-
 fn opencode_display_path(storage_root: &Path, db_paths: &[PathBuf]) -> String {
     if storage_root.exists() {
         storage_root.display().to_string()
@@ -482,14 +473,7 @@ impl SessionIndexer {
             return Ok(false);
         };
 
-        let pattern = format!("{}/%", escape_like_pattern(agents_str));
-        let known: Vec<String> = {
-            let mut stmt = self
-                .db
-                .prepare("SELECT file_path FROM sessions WHERE file_path LIKE ?1 ESCAPE '\\'")?;
-            stmt.query_map([pattern], |row| row.get(0))?
-                .collect::<std::result::Result<Vec<_>, _>>()?
-        };
+        let known = self.indexed_paths_under(agents_str)?;
 
         let mut removed_direct_child = false;
         for file_path in known {
@@ -518,19 +502,30 @@ impl SessionIndexer {
         let Some(dir_str) = dir.to_str() else {
             return Ok(removed);
         };
-        let pattern = format!("{}/%", escape_like_pattern(dir_str));
-        let descendants: Vec<String> = {
-            let mut stmt = self
-                .db
-                .prepare("SELECT file_path FROM sessions WHERE file_path LIKE ?1 ESCAPE '\\'")?;
-            stmt.query_map([pattern], |row| row.get(0))?
-                .collect::<std::result::Result<Vec<_>, _>>()?
-        };
-        for file_path in descendants {
+        for file_path in self.indexed_paths_under(dir_str)? {
             removed += self.remove_session_for_file(Path::new(&file_path))?;
         }
 
         Ok(removed)
+    }
+
+    /// Return the indexed `file_path`s strictly beneath `dir`, i.e. those
+    /// starting with `<dir>/`. Uses a half-open prefix range so the
+    /// `idx_sessions_file_path` index serves it without scanning the table, and
+    /// so the common leaf case (no descendants) returns immediately.
+    fn indexed_paths_under(&self, dir: &str) -> Result<Vec<String>> {
+        // `/` is byte 0x2F, so the next possible byte 0x30 (`0`) bounds every
+        // path beginning with `<dir>/` from above. Comparison uses the column's
+        // default BINARY collation, so the match is exact and case-sensitive.
+        let lower = format!("{dir}/");
+        let upper = format!("{dir}0");
+        let mut stmt = self
+            .db
+            .prepare("SELECT file_path FROM sessions WHERE file_path >= ?1 AND file_path < ?2")?;
+        let rows = stmt
+            .query_map([lower, upper], |row| row.get(0))?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
     }
 
     fn process_vibe_session_dir(
@@ -2461,6 +2456,62 @@ mod tests {
     }
 
     #[test]
+    fn vibe_incremental_prunes_child_when_whole_agents_dir_removed() {
+        let temp_db = NamedTempFile::new().unwrap();
+        let mut indexer = SessionIndexer::new(temp_db.path()).unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let sessions_dir = temp_dir.path();
+        let parent_dir = sessions_dir.join("session_parent");
+        let agents_dir = parent_dir.join("agents");
+        let child_dir = agents_dir.join("comique_20260101_000100");
+
+        write_vibe_session_dir(
+            &parent_dir,
+            "parent-session",
+            None,
+            &vibe_task_messages("comique", "call_1"),
+        );
+        write_vibe_session_dir(
+            &child_dir,
+            "child-session",
+            Some("comique"),
+            &vibe_plain_messages(),
+        );
+        indexer
+            .index_vibe_sessions_incremental(sessions_dir)
+            .unwrap();
+
+        // Remove the entire agents/ directory (not just one child). The parent's
+        // messages.jsonl is unchanged, so the prune must still drop the orphaned
+        // child row and relink the parent.
+        std::fs::remove_dir_all(&agents_dir).unwrap();
+        indexer
+            .index_vibe_sessions_incremental(sessions_dir)
+            .unwrap();
+
+        let child_rows: i64 = indexer
+            .db
+            .query_row(
+                "SELECT COUNT(*) FROM sessions WHERE id = 'child-session'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(child_rows, 0, "orphaned child row survived agents/ removal");
+
+        let dangling: i64 = indexer
+            .db
+            .query_row(
+                "SELECT COUNT(*) FROM subagents \
+                 WHERE session_id = 'parent-session' AND child_session_id = 'child-session'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(dangling, 0, "parent still links to pruned child");
+    }
+
+    #[test]
     fn vibe_incremental_removes_whole_subtree_when_intermediate_deleted() {
         let temp_db = NamedTempFile::new().unwrap();
         let mut indexer = SessionIndexer::new(temp_db.path()).unwrap();
@@ -2521,6 +2572,75 @@ mod tests {
             )
             .unwrap();
         assert_eq!(dangling, 0, "parent still links to deleted child");
+    }
+
+    #[test]
+    fn vibe_incremental_subtree_removal_preserves_case_distinct_sibling() {
+        let temp_db = NamedTempFile::new().unwrap();
+        let mut indexer = SessionIndexer::new(temp_db.path()).unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let sessions_dir = temp_dir.path();
+        let parent_dir = sessions_dir.join("session_parent");
+        let removed_child = parent_dir.join("agents").join("Agent");
+        let removed_grandchild = removed_child.join("agents").join("removed_grandchild");
+        let surviving_child = parent_dir.join("agents").join("agent");
+        let surviving_grandchild = surviving_child.join("agents").join("surviving_grandchild");
+
+        write_vibe_session_dir(&parent_dir, "parent-session", None, &vibe_plain_messages());
+        write_vibe_session_dir(
+            &removed_child,
+            "removed-child-session",
+            Some("Agent"),
+            &vibe_plain_messages(),
+        );
+        write_vibe_session_dir(
+            &removed_grandchild,
+            "removed-grandchild-session",
+            Some("removed_grandchild"),
+            &vibe_plain_messages(),
+        );
+        write_vibe_session_dir(
+            &surviving_child,
+            "surviving-child-session",
+            Some("agent"),
+            &vibe_plain_messages(),
+        );
+        write_vibe_session_dir(
+            &surviving_grandchild,
+            "surviving-grandchild-session",
+            Some("surviving_grandchild"),
+            &vibe_plain_messages(),
+        );
+        indexer
+            .index_vibe_sessions_incremental(sessions_dir)
+            .unwrap();
+
+        std::fs::remove_dir_all(&removed_child).unwrap();
+        indexer
+            .index_vibe_sessions_incremental(sessions_dir)
+            .unwrap();
+
+        let removed: i64 = indexer
+            .db
+            .query_row(
+                "SELECT COUNT(*) FROM sessions \
+                 WHERE id IN ('removed-child-session', 'removed-grandchild-session')",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(removed, 0);
+
+        let surviving: i64 = indexer
+            .db
+            .query_row(
+                "SELECT COUNT(*) FROM sessions \
+                 WHERE id IN ('surviving-child-session', 'surviving-grandchild-session')",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(surviving, 2, "case-distinct sibling subtree was removed");
     }
 
     #[test]

--- a/src/database/indexer.rs
+++ b/src/database/indexer.rs
@@ -349,7 +349,7 @@ impl SessionIndexer {
                 continue;
             };
 
-            self.index_vibe_session_dir(
+            self.index_vibe_session_tree(
                 &path,
                 &fingerprint_target,
                 incremental,
@@ -357,22 +357,58 @@ impl SessionIndexer {
                 &mut stats,
                 errors_detail,
             )?;
-
-            // Spawned agents are stored as sibling sessions under `<session>/agents/`.
-            for (child_path, child_fingerprint) in Self::vibe_agent_child_dirs(&path) {
-                self.index_vibe_session_dir(
-                    &child_path,
-                    &child_fingerprint,
-                    incremental,
-                    &parser,
-                    &mut stats,
-                    errors_detail,
-                )?;
-            }
         }
 
         self.prune_orphan_fingerprints()?;
         Ok(stats)
+    }
+
+    /// Index a Vibe session dir and, recursively, the agent children it
+    /// spawned under `<session>/agents/` (and their own children, for nested
+    /// `task` calls). Returns whether this session dir itself was (re)parsed,
+    /// so a parent can refresh its subagent links when a child appears or
+    /// changes.
+    fn index_vibe_session_tree(
+        &mut self,
+        path: &Path,
+        fingerprint_target: &Path,
+        incremental: bool,
+        parser: &MistralVibeParser,
+        stats: &mut IndexingStats,
+        errors_detail: &mut VecDeque<IndexingError>,
+    ) -> Result<bool> {
+        let mut reparsed = self.index_vibe_session_dir(
+            path,
+            fingerprint_target,
+            incremental,
+            parser,
+            stats,
+            errors_detail,
+        )?;
+
+        let mut child_changed = false;
+        for (child_path, child_fingerprint) in Self::vibe_agent_child_dirs(path) {
+            child_changed |= self.index_vibe_session_tree(
+                &child_path,
+                &child_fingerprint,
+                incremental,
+                parser,
+                stats,
+                errors_detail,
+            )?;
+        }
+
+        // A child directory only contributes to the parent's subagent links
+        // (e.g. `child_session_id`) at parse time. If a child appeared or
+        // changed but the parent was skipped by its `messages.jsonl`
+        // fingerprint, those links would stay stale; force a reparse.
+        if incremental && child_changed && !reparsed {
+            stats.skipped = stats.skipped.saturating_sub(1);
+            self.process_vibe_session_dir(path, fingerprint_target, parser, stats, errors_detail)?;
+            reparsed = true;
+        }
+
+        Ok(reparsed)
     }
 
     fn index_vibe_session_dir(
@@ -383,13 +419,14 @@ impl SessionIndexer {
         parser: &MistralVibeParser,
         stats: &mut IndexingStats,
         errors_detail: &mut VecDeque<IndexingError>,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         if incremental && !self.should_reindex(fingerprint_target)? {
             stats.skipped += 1;
-            return Ok(());
+            return Ok(false);
         }
 
-        self.process_vibe_session_dir(path, fingerprint_target, parser, stats, errors_detail)
+        self.process_vibe_session_dir(path, fingerprint_target, parser, stats, errors_detail)?;
+        Ok(true)
     }
 
     /// Enumerate the child agent session dirs under `<session_dir>/agents/`,
@@ -1991,6 +2028,170 @@ mod tests {
             )
             .unwrap();
         assert_eq!(linked_child, "child-session");
+    }
+
+    fn write_vibe_session_dir(
+        dir: &Path,
+        session_id: &str,
+        agent_name: Option<&str>,
+        messages: &[String],
+    ) {
+        std::fs::create_dir_all(dir).unwrap();
+        let mut meta = serde_json::json!({
+            "session_id": session_id,
+            "parent_session_id": null,
+            "start_time": "2026-01-01T00:00:00Z",
+            "end_time": "2026-01-01T00:01:00Z",
+            "environment": { "working_directory": "/tmp" }
+        });
+        if let Some(name) = agent_name {
+            meta["agent_profile"] = serde_json::json!({ "name": name });
+        }
+        std::fs::write(dir.join("meta.json"), meta.to_string()).unwrap();
+        std::fs::write(dir.join("messages.jsonl"), messages.join("\n")).unwrap();
+    }
+
+    fn vibe_task_messages(agent: &str, call_id: &str) -> Vec<String> {
+        let task_args = serde_json::json!({ "agent": agent, "task": "Review" }).to_string();
+        vec![
+            serde_json::json!({ "role": "user", "content": "Ask the agent" }).to_string(),
+            serde_json::json!({
+                "role": "assistant",
+                "tool_calls": [{
+                    "id": call_id,
+                    "type": "function",
+                    "function": { "name": "task", "arguments": task_args }
+                }]
+            })
+            .to_string(),
+            serde_json::json!({
+                "role": "tool",
+                "tool_call_id": call_id,
+                "content": "Punchline"
+            })
+            .to_string(),
+        ]
+    }
+
+    fn vibe_plain_messages() -> Vec<String> {
+        vec![
+            serde_json::json!({ "role": "user", "content": "Do the bit" }).to_string(),
+            serde_json::json!({ "role": "assistant", "content": "Here is my bit" }).to_string(),
+        ]
+    }
+
+    #[test]
+    fn vibe_indexing_descends_into_nested_grandchildren() {
+        let temp_db = NamedTempFile::new().unwrap();
+        let mut indexer = SessionIndexer::new(temp_db.path()).unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let sessions_dir = temp_dir.path();
+
+        let parent_dir = sessions_dir.join("session_parent");
+        let child_dir = parent_dir.join("agents").join("comique_20260101_000100");
+        let grandchild_dir = child_dir.join("agents").join("clown_20260101_000200");
+
+        write_vibe_session_dir(
+            &parent_dir,
+            "parent-session",
+            None,
+            &vibe_task_messages("comique", "call_1"),
+        );
+        write_vibe_session_dir(
+            &child_dir,
+            "child-session",
+            Some("comique"),
+            &vibe_task_messages("clown", "call_2"),
+        );
+        write_vibe_session_dir(
+            &grandchild_dir,
+            "grandchild-session",
+            Some("clown"),
+            &vibe_plain_messages(),
+        );
+
+        let stats = indexer
+            .index_vibe_sessions_incremental(sessions_dir)
+            .unwrap();
+        assert_eq!(stats.indexed, 3);
+
+        let gc_is_subagent: i64 = indexer
+            .db
+            .query_row(
+                "SELECT is_subagent FROM sessions WHERE id = 'grandchild-session'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(gc_is_subagent, 1);
+
+        let linked: String = indexer
+            .db
+            .query_row(
+                "SELECT child_session_id FROM subagents WHERE session_id = 'child-session'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(linked, "grandchild-session");
+    }
+
+    #[test]
+    fn vibe_incremental_relinks_parent_when_child_appears_later() {
+        let temp_db = NamedTempFile::new().unwrap();
+        let mut indexer = SessionIndexer::new(temp_db.path()).unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let sessions_dir = temp_dir.path();
+        let parent_dir = sessions_dir.join("session_parent");
+
+        // First pass: the parent already logged the `task` call, but the child
+        // directory has not appeared yet, so the link cannot resolve.
+        write_vibe_session_dir(
+            &parent_dir,
+            "parent-session",
+            None,
+            &vibe_task_messages("comique", "call_1"),
+        );
+        let first = indexer
+            .index_vibe_sessions_incremental(sessions_dir)
+            .unwrap();
+        assert_eq!(first.indexed, 1);
+
+        let unlinked: i64 = indexer
+            .db
+            .query_row(
+                "SELECT COUNT(*) FROM subagents \
+                 WHERE session_id = 'parent-session' AND child_session_id IS NULL",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(unlinked, 1);
+
+        // Child directory appears later; the parent's messages.jsonl is unchanged,
+        // so the fingerprint check alone would skip the parent and leave the link
+        // dangling. The child change must trigger a parent reparse.
+        let child_dir = parent_dir.join("agents").join("comique_20260101_000100");
+        write_vibe_session_dir(
+            &child_dir,
+            "child-session",
+            Some("comique"),
+            &vibe_plain_messages(),
+        );
+
+        indexer
+            .index_vibe_sessions_incremental(sessions_dir)
+            .unwrap();
+
+        let linked: String = indexer
+            .db
+            .query_row(
+                "SELECT child_session_id FROM subagents WHERE session_id = 'parent-session'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(linked, "child-session");
     }
 
     #[test]

--- a/src/database/indexer.rs
+++ b/src/database/indexer.rs
@@ -53,6 +53,15 @@ pub(crate) fn opencode_source_available(storage_root: &Path, db_paths: &[PathBuf
     storage_root.exists() || db_paths.iter().any(|path| path.exists())
 }
 
+/// Escape the SQL `LIKE` metacharacters in `value` so it can be used as a
+/// literal prefix with `ESCAPE '\'`.
+fn escape_like_pattern(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
+}
+
 fn opencode_display_path(storage_root: &Path, db_paths: &[PathBuf]) -> String {
     if storage_root.exists() {
         storage_root.display().to_string()
@@ -386,7 +395,10 @@ impl SessionIndexer {
             errors_detail,
         )?;
 
-        let mut child_changed = false;
+        // Drop children whose directories were deleted since the last run, so
+        // their session rows do not linger and the parent's subagent links do
+        // not dangle. A removed direct child counts as a change for the parent.
+        let mut child_changed = self.prune_deleted_vibe_children(path, stats)?;
         for (child_path, child_fingerprint) in Self::vibe_agent_child_dirs(path) {
             child_changed |= self.index_vibe_session_tree(
                 &child_path,
@@ -399,9 +411,10 @@ impl SessionIndexer {
         }
 
         // A child directory only contributes to the parent's subagent links
-        // (e.g. `child_session_id`) at parse time. If a child appeared or
-        // changed but the parent was skipped by its `messages.jsonl`
-        // fingerprint, those links would stay stale; force a reparse.
+        // (e.g. `child_session_id`) at parse time. If a child appeared,
+        // changed, or was removed but the parent was skipped by its
+        // `messages.jsonl` fingerprint, those links would stay stale; force a
+        // reparse.
         if incremental && child_changed && !reparsed {
             stats.skipped = stats.skipped.saturating_sub(1);
             self.process_vibe_session_dir(path, fingerprint_target, parser, stats, errors_detail)?;
@@ -445,6 +458,47 @@ impl SessionIndexer {
             }
         }
         children
+    }
+
+    /// Remove indexed Vibe child sessions under `<session_dir>/agents/` whose
+    /// directories no longer exist on disk, along with any deeper descendants
+    /// they spawned. Returns `true` if a direct child was removed, so the
+    /// parent can be reparsed to drop the now-dangling subagent link.
+    fn prune_deleted_vibe_children(
+        &mut self,
+        session_dir: &Path,
+        stats: &mut IndexingStats,
+    ) -> Result<bool> {
+        let agents_dir = session_dir.join("agents");
+        let Some(agents_str) = agents_dir.to_str() else {
+            return Ok(false);
+        };
+
+        let pattern = format!("{}/%", escape_like_pattern(agents_str));
+        let known: Vec<String> = {
+            let mut stmt = self
+                .db
+                .prepare("SELECT file_path FROM sessions WHERE file_path LIKE ?1 ESCAPE '\\'")?;
+            stmt.query_map([pattern], |row| row.get(0))?
+                .collect::<std::result::Result<Vec<_>, _>>()?
+        };
+
+        let mut removed_direct_child = false;
+        for file_path in known {
+            let child = PathBuf::from(&file_path);
+            if child.exists() {
+                continue;
+            }
+            stats.removed += self.remove_session_for_file(&child)?;
+            // Direct children sit at `<session_dir>/agents/<child>`; deeper
+            // descendants are pruned here too but only a direct child forces the
+            // immediate parent to refresh its links.
+            if child.parent() == Some(agents_dir.as_path()) {
+                removed_direct_child = true;
+            }
+        }
+
+        Ok(removed_direct_child)
     }
 
     fn process_vibe_session_dir(
@@ -2192,6 +2246,76 @@ mod tests {
             )
             .unwrap();
         assert_eq!(linked, "child-session");
+    }
+
+    #[test]
+    fn vibe_incremental_removes_deleted_child_and_relinks_parent() {
+        let temp_db = NamedTempFile::new().unwrap();
+        let mut indexer = SessionIndexer::new(temp_db.path()).unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let sessions_dir = temp_dir.path();
+        let parent_dir = sessions_dir.join("session_parent");
+        let child_dir = parent_dir.join("agents").join("comique_20260101_000100");
+
+        // First pass: parent links its spawned child.
+        write_vibe_session_dir(
+            &parent_dir,
+            "parent-session",
+            None,
+            &vibe_task_messages("comique", "call_1"),
+        );
+        write_vibe_session_dir(
+            &child_dir,
+            "child-session",
+            Some("comique"),
+            &vibe_plain_messages(),
+        );
+        let first = indexer
+            .index_vibe_sessions_incremental(sessions_dir)
+            .unwrap();
+        assert_eq!(first.indexed, 2);
+
+        let linked: String = indexer
+            .db
+            .query_row(
+                "SELECT child_session_id FROM subagents WHERE session_id = 'parent-session'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(linked, "child-session");
+
+        // The child directory is deleted; the parent's messages.jsonl is
+        // unchanged, so only the removal can trigger the relink.
+        std::fs::remove_dir_all(&child_dir).unwrap();
+
+        let second = indexer
+            .index_vibe_sessions_incremental(sessions_dir)
+            .unwrap();
+        assert!(second.removed >= 1);
+
+        // The child session row is gone.
+        let child_rows: i64 = indexer
+            .db
+            .query_row(
+                "SELECT COUNT(*) FROM sessions WHERE id = 'child-session'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(child_rows, 0);
+
+        // The parent was reparsed and no longer links to a now-missing child.
+        let dangling: i64 = indexer
+            .db
+            .query_row(
+                "SELECT COUNT(*) FROM subagents \
+                 WHERE session_id = 'parent-session' AND child_session_id = 'child-session'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(dangling, 0);
     }
 
     #[test]

--- a/src/database/indexer.rs
+++ b/src/database/indexer.rs
@@ -1454,7 +1454,7 @@ impl SessionIndexer {
             build_per_source_result(
                 AiAssistant::Codex,
                 sources.codex_dir.display().to_string(),
-                sources.codex_dir.exists(),
+                !Self::codex_index_roots(&sources.codex_dir).is_empty(),
                 codex,
             ),
             build_per_source_result(
@@ -3009,6 +3009,47 @@ mod tests {
             &[sqlite_path.clone()]
         ));
         assert!(!opencode_source_available(&storage_root, &[]));
+    }
+
+    #[test]
+    fn indexing_diagnostics_codex_available_with_archived_only() {
+        use crate::models::indexing_diagnostics::SourceStatus;
+
+        let temp = tempfile::tempdir().unwrap();
+        let codex_home = temp.path().join("codex");
+        // Active sessions dir is absent; only the adjacent archive remains.
+        let sessions_dir = codex_home.join("sessions");
+        let archived_dir = codex_home.join("archived_sessions");
+        std::fs::create_dir_all(&archived_dir).unwrap();
+        std::fs::write(
+            archived_dir.join("rollout-2026-01-01T00-00-00-archived.jsonl"),
+            concat!(
+                "{\"type\":\"session_meta\",\"payload\":{\"id\":\"archive-only-availability\",\"timestamp\":\"2026-01-01T00:00:00Z\",\"cwd\":\"/tmp\"}}\n",
+                "{\"type\":\"event_msg\",\"timestamp\":\"2026-01-01T00:00:01Z\",\"payload\":{\"type\":\"user_message\",\"message\":\"Hi archived\"}}\n",
+                "{\"type\":\"event_msg\",\"timestamp\":\"2026-01-01T00:00:02Z\",\"payload\":{\"type\":\"agent_message\",\"message\":\"Done\"}}\n"
+            ),
+        )
+        .unwrap();
+
+        let sources = SessionSources {
+            codex_dir: sessions_dir.clone(),
+            ..SessionSources::resolve(Some(temp.path()))
+        };
+
+        let temp_db = tempfile::NamedTempFile::new().unwrap();
+        let mut indexer = SessionIndexer::new(temp_db.path()).unwrap();
+        let result = indexer.index_all_incremental(&sources).unwrap();
+
+        let codex = result
+            .per_source
+            .iter()
+            .find(|source| source.assistant == AiAssistant::Codex)
+            .unwrap();
+
+        // Archived rollouts are indexed, so the status must reflect availability
+        // rather than reporting NotFound from the absent `sessions/` dir.
+        assert_eq!(codex.indexed, 1);
+        assert_ne!(codex.status, SourceStatus::NotFound);
     }
 
     #[test]

--- a/src/database/indexer.rs
+++ b/src/database/indexer.rs
@@ -645,7 +645,10 @@ impl SessionIndexer {
         if sessions_dir.exists() {
             roots.push(sessions_dir.to_path_buf());
         }
-        if sessions_dir.file_name().and_then(|name| name.to_str()) == Some("sessions")
+        if sessions_dir
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| matches!(name, "sessions" | "codex_sessions"))
             && let Some(codex_home) = sessions_dir.parent()
         {
             let archived = codex_home.join("archived_sessions");
@@ -1937,6 +1940,41 @@ mod tests {
             .db
             .query_row(
                 "SELECT COUNT(*) > 0 FROM sessions WHERE id = 'archived-rollout'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(exists);
+    }
+
+    #[test]
+    fn codex_indexing_includes_archived_rollouts_next_to_override_dir() {
+        let temp_db = NamedTempFile::new().unwrap();
+        let mut indexer = SessionIndexer::new(temp_db.path()).unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let sessions_dir = temp_dir.path().join("codex_sessions");
+        let archived_dir = temp_dir.path().join("archived_sessions");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+        std::fs::create_dir_all(&archived_dir).unwrap();
+        std::fs::write(
+            archived_dir.join("rollout-2026-01-01T00-00-00-archived.jsonl"),
+            concat!(
+                "{\"type\":\"session_meta\",\"payload\":{\"id\":\"override-archived-rollout\",\"timestamp\":\"2026-01-01T00:00:00Z\",\"cwd\":\"/tmp\"}}\n",
+                "{\"type\":\"event_msg\",\"timestamp\":\"2026-01-01T00:00:01Z\",\"payload\":{\"type\":\"user_message\",\"message\":\"Hi archived\"}}\n",
+                "{\"type\":\"event_msg\",\"timestamp\":\"2026-01-01T00:00:02Z\",\"payload\":{\"type\":\"agent_message\",\"message\":\"Done\"}}\n"
+            ),
+        )
+        .unwrap();
+
+        let stats = indexer
+            .index_codex_sessions_incremental(&sessions_dir)
+            .unwrap();
+
+        assert_eq!(stats.indexed, 1);
+        let exists: bool = indexer
+            .db
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM sessions WHERE id = 'override-archived-rollout'",
                 [],
                 |row| row.get(0),
             )

--- a/src/database/indexer.rs
+++ b/src/database/indexer.rs
@@ -293,22 +293,24 @@ impl SessionIndexer {
         let parser = CodexParser;
         let mut stats = IndexingStats::default();
 
-        for entry in walkdir::WalkDir::new(sessions_dir)
-            .max_depth(5)
-            .into_iter()
-            .filter_map(|e| e.ok())
-        {
-            let path = entry.path();
-            if !Self::is_codex_session_file(path) {
-                continue;
-            }
+        for root in Self::codex_index_roots(sessions_dir) {
+            for entry in walkdir::WalkDir::new(&root)
+                .max_depth(5)
+                .into_iter()
+                .filter_map(|e| e.ok())
+            {
+                let path = entry.path();
+                if !Self::is_codex_session_file(path) {
+                    continue;
+                }
 
-            if incremental && !self.should_reindex(path)? {
-                stats.skipped += 1;
-                continue;
-            }
+                if incremental && !self.should_reindex(path)? {
+                    stats.skipped += 1;
+                    continue;
+                }
 
-            self.process_codex_session_file(path, &parser, &mut stats, errors_detail);
+                self.process_codex_session_file(path, &parser, &mut stats, errors_detail);
+            }
         }
 
         self.prune_orphan_fingerprints()?;
@@ -496,7 +498,23 @@ impl SessionIndexer {
             && path
                 .file_name()
                 .and_then(|name| name.to_str())
-                .is_some_and(|name| name.starts_with("rollout-") && name.ends_with(".jsonl"))
+                .is_some_and(|name| {
+                    name.starts_with("rollout-")
+                        && (name.ends_with(".jsonl") || name.ends_with(".jsonl.zst"))
+                })
+    }
+
+    fn codex_index_roots(sessions_dir: &Path) -> Vec<PathBuf> {
+        let mut roots = vec![sessions_dir.to_path_buf()];
+        if sessions_dir.file_name().and_then(|name| name.to_str()) == Some("sessions")
+            && let Some(codex_home) = sessions_dir.parent()
+        {
+            let archived = codex_home.join("archived_sessions");
+            if archived.exists() {
+                roots.push(archived);
+            }
+        }
+        roots
     }
 
     fn prune_sidechain_session(
@@ -1749,6 +1767,53 @@ mod tests {
             .unwrap();
         assert_eq!(second.indexed, 0);
         assert!(second.skipped > 0);
+    }
+
+    #[test]
+    fn codex_indexing_includes_archived_rollouts_next_to_sessions_dir() {
+        let temp_db = NamedTempFile::new().unwrap();
+        let mut indexer = SessionIndexer::new(temp_db.path()).unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let codex_home = temp_dir.path();
+        let sessions_dir = codex_home.join("sessions");
+        let archived_dir = codex_home.join("archived_sessions");
+        std::fs::create_dir_all(sessions_dir.join("2026/01/01")).unwrap();
+        std::fs::create_dir_all(&archived_dir).unwrap();
+        std::fs::write(
+            archived_dir.join("rollout-2026-01-01T00-00-00-archived.jsonl"),
+            concat!(
+                "{\"type\":\"session_meta\",\"payload\":{\"id\":\"archived-rollout\",\"timestamp\":\"2026-01-01T00:00:00Z\",\"cwd\":\"/tmp\"}}\n",
+                "{\"type\":\"event_msg\",\"timestamp\":\"2026-01-01T00:00:01Z\",\"payload\":{\"type\":\"user_message\",\"message\":\"Hi archived\"}}\n",
+                "{\"type\":\"event_msg\",\"timestamp\":\"2026-01-01T00:00:02Z\",\"payload\":{\"type\":\"agent_message\",\"message\":\"Done\"}}\n"
+            ),
+        )
+        .unwrap();
+
+        let stats = indexer
+            .index_codex_sessions_incremental(&sessions_dir)
+            .unwrap();
+
+        assert_eq!(stats.indexed, 1);
+        let exists: bool = indexer
+            .db
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM sessions WHERE id = 'archived-rollout'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(exists);
+    }
+
+    #[test]
+    fn codex_session_file_matcher_accepts_compressed_rollouts() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir
+            .path()
+            .join("rollout-2026-01-01T00-00-00-session.jsonl.zst");
+        std::fs::write(&path, []).unwrap();
+
+        assert!(SessionIndexer::is_codex_session_file(&path));
     }
 
     #[test]

--- a/src/database/indexer.rs
+++ b/src/database/indexer.rs
@@ -460,10 +460,18 @@ impl SessionIndexer {
         children
     }
 
-    /// Remove indexed Vibe child sessions under `<session_dir>/agents/` whose
-    /// directories no longer exist on disk, along with any deeper descendants
-    /// they spawned. Returns `true` if a direct child was removed, so the
-    /// parent can be reparsed to drop the now-dangling subagent link.
+    /// Remove indexed Vibe child sessions whose **direct** child directory under
+    /// `<session_dir>/agents/` no longer exists on disk, cascading the removal to
+    /// every session beneath that deleted child. Returns `true` if a direct child
+    /// was removed, so the immediate parent can be reparsed to drop the
+    /// now-dangling subagent link.
+    ///
+    /// Each parent prunes only its own direct children: an ancestor must not
+    /// remove a grandchild on the intermediate parent's behalf, or that
+    /// intermediate would never observe the change and would keep a dangling
+    /// link. Cascading to the deleted child's subtree still cleans up the case
+    /// where an entire intermediate directory was removed (no surviving
+    /// directory recurses into it).
     fn prune_deleted_vibe_children(
         &mut self,
         session_dir: &Path,
@@ -486,19 +494,43 @@ impl SessionIndexer {
         let mut removed_direct_child = false;
         for file_path in known {
             let child = PathBuf::from(&file_path);
+            // Only act on direct children; deeper descendants are removed as part
+            // of the subtree of whichever direct child is gone.
+            if child.parent() != Some(agents_dir.as_path()) {
+                continue;
+            }
             if child.exists() {
                 continue;
             }
-            stats.removed += self.remove_session_for_file(&child)?;
-            // Direct children sit at `<session_dir>/agents/<child>`; deeper
-            // descendants are pruned here too but only a direct child forces the
-            // immediate parent to refresh its links.
-            if child.parent() == Some(agents_dir.as_path()) {
-                removed_direct_child = true;
-            }
+            stats.removed += self.remove_vibe_session_subtree(&child)?;
+            removed_direct_child = true;
         }
 
         Ok(removed_direct_child)
+    }
+
+    /// Remove a Vibe session directory and every session indexed beneath it,
+    /// returning the number of session rows removed. Used when a child directory
+    /// is deleted so its spawned descendants do not linger as orphans.
+    fn remove_vibe_session_subtree(&mut self, dir: &Path) -> Result<usize> {
+        let mut removed = self.remove_session_for_file(dir)?;
+
+        let Some(dir_str) = dir.to_str() else {
+            return Ok(removed);
+        };
+        let pattern = format!("{}/%", escape_like_pattern(dir_str));
+        let descendants: Vec<String> = {
+            let mut stmt = self
+                .db
+                .prepare("SELECT file_path FROM sessions WHERE file_path LIKE ?1 ESCAPE '\\'")?;
+            stmt.query_map([pattern], |row| row.get(0))?
+                .collect::<std::result::Result<Vec<_>, _>>()?
+        };
+        for file_path in descendants {
+            removed += self.remove_session_for_file(Path::new(&file_path))?;
+        }
+
+        Ok(removed)
     }
 
     fn process_vibe_session_dir(
@@ -2358,6 +2390,137 @@ mod tests {
             )
             .unwrap();
         assert_eq!(linked, "child-session");
+    }
+
+    #[test]
+    fn vibe_incremental_relinks_intermediate_when_grandchild_deleted() {
+        let temp_db = NamedTempFile::new().unwrap();
+        let mut indexer = SessionIndexer::new(temp_db.path()).unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let sessions_dir = temp_dir.path();
+        let parent_dir = sessions_dir.join("session_parent");
+        let child_dir = parent_dir.join("agents").join("comique_20260101_000100");
+        let grandchild_dir = child_dir.join("agents").join("clown_20260101_000200");
+
+        // A spawns B (comique), B spawns C (clown).
+        write_vibe_session_dir(
+            &parent_dir,
+            "parent-session",
+            None,
+            &vibe_task_messages("comique", "call_1"),
+        );
+        write_vibe_session_dir(
+            &child_dir,
+            "child-session",
+            Some("comique"),
+            &vibe_task_messages("clown", "call_2"),
+        );
+        write_vibe_session_dir(
+            &grandchild_dir,
+            "grandchild-session",
+            Some("clown"),
+            &vibe_plain_messages(),
+        );
+        let first = indexer
+            .index_vibe_sessions_incremental(sessions_dir)
+            .unwrap();
+        assert_eq!(first.indexed, 3);
+
+        // Delete ONLY the grandchild. The intermediate child's messages.jsonl is
+        // unchanged, so the grandchild removal must still force the intermediate
+        // to reparse and drop its now-dangling link.
+        std::fs::remove_dir_all(&grandchild_dir).unwrap();
+        let second = indexer
+            .index_vibe_sessions_incremental(sessions_dir)
+            .unwrap();
+        assert!(second.removed >= 1);
+
+        let grandchild_rows: i64 = indexer
+            .db
+            .query_row(
+                "SELECT COUNT(*) FROM sessions WHERE id = 'grandchild-session'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(grandchild_rows, 0);
+
+        let dangling: i64 = indexer
+            .db
+            .query_row(
+                "SELECT COUNT(*) FROM subagents \
+                 WHERE session_id = 'child-session' AND child_session_id = 'grandchild-session'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            dangling, 0,
+            "intermediate still links to deleted grandchild"
+        );
+    }
+
+    #[test]
+    fn vibe_incremental_removes_whole_subtree_when_intermediate_deleted() {
+        let temp_db = NamedTempFile::new().unwrap();
+        let mut indexer = SessionIndexer::new(temp_db.path()).unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let sessions_dir = temp_dir.path();
+        let parent_dir = sessions_dir.join("session_parent");
+        let child_dir = parent_dir.join("agents").join("comique_20260101_000100");
+        let grandchild_dir = child_dir.join("agents").join("clown_20260101_000200");
+
+        write_vibe_session_dir(
+            &parent_dir,
+            "parent-session",
+            None,
+            &vibe_task_messages("comique", "call_1"),
+        );
+        write_vibe_session_dir(
+            &child_dir,
+            "child-session",
+            Some("comique"),
+            &vibe_task_messages("clown", "call_2"),
+        );
+        write_vibe_session_dir(
+            &grandchild_dir,
+            "grandchild-session",
+            Some("clown"),
+            &vibe_plain_messages(),
+        );
+        indexer
+            .index_vibe_sessions_incremental(sessions_dir)
+            .unwrap();
+
+        // Delete the whole intermediate subtree (B and its grandchild C). The
+        // grandchild must not survive as an orphan even though no surviving
+        // directory recurses into it.
+        std::fs::remove_dir_all(&child_dir).unwrap();
+        indexer
+            .index_vibe_sessions_incremental(sessions_dir)
+            .unwrap();
+
+        let surviving: i64 = indexer
+            .db
+            .query_row(
+                "SELECT COUNT(*) FROM sessions \
+                 WHERE id IN ('child-session', 'grandchild-session')",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(surviving, 0, "deleted subtree left orphan session rows");
+
+        let dangling: i64 = indexer
+            .db
+            .query_row(
+                "SELECT COUNT(*) FROM subagents \
+                 WHERE session_id = 'parent-session' AND child_session_id = 'child-session'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(dangling, 0, "parent still links to deleted child");
     }
 
     #[test]

--- a/src/database/indexer.rs
+++ b/src/database/indexer.rs
@@ -286,14 +286,15 @@ impl SessionIndexer {
         incremental: bool,
         errors_detail: &mut VecDeque<IndexingError>,
     ) -> Result<IndexingStats> {
-        if !sessions_dir.exists() {
+        let roots = Self::codex_index_roots(sessions_dir);
+        if roots.is_empty() {
             return Ok(IndexingStats::default());
         }
 
         let parser = CodexParser;
         let mut stats = IndexingStats::default();
 
-        for root in Self::codex_index_roots(sessions_dir) {
+        for root in roots {
             for entry in walkdir::WalkDir::new(&root)
                 .max_depth(5)
                 .into_iter()
@@ -549,7 +550,10 @@ impl SessionIndexer {
     }
 
     fn codex_index_roots(sessions_dir: &Path) -> Vec<PathBuf> {
-        let mut roots = vec![sessions_dir.to_path_buf()];
+        let mut roots = Vec::new();
+        if sessions_dir.exists() {
+            roots.push(sessions_dir.to_path_buf());
+        }
         if sessions_dir.file_name().and_then(|name| name.to_str()) == Some("sessions")
             && let Some(codex_home) = sessions_dir.parent()
         {
@@ -1842,6 +1846,42 @@ mod tests {
             .db
             .query_row(
                 "SELECT COUNT(*) > 0 FROM sessions WHERE id = 'archived-rollout'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(exists);
+    }
+
+    #[test]
+    fn codex_indexing_includes_archived_rollouts_when_sessions_dir_absent() {
+        let temp_db = NamedTempFile::new().unwrap();
+        let mut indexer = SessionIndexer::new(temp_db.path()).unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let codex_home = temp_dir.path();
+        // Active sessions dir does not exist; only archives remain.
+        let sessions_dir = codex_home.join("sessions");
+        let archived_dir = codex_home.join("archived_sessions");
+        std::fs::create_dir_all(&archived_dir).unwrap();
+        std::fs::write(
+            archived_dir.join("rollout-2026-01-01T00-00-00-archived.jsonl"),
+            concat!(
+                "{\"type\":\"session_meta\",\"payload\":{\"id\":\"archive-only-rollout\",\"timestamp\":\"2026-01-01T00:00:00Z\",\"cwd\":\"/tmp\"}}\n",
+                "{\"type\":\"event_msg\",\"timestamp\":\"2026-01-01T00:00:01Z\",\"payload\":{\"type\":\"user_message\",\"message\":\"Hi archived\"}}\n",
+                "{\"type\":\"event_msg\",\"timestamp\":\"2026-01-01T00:00:02Z\",\"payload\":{\"type\":\"agent_message\",\"message\":\"Done\"}}\n"
+            ),
+        )
+        .unwrap();
+
+        let stats = indexer
+            .index_codex_sessions_incremental(&sessions_dir)
+            .unwrap();
+
+        assert_eq!(stats.indexed, 1);
+        let exists: bool = indexer
+            .db
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM sessions WHERE id = 'archive-only-rollout'",
                 [],
                 |row| row.get(0),
             )

--- a/src/database/indexer.rs
+++ b/src/database/indexer.rs
@@ -2287,6 +2287,80 @@ mod tests {
     }
 
     #[test]
+    fn vibe_incremental_defers_child_link_until_child_messages_appear() {
+        let temp_db = NamedTempFile::new().unwrap();
+        let mut indexer = SessionIndexer::new(temp_db.path()).unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let sessions_dir = temp_dir.path();
+        let parent_dir = sessions_dir.join("session_parent");
+        let child_dir = parent_dir.join("agents").join("comique_20260101_000100");
+
+        // First pass: the parent logged its `task` call and the child directory
+        // already exists with a `meta.json`, but the child has not written its
+        // `messages.jsonl` yet (still starting up). The indexer cannot index the
+        // child, so the parent must not emit a dangling link to it.
+        write_vibe_session_dir(
+            &parent_dir,
+            "parent-session",
+            None,
+            &vibe_task_messages("comique", "call_1"),
+        );
+        std::fs::create_dir_all(&child_dir).unwrap();
+        std::fs::write(
+            child_dir.join("meta.json"),
+            serde_json::json!({
+                "session_id": "child-session",
+                "parent_session_id": null,
+                "start_time": "2026-01-01T00:01:00Z",
+                "end_time": null,
+                "agent_profile": { "name": "comique" },
+                "environment": { "working_directory": "/tmp" }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let first = indexer
+            .index_vibe_sessions_incremental(sessions_dir)
+            .unwrap();
+        assert_eq!(first.indexed, 1);
+
+        let unlinked: i64 = indexer
+            .db
+            .query_row(
+                "SELECT COUNT(*) FROM subagents \
+                 WHERE session_id = 'parent-session' AND child_session_id IS NULL",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(unlinked, 1);
+
+        // The child finishes writing its messages; the parent's messages.jsonl is
+        // unchanged, so the newly indexable child must trigger a parent reparse
+        // that finally resolves the link.
+        std::fs::write(
+            child_dir.join("messages.jsonl"),
+            vibe_plain_messages().join("\n"),
+        )
+        .unwrap();
+
+        indexer
+            .index_vibe_sessions_incremental(sessions_dir)
+            .unwrap();
+
+        let linked: String = indexer
+            .db
+            .query_row(
+                "SELECT child_session_id FROM subagents WHERE session_id = 'parent-session'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(linked, "child-session");
+    }
+
+    #[test]
     fn vibe_incremental_removes_deleted_child_and_relinks_parent() {
         let temp_db = NamedTempFile::new().unwrap();
         let mut indexer = SessionIndexer::new(temp_db.path()).unwrap();

--- a/src/database/indexer.rs
+++ b/src/database/indexer.rs
@@ -347,22 +347,66 @@ impl SessionIndexer {
             else {
                 continue;
             };
-            if incremental && !self.should_reindex(&fingerprint_target)? {
-                stats.skipped += 1;
-                continue;
-            }
 
-            self.process_vibe_session_dir(
+            self.index_vibe_session_dir(
                 &path,
                 &fingerprint_target,
+                incremental,
                 &parser,
                 &mut stats,
                 errors_detail,
             )?;
+
+            // Spawned agents are stored as sibling sessions under `<session>/agents/`.
+            for (child_path, child_fingerprint) in Self::vibe_agent_child_dirs(&path) {
+                self.index_vibe_session_dir(
+                    &child_path,
+                    &child_fingerprint,
+                    incremental,
+                    &parser,
+                    &mut stats,
+                    errors_detail,
+                )?;
+            }
         }
 
         self.prune_orphan_fingerprints()?;
         Ok(stats)
+    }
+
+    fn index_vibe_session_dir(
+        &mut self,
+        path: &Path,
+        fingerprint_target: &Path,
+        incremental: bool,
+        parser: &MistralVibeParser,
+        stats: &mut IndexingStats,
+        errors_detail: &mut VecDeque<IndexingError>,
+    ) -> Result<()> {
+        if incremental && !self.should_reindex(fingerprint_target)? {
+            stats.skipped += 1;
+            return Ok(());
+        }
+
+        self.process_vibe_session_dir(path, fingerprint_target, parser, stats, errors_detail)
+    }
+
+    /// Enumerate the child agent session dirs under `<session_dir>/agents/`,
+    /// returning `(session_dir, messages.jsonl)` pairs for each valid one.
+    fn vibe_agent_child_dirs(session_dir: &Path) -> Vec<(PathBuf, PathBuf)> {
+        let Ok(entries) = std::fs::read_dir(session_dir.join("agents")) else {
+            return Vec::new();
+        };
+
+        let mut children = Vec::new();
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let fingerprint_target = path.join("messages.jsonl");
+            if path.is_dir() && path.join("meta.json").exists() && fingerprint_target.exists() {
+                children.push((path, fingerprint_target));
+            }
+        }
+        children
     }
 
     fn process_vibe_session_dir(
@@ -1814,6 +1858,99 @@ mod tests {
         std::fs::write(&path, []).unwrap();
 
         assert!(SessionIndexer::is_codex_session_file(&path));
+    }
+
+    #[test]
+    fn vibe_indexing_indexes_agent_children_and_links_parent() {
+        let temp_db = NamedTempFile::new().unwrap();
+        let mut indexer = SessionIndexer::new(temp_db.path()).unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let sessions_dir = temp_dir.path();
+        let parent_dir = sessions_dir.join("session_parent");
+        let child_dir = parent_dir.join("agents").join("comique_20260101_000100");
+        std::fs::create_dir_all(&child_dir).unwrap();
+
+        std::fs::write(
+            parent_dir.join("meta.json"),
+            serde_json::json!({
+                "session_id": "parent-session",
+                "parent_session_id": null,
+                "start_time": "2026-01-01T00:00:00Z",
+                "end_time": "2026-01-01T00:01:00Z",
+                "environment": { "working_directory": "/tmp" }
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let task_args = serde_json::json!({ "agent": "comique", "task": "Review" }).to_string();
+        let parent_messages = [
+            serde_json::json!({ "role": "user", "content": "Ask the comedian" }).to_string(),
+            serde_json::json!({
+                "role": "assistant",
+                "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": { "name": "task", "arguments": task_args }
+                }]
+            })
+            .to_string(),
+            serde_json::json!({
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": "Punchline"
+            })
+            .to_string(),
+        ];
+        std::fs::write(
+            parent_dir.join("messages.jsonl"),
+            parent_messages.join("\n"),
+        )
+        .unwrap();
+
+        std::fs::write(
+            child_dir.join("meta.json"),
+            serde_json::json!({
+                "session_id": "child-session",
+                "parent_session_id": null,
+                "start_time": "2026-01-01T00:01:00Z",
+                "end_time": "2026-01-01T00:01:30Z",
+                "environment": { "working_directory": "/tmp" },
+                "agent_profile": { "name": "comique" }
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let child_messages = [
+            serde_json::json!({ "role": "user", "content": "Do the bit" }).to_string(),
+            serde_json::json!({ "role": "assistant", "content": "Here is my bit" }).to_string(),
+        ];
+        std::fs::write(child_dir.join("messages.jsonl"), child_messages.join("\n")).unwrap();
+
+        let stats = indexer
+            .index_vibe_sessions_incremental(sessions_dir)
+            .unwrap();
+
+        assert_eq!(stats.indexed, 2);
+
+        let child_is_subagent: i64 = indexer
+            .db
+            .query_row(
+                "SELECT is_subagent FROM sessions WHERE id = 'child-session'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(child_is_subagent, 1);
+
+        let linked_child: String = indexer
+            .db
+            .query_row(
+                "SELECT child_session_id FROM subagents WHERE session_id = 'parent-session'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(linked_child, "child-session");
     }
 
     #[test]

--- a/src/database/schema.rs
+++ b/src/database/schema.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use rusqlite::Connection;
 
 #[cfg(test)]
-const CURRENT_DB_VERSION: i64 = 13;
+const CURRENT_DB_VERSION: i64 = 14;
 
 fn column_exists(conn: &Connection, table_name: &str, column_name: &str) -> Result<bool> {
     Ok(conn.query_row(
@@ -44,6 +44,9 @@ fn table_exists(conn: &Connection, name: &str) -> Result<bool> {
 ///   13 – replace FTS5-virtual `messages` with a b-tree source table backed
 ///        by an FTS5 external-content `messages_fts` index; clear
 ///        file_fingerprints to force reindexing from JSONL
+///   14 – clear file_fingerprints to re-index after Mistral Vibe subagent
+///        support: parents must be re-parsed to emit subagent rows linking the
+///        child sessions now indexed from `<session>/agents/`
 pub fn initialize_database(conn: &Connection) -> Result<()> {
     let version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
 
@@ -85,6 +88,9 @@ pub fn initialize_database(conn: &Connection) -> Result<()> {
     }
     if version < 13 {
         apply_v13_migration(conn)?;
+    }
+    if version < 14 {
+        apply_v14_migration(conn)?;
     }
 
     Ok(())
@@ -580,6 +586,19 @@ fn apply_v13_migration(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
+/// Migrate from v13 to v14.
+///
+/// Clears `file_fingerprints` so the next incremental index re-parses every
+/// session. This is required for Mistral Vibe subagent support: previously
+/// unchanged parent sessions are skipped by the incremental indexer, so without
+/// a fingerprint clear they would never emit the subagent rows that link the
+/// child sessions now discovered under `<session>/agents/`.
+fn apply_v14_migration(conn: &Connection) -> Result<()> {
+    conn.execute("DELETE FROM file_fingerprints", [])?;
+    conn.execute_batch("PRAGMA user_version = 14")?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -898,6 +917,34 @@ mod tests {
             .unwrap();
 
         assert_eq!(message_count, 0);
+        assert_eq!(fingerprint_count, 0);
+    }
+
+    #[test]
+    fn v13_to_v14_migration_clears_fingerprints() {
+        let conn = Connection::open_in_memory().unwrap();
+        initialize_database(&conn).unwrap();
+
+        conn.execute_batch("PRAGMA user_version = 13").unwrap();
+        conn.execute(
+            "INSERT INTO file_fingerprints (file_path, mtime_ns, size)
+             VALUES ('/tmp/old.jsonl', 10, 20)",
+            [],
+        )
+        .unwrap();
+
+        initialize_database(&conn).unwrap();
+
+        let version: i64 = conn
+            .query_row("PRAGMA user_version", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(version, CURRENT_DB_VERSION);
+
+        let fingerprint_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM file_fingerprints", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
         assert_eq!(fingerprint_count, 0);
     }
 

--- a/src/database/schema.rs
+++ b/src/database/schema.rs
@@ -159,6 +159,12 @@ fn apply_v1_migration(conn: &Connection) -> Result<()> {
         "CREATE INDEX IF NOT EXISTS idx_parent_session ON sessions(parent_session_id)",
         [],
     )?;
+    // Serves prefix-range lookups of sessions beneath a directory (e.g. pruning
+    // deleted Mistral Vibe subagent subtrees) without scanning the table.
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_sessions_file_path ON sessions(file_path)",
+        [],
+    )?;
 
     // FTS5 messages table (unchanged from v0; IF NOT EXISTS is safe)
     conn.execute(

--- a/src/database/schema.rs
+++ b/src/database/schema.rs
@@ -46,7 +46,8 @@ fn table_exists(conn: &Connection, name: &str) -> Result<bool> {
 ///        file_fingerprints to force reindexing from JSONL
 ///   14 – clear file_fingerprints to re-index after Mistral Vibe subagent
 ///        support: parents must be re-parsed to emit subagent rows linking the
-///        child sessions now indexed from `<session>/agents/`
+///        child sessions now indexed from `<session>/agents/`; add an index on
+///        sessions.file_path for efficient Vibe subtree pruning
 pub fn initialize_database(conn: &Connection) -> Result<()> {
     let version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
 
@@ -159,13 +160,6 @@ fn apply_v1_migration(conn: &Connection) -> Result<()> {
         "CREATE INDEX IF NOT EXISTS idx_parent_session ON sessions(parent_session_id)",
         [],
     )?;
-    // Serves prefix-range lookups of sessions beneath a directory (e.g. pruning
-    // deleted Mistral Vibe subagent subtrees) without scanning the table.
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_sessions_file_path ON sessions(file_path)",
-        [],
-    )?;
-
     // FTS5 messages table (unchanged from v0; IF NOT EXISTS is safe)
     conn.execute(
         "CREATE VIRTUAL TABLE IF NOT EXISTS messages USING fts5(
@@ -598,8 +592,14 @@ fn apply_v13_migration(conn: &Connection) -> Result<()> {
 /// session. This is required for Mistral Vibe subagent support: previously
 /// unchanged parent sessions are skipped by the incremental indexer, so without
 /// a fingerprint clear they would never emit the subagent rows that link the
-/// child sessions now discovered under `<session>/agents/`.
+/// child sessions now discovered under `<session>/agents/`. Adds an index on
+/// `sessions.file_path` to serve prefix-range lookups used when pruning deleted
+/// Mistral Vibe subagent subtrees.
 fn apply_v14_migration(conn: &Connection) -> Result<()> {
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_sessions_file_path ON sessions(file_path)",
+        [],
+    )?;
     conn.execute("DELETE FROM file_fingerprints", [])?;
     conn.execute_batch("PRAGMA user_version = 14")?;
     Ok(())
@@ -927,11 +927,15 @@ mod tests {
     }
 
     #[test]
-    fn v13_to_v14_migration_clears_fingerprints() {
+    fn v13_to_v14_migration_clears_fingerprints_and_indexes_file_path() {
         let conn = Connection::open_in_memory().unwrap();
         initialize_database(&conn).unwrap();
 
-        conn.execute_batch("PRAGMA user_version = 13").unwrap();
+        conn.execute_batch(
+            "DROP INDEX idx_sessions_file_path;
+             PRAGMA user_version = 13;",
+        )
+        .unwrap();
         conn.execute(
             "INSERT INTO file_fingerprints (file_path, mtime_ns, size)
              VALUES ('/tmp/old.jsonl', 10, 20)",
@@ -952,6 +956,11 @@ mod tests {
             })
             .unwrap();
         assert_eq!(fingerprint_count, 0);
+        assert!(index_exists(&conn, "idx_sessions_file_path"));
+        assert_eq!(
+            index_columns(&conn, "idx_sessions_file_path"),
+            vec!["file_path"]
+        );
     }
 
     #[test]

--- a/src/parsers/codex.rs
+++ b/src/parsers/codex.rs
@@ -3,7 +3,7 @@ use chrono::{DateTime, Utc};
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, Read};
 use std::path::Path;
 
 use crate::models::{
@@ -1004,10 +1004,24 @@ fn extract_parent_thread_id(source: Option<&Value>) -> Option<String> {
         })
 }
 
+fn open_rollout_reader(file_path: &Path) -> Result<Box<dyn BufRead>> {
+    let file = File::open(file_path).context("Failed to open session file")?;
+    if file_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.ends_with(".jsonl.zst"))
+    {
+        let decoder = zstd::stream::read::Decoder::new(file)
+            .context("Failed to open compressed session file")?;
+        return Ok(Box::new(BufReader::new(Box::new(decoder) as Box<dyn Read>)));
+    }
+
+    Ok(Box::new(BufReader::new(file)))
+}
+
 impl CodexParser {
     pub fn parse(&self, file_path: &Path) -> Result<ParsedSession> {
-        let file = File::open(file_path).context("Failed to open session file")?;
-        let reader = BufReader::new(file);
+        let reader = open_rollout_reader(file_path)?;
 
         let mut lines = reader.lines();
 
@@ -1058,7 +1072,12 @@ impl CodexParser {
             .get("cwd")
             .and_then(|v| v.as_str())
             .map(str::to_string);
-        let parent_session_id = extract_parent_thread_id(payload.get("source"));
+        let parent_session_id = extract_parent_thread_id(payload.get("source")).or_else(|| {
+            payload
+                .get("parent_thread_id")
+                .and_then(|value| value.as_str())
+                .map(str::to_string)
+        });
         let is_subagent = parent_session_id.is_some();
 
         let mut state = ParseState::new(session_id.clone(), start_time);
@@ -1547,6 +1566,41 @@ mod tests {
             parsed.session.parent_session_id.as_deref(),
             Some("019da0bb-541a-74e2-ae0a-6693c5e4fe04")
         );
+    }
+
+    #[test]
+    fn parse_child_session_uses_direct_parent_thread_id_fallback() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        writeln!(file, r#"{{"type":"session_meta","payload":{{"id":"child-direct-parent","parent_thread_id":"019da0bb-541a-74e2-ae0a-6693c5e4fe04","timestamp":"2026-01-01T00:00:00Z","cwd":"/tmp","source":{{"cli":{{}}}}}}}}"#).unwrap();
+        writeln!(file, r#"{{"type":"event_msg","timestamp":"2026-01-01T00:00:01Z","payload":{{"type":"user_message","message":"Hi"}}}}"#).unwrap();
+        writeln!(file, r#"{{"type":"event_msg","timestamp":"2026-01-01T00:00:02Z","payload":{{"type":"agent_message","message":"Done"}}}}"#).unwrap();
+
+        let parsed = CodexParser.parse(file.path()).unwrap();
+
+        assert!(parsed.session.is_subagent);
+        assert_eq!(
+            parsed.session.parent_session_id.as_deref(),
+            Some("019da0bb-541a-74e2-ae0a-6693c5e4fe04")
+        );
+    }
+
+    #[test]
+    fn parse_reads_compressed_jsonl_zst_rollout() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir
+            .path()
+            .join("rollout-2026-01-01T00-00-00-compressed.jsonl.zst");
+        let file = std::fs::File::create(&path).unwrap();
+        let mut encoder = zstd::stream::write::Encoder::new(file, 0).unwrap();
+        writeln!(encoder, r#"{{"type":"session_meta","payload":{{"id":"compressed-rollout","timestamp":"2026-01-01T00:00:00Z","cwd":"/tmp"}}}}"#).unwrap();
+        writeln!(encoder, r#"{{"type":"event_msg","timestamp":"2026-01-01T00:00:01Z","payload":{{"type":"user_message","message":"Hi compressed"}}}}"#).unwrap();
+        writeln!(encoder, r#"{{"type":"event_msg","timestamp":"2026-01-01T00:00:02Z","payload":{{"type":"agent_message","message":"Done"}}}}"#).unwrap();
+        encoder.finish().unwrap();
+
+        let parsed = CodexParser.parse(&path).unwrap();
+
+        assert_eq!(parsed.session.id, "compressed-rollout");
+        assert_eq!(parsed.messages[0].content, "Hi compressed");
     }
 
     #[test]

--- a/src/parsers/codex.rs
+++ b/src/parsers/codex.rs
@@ -3,7 +3,7 @@ use chrono::{DateTime, Utc};
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
-use std::io::{BufRead, BufReader, Read};
+use std::io::{BufRead, BufReader};
 use std::path::Path;
 
 use crate::models::{
@@ -1013,7 +1013,7 @@ fn open_rollout_reader(file_path: &Path) -> Result<Box<dyn BufRead>> {
     {
         let decoder = zstd::stream::read::Decoder::new(file)
             .context("Failed to open compressed session file")?;
-        return Ok(Box::new(BufReader::new(Box::new(decoder) as Box<dyn Read>)));
+        return Ok(Box::new(BufReader::new(decoder)));
     }
 
     Ok(Box::new(BufReader::new(file)))

--- a/src/parsers/mistral_vibe.rs
+++ b/src/parsers/mistral_vibe.rs
@@ -19,6 +19,12 @@ pub enum ParseError {
     NoUserMessages,
 }
 
+/// Profile Mistral Vibe spawns when a `task` call omits the `agent` argument.
+/// The child session lands in `agents/explore_*` with `agent_profile.name`
+/// set to this value, so linkage must assume the same default. Coupled to
+/// Vibe's upstream default; update if that profile is ever renamed.
+const VIBE_DEFAULT_AGENT_PROFILE: &str = "explore";
+
 pub struct MistralVibeParser;
 
 impl MistralVibeParser {
@@ -459,7 +465,7 @@ impl MistralVibeParser {
                 .map(str::to_string)
         };
         (
-            pick("agent").or_else(|| Some("explore".to_string())),
+            pick("agent").or_else(|| Some(VIBE_DEFAULT_AGENT_PROFILE.to_string())),
             pick("task"),
         )
     }

--- a/src/parsers/mistral_vibe.rs
+++ b/src/parsers/mistral_vibe.rs
@@ -53,6 +53,13 @@ impl MistralVibeParser {
         let session_model =
             normalize_model(metadata.get("config").and_then(|c| c.get("active_model")));
 
+        let parent_session_id = metadata
+            .get("parent_session_id")
+            .and_then(|v| v.as_str())
+            .map(str::to_string)
+            .filter(|value| !value.trim().is_empty());
+        let is_subagent = parent_session_id.is_some();
+
         let token_usage = metadata.get("stats").and_then(|stats| {
             let prompt = stats.get("session_prompt_tokens")?.as_i64()?;
             let completion = stats.get("session_completion_tokens")?.as_i64()?;
@@ -260,8 +267,8 @@ impl MistralVibeParser {
                 last_updated: end_time,
                 pinned_at: None,
                 first_prompt,
-                parent_session_id: None,
-                is_subagent: false,
+                parent_session_id,
+                is_subagent,
                 token_usage: None,
                 edit_count: 0,
                 read_count: 0,
@@ -437,6 +444,35 @@ mod tests {
         );
 
         assert_eq!(session.start_time, expected);
+    }
+
+    #[test]
+    fn parse_reads_parent_session_id_from_metadata() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        let meta = json!({
+            "session_id": "child-session",
+            "parent_session_id": "parent-session",
+            "start_time": "2026-02-03T19:14:51Z",
+            "end_time": "2026-02-03T19:16:05Z",
+            "environment": { "working_directory": "/tmp/project" }
+        });
+        fs::write(root.join("meta.json"), serde_json::to_vec(&meta).unwrap()).unwrap();
+        write_messages(
+            &root.join("messages.jsonl"),
+            &[
+                r#"{"role":"user","content":"Hi"}"#,
+                r#"{"role":"assistant","content":"Hello"}"#,
+            ],
+        );
+
+        let parsed = MistralVibeParser.parse(root).unwrap();
+
+        assert_eq!(
+            parsed.session.parent_session_id.as_deref(),
+            Some("parent-session")
+        );
+        assert!(parsed.session.is_subagent);
     }
 
     #[test]

--- a/src/parsers/mistral_vibe.rs
+++ b/src/parsers/mistral_vibe.rs
@@ -1,14 +1,14 @@
 use anyhow::{Context, Result};
 use chrono::{DateTime, Duration, NaiveDateTime, TimeZone, Utc};
 use serde_json::Value;
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
 
 use crate::models::{
-    AiAssistant, Message, ReasoningAttachment, Role, Session, TokenUsage, ToolCall, ToolCallStatus,
-    TranscriptItem, TranscriptItemKind,
+    AiAssistant, Message, ReasoningAttachment, Role, Session, Subagent, TokenUsage, ToolCall,
+    ToolCallStatus, TranscriptItem, TranscriptItemKind,
 };
 use crate::parsers::ParsedSession;
 use crate::parsers::model::normalize_model;
@@ -53,12 +53,16 @@ impl MistralVibeParser {
         let session_model =
             normalize_model(metadata.get("config").and_then(|c| c.get("active_model")));
 
-        let parent_session_id = metadata
-            .get("parent_session_id")
-            .and_then(|v| v.as_str())
-            .map(str::to_string)
-            .filter(|value| !value.trim().is_empty());
+        // Mistral Vibe encodes the parent/child relationship through the
+        // directory layout (`<parent>/agents/<agent>_*`), not a metadata field
+        // (`parent_session_id` is always null in real sessions).
+        let parent_session_id = Self::parent_session_id_from_dir(session_dir);
         let is_subagent = parent_session_id.is_some();
+
+        // Map each spawned agent's profile name to the child session ids it
+        // produced (chronological), so `task` tool calls can be paired with the
+        // session they spawned.
+        let mut children_by_agent = Self::discover_subagent_children(session_dir);
 
         let token_usage = metadata.get("stats").and_then(|stats| {
             let prompt = stats.get("session_prompt_tokens")?.as_i64()?;
@@ -78,12 +82,16 @@ impl MistralVibeParser {
 
         let mut messages: Vec<Message> = Vec::new();
         let mut tool_calls: Vec<ToolCall> = Vec::new();
+        let mut subagents: Vec<Subagent> = Vec::new();
         let mut transcript_items: Vec<TranscriptItem> = Vec::new();
         let mut reasoning_attachments: Vec<ReasoningAttachment> = Vec::new();
         let mut pending_reasoning: Option<ReasoningAttachment> = None;
         let mut has_user_message = false;
         // Maps the raw tool_call id from the JSON → index in tool_calls vec for result correlation
         let mut pending_calls: HashMap<String, usize> = HashMap::new();
+        // Maps the raw tool_call id of a `task` call → index in subagents vec,
+        // so the spawned agent's response can be captured as its result.
+        let mut pending_subagent_calls: HashMap<String, usize> = HashMap::new();
 
         for line in reader.lines() {
             let line = line.context("Failed to read line")?;
@@ -97,16 +105,19 @@ impl MistralVibeParser {
             match role {
                 Some("system") => continue,
                 Some("tool") => {
-                    // Correlate tool result with the pending ToolCall by tool_call_id
-                    if let Some(raw_id) = event.get("tool_call_id").and_then(|v| v.as_str())
-                        && let Some(&tc_idx) = pending_calls.get(raw_id)
-                    {
+                    // Correlate tool result with the pending ToolCall (or
+                    // subagent `task` call) by tool_call_id.
+                    if let Some(raw_id) = event.get("tool_call_id").and_then(|v| v.as_str()) {
                         let output = event
                             .get("content")
                             .and_then(|v| v.as_str())
                             .map(str::to_string);
-                        tool_calls[tc_idx].output_text = output;
-                        tool_calls[tc_idx].status = ToolCallStatus::Completed;
+                        if let Some(&tc_idx) = pending_calls.get(raw_id) {
+                            tool_calls[tc_idx].output_text = output;
+                            tool_calls[tc_idx].status = ToolCallStatus::Completed;
+                        } else if let Some(&sa_idx) = pending_subagent_calls.get(raw_id) {
+                            subagents[sa_idx].result_summary = output;
+                        }
                     }
                 }
                 Some("user") => {
@@ -205,6 +216,47 @@ impl MistralVibeParser {
                                 .and_then(|v| v.as_str())
                                 .map(str::to_string);
 
+                            // The `task` tool spawns a child agent session; surface
+                            // it as a navigable subagent rather than a plain call.
+                            if tool_name == "task" {
+                                let (agent_name, task_prompt) =
+                                    Self::extract_task_arguments(input_json.as_deref());
+                                let child_session_id = agent_name
+                                    .as_deref()
+                                    .and_then(|name| children_by_agent.get_mut(name))
+                                    .and_then(|queue| queue.pop_front());
+                                let subagent_id = format!("{}-{}", session_id, raw_id);
+                                let item_idx = transcript_items.len() as i64;
+                                let sa_idx = subagents.len();
+
+                                pending_subagent_calls.insert(raw_id, sa_idx);
+                                subagents.push(Subagent {
+                                    id: subagent_id.clone(),
+                                    agent_id: agent_name.clone(),
+                                    session_id: session_id.clone(),
+                                    title: agent_name
+                                        .clone()
+                                        .unwrap_or_else(|| "Subagent".to_string()),
+                                    prompt: task_prompt,
+                                    result_summary: None,
+                                    child_session_id,
+                                    parser_ref: Some(subagent_id.clone()),
+                                });
+                                transcript_items.push(TranscriptItem {
+                                    session_id: session_id.clone(),
+                                    item_index: item_idx,
+                                    kind: TranscriptItemKind::Subagent,
+                                    message_index: None,
+                                    tool_call_id: None,
+                                    subagent_id: Some(subagent_id),
+                                });
+                                if let Some(mut attachment) = pending_reasoning.take() {
+                                    attachment.transcript_item_index = item_idx;
+                                    reasoning_attachments.push(attachment);
+                                }
+                                continue;
+                            }
+
                             let tc_idx = tool_calls.len();
                             let item_idx = transcript_items.len() as i64;
                             let tc_id = format!("{}-{}", session_id, raw_id);
@@ -277,7 +329,7 @@ impl MistralVibeParser {
             },
             messages,
             tool_calls,
-            subagents: Vec::new(),
+            subagents,
             transcript_items,
             reasoning_attachments,
             token_usage,
@@ -319,6 +371,90 @@ impl MistralVibeParser {
             timestamp,
             model,
         });
+    }
+
+    /// Derive the parent session id when `session_dir` is a child agent
+    /// transcript, i.e. it lives under `<parent>/agents/<agent>_*`.
+    fn parent_session_id_from_dir(session_dir: &Path) -> Option<String> {
+        let parent = session_dir.parent()?;
+        if parent.file_name().and_then(|name| name.to_str()) != Some("agents") {
+            return None;
+        }
+        let meta = Self::read_json(&parent.parent()?.join("meta.json")).ok()?;
+        meta.get("session_id")
+            .and_then(|v| v.as_str())
+            .map(str::to_string)
+            .filter(|value| !value.trim().is_empty())
+    }
+
+    /// Collect the child sessions spawned by this session, keyed by agent
+    /// profile name and ordered chronologically within each name so repeated
+    /// `task` calls to the same agent pair with the right child.
+    fn discover_subagent_children(session_dir: &Path) -> HashMap<String, VecDeque<String>> {
+        let Ok(entries) = std::fs::read_dir(session_dir.join("agents")) else {
+            return HashMap::new();
+        };
+
+        // (agent_name, start_time, dir_name, session_id)
+        let mut children: Vec<(String, DateTime<Utc>, String, String)> = Vec::new();
+        for entry in entries.flatten() {
+            let dir = entry.path();
+            if !dir.is_dir() {
+                continue;
+            }
+            let Ok(meta) = Self::read_json(&dir.join("meta.json")) else {
+                continue;
+            };
+            let Some(child_id) = meta
+                .get("session_id")
+                .and_then(|v| v.as_str())
+                .filter(|value| !value.trim().is_empty())
+            else {
+                continue;
+            };
+            let dir_name = dir
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or_default()
+                .to_string();
+            let agent_name = meta
+                .get("agent_profile")
+                .and_then(|profile| profile.get("name"))
+                .and_then(|v| v.as_str())
+                .filter(|value| !value.trim().is_empty())
+                .map(str::to_string)
+                .or_else(|| dir_name.split('_').next().map(str::to_string))
+                .unwrap_or_default();
+            let start_time = meta
+                .get("start_time")
+                .and_then(|v| v.as_str())
+                .and_then(|value| Self::parse_timestamp(value).ok())
+                .unwrap_or_else(|| DateTime::<Utc>::from_timestamp(0, 0).unwrap());
+            children.push((agent_name, start_time, dir_name, child_id.to_string()));
+        }
+
+        children.sort_by(|a, b| a.1.cmp(&b.1).then_with(|| a.2.cmp(&b.2)));
+
+        let mut by_agent: HashMap<String, VecDeque<String>> = HashMap::new();
+        for (agent_name, _, _, child_id) in children {
+            by_agent.entry(agent_name).or_default().push_back(child_id);
+        }
+        by_agent
+    }
+
+    /// Extract `(agent, task)` from a `task` tool call's JSON arguments string.
+    fn extract_task_arguments(arguments: Option<&str>) -> (Option<String>, Option<String>) {
+        let Some(value) = arguments.and_then(|raw| serde_json::from_str::<Value>(raw).ok()) else {
+            return (None, None);
+        };
+        let pick = |key: &str| {
+            value
+                .get(key)
+                .and_then(|v| v.as_str())
+                .filter(|text| !text.trim().is_empty())
+                .map(str::to_string)
+        };
+        (pick("agent"), pick("task"))
     }
 
     fn read_json(path: &Path) -> Result<Value> {
@@ -446,33 +582,91 @@ mod tests {
         assert_eq!(session.start_time, expected);
     }
 
-    #[test]
-    fn parse_reads_parent_session_id_from_metadata() {
-        let temp_dir = TempDir::new().unwrap();
-        let root = temp_dir.path();
-        let meta = json!({
-            "session_id": "child-session",
-            "parent_session_id": "parent-session",
+    fn write_session_meta(dir: &Path, session_id: &str, agent_name: Option<&str>) {
+        let mut meta = json!({
+            "session_id": session_id,
+            "parent_session_id": null,
             "start_time": "2026-02-03T19:14:51Z",
             "end_time": "2026-02-03T19:16:05Z",
             "environment": { "working_directory": "/tmp/project" }
         });
-        fs::write(root.join("meta.json"), serde_json::to_vec(&meta).unwrap()).unwrap();
+        if let Some(name) = agent_name {
+            meta["agent_profile"] = json!({ "name": name });
+        }
+        fs::create_dir_all(dir).unwrap();
+        fs::write(dir.join("meta.json"), serde_json::to_vec(&meta).unwrap()).unwrap();
+    }
+
+    #[test]
+    fn parse_marks_child_in_agents_dir_as_subagent_with_parent_id() {
+        let temp_dir = TempDir::new().unwrap();
+        let parent_dir = temp_dir.path().join("session_parent");
+        let child_dir = parent_dir.join("agents").join("comique_20260203_191500");
+
+        write_session_meta(&parent_dir, "parent-session", None);
+        write_session_meta(&child_dir, "child-session", Some("comique"));
         write_messages(
-            &root.join("messages.jsonl"),
+            &child_dir.join("messages.jsonl"),
             &[
-                r#"{"role":"user","content":"Hi"}"#,
-                r#"{"role":"assistant","content":"Hello"}"#,
+                r#"{"role":"user","content":"Do the bit"}"#,
+                r#"{"role":"assistant","content":"Here is my bit"}"#,
             ],
         );
 
-        let parsed = MistralVibeParser.parse(root).unwrap();
+        let parsed = MistralVibeParser.parse(&child_dir).unwrap();
 
+        assert!(parsed.session.is_subagent);
         assert_eq!(
             parsed.session.parent_session_id.as_deref(),
             Some("parent-session")
         );
-        assert!(parsed.session.is_subagent);
+    }
+
+    #[test]
+    fn parse_links_task_tool_call_to_spawned_child_session() {
+        let temp_dir = TempDir::new().unwrap();
+        let parent_dir = temp_dir.path().join("session_parent");
+        let child_dir = parent_dir.join("agents").join("comique_20260203_191500");
+
+        write_session_meta(&parent_dir, "parent-session", None);
+        write_session_meta(&child_dir, "child-session", Some("comique"));
+        write_messages(
+            &child_dir.join("messages.jsonl"),
+            &[r#"{"role":"user","content":"Do the bit"}"#],
+        );
+        write_messages(
+            &parent_dir.join("messages.jsonl"),
+            &[
+                r#"{"role":"user","content":"Ask the comedian"}"#,
+                r#"{"role":"assistant","tool_calls":[{"id":"call_1","function":{"name":"task","arguments":"{\"agent\":\"comique\",\"task\":\"Review the README\"}"},"type":"function"}]}"#,
+                r#"{"role":"tool","tool_call_id":"call_1","content":"Here is the punchline"}"#,
+            ],
+        );
+
+        let parsed = MistralVibeParser.parse(&parent_dir).unwrap();
+
+        assert!(!parsed.session.is_subagent);
+        assert_eq!(parsed.subagents.len(), 1);
+        let subagent = &parsed.subagents[0];
+        assert_eq!(subagent.agent_id.as_deref(), Some("comique"));
+        assert_eq!(subagent.prompt.as_deref(), Some("Review the README"));
+        assert_eq!(subagent.child_session_id.as_deref(), Some("child-session"));
+        assert_eq!(
+            subagent.result_summary.as_deref(),
+            Some("Here is the punchline")
+        );
+
+        // The task call surfaces as a navigable Subagent transcript item, not a tool call.
+        assert!(parsed.tool_calls.is_empty());
+        let subagent_item = parsed
+            .transcript_items
+            .iter()
+            .find(|item| matches!(item.kind, TranscriptItemKind::Subagent))
+            .expect("subagent transcript item");
+        assert_eq!(
+            subagent_item.subagent_id.as_deref(),
+            Some(subagent.id.as_str())
+        );
     }
 
     #[test]

--- a/src/parsers/mistral_vibe.rs
+++ b/src/parsers/mistral_vibe.rs
@@ -53,9 +53,10 @@ impl MistralVibeParser {
         let session_model =
             normalize_model(metadata.get("config").and_then(|c| c.get("active_model")));
 
-        // Mistral Vibe encodes the parent/child relationship through the
-        // directory layout (`<parent>/agents/<agent>_*`), not a metadata field
-        // (`parent_session_id` is always null in real sessions).
+        // Mistral Vibe encodes task-spawned subagents through the directory
+        // layout (`<parent>/agents/<agent>_*`). The generic metadata
+        // `parent_session_id` field is used by other session-lineage flows and
+        // is not proof that a session is a subagent.
         let parent_session_id = Self::parent_session_id_from_dir(session_dir);
         let is_subagent = parent_session_id.is_some();
 
@@ -447,6 +448,9 @@ impl MistralVibeParser {
         let Some(value) = arguments.and_then(|raw| serde_json::from_str::<Value>(raw).ok()) else {
             return (None, None);
         };
+        if !value.is_object() {
+            return (None, None);
+        }
         let pick = |key: &str| {
             value
                 .get(key)
@@ -454,7 +458,10 @@ impl MistralVibeParser {
                 .filter(|text| !text.trim().is_empty())
                 .map(str::to_string)
         };
-        (pick("agent"), pick("task"))
+        (
+            pick("agent").or_else(|| Some("explore".to_string())),
+            pick("task"),
+        )
     }
 
     fn read_json(path: &Path) -> Result<Value> {
@@ -666,6 +673,37 @@ mod tests {
         assert_eq!(
             subagent_item.subagent_id.as_deref(),
             Some(subagent.id.as_str())
+        );
+    }
+
+    #[test]
+    fn parse_links_task_without_agent_argument_to_default_explore_child() {
+        let temp_dir = TempDir::new().unwrap();
+        let parent_dir = temp_dir.path().join("session_parent");
+        let child_dir = parent_dir.join("agents").join("explore_20260203_191500");
+
+        write_session_meta(&parent_dir, "parent-session", None);
+        write_session_meta(&child_dir, "child-session", Some("explore"));
+        write_messages(
+            &child_dir.join("messages.jsonl"),
+            &[r#"{"role":"user","content":"Inspect the project"}"#],
+        );
+        write_messages(
+            &parent_dir.join("messages.jsonl"),
+            &[
+                r#"{"role":"user","content":"Explore the project"}"#,
+                r#"{"role":"assistant","tool_calls":[{"id":"call_1","function":{"name":"task","arguments":"{\"task\":\"Inspect the project\"}"},"type":"function"}]}"#,
+                r#"{"role":"tool","tool_call_id":"call_1","content":"response: Done\nturns_used: 1\ncompleted: true"}"#,
+            ],
+        );
+
+        let parsed = MistralVibeParser.parse(&parent_dir).unwrap();
+
+        assert_eq!(parsed.subagents.len(), 1);
+        assert_eq!(parsed.subagents[0].agent_id.as_deref(), Some("explore"));
+        assert_eq!(
+            parsed.subagents[0].child_session_id.as_deref(),
+            Some("child-session")
         );
     }
 

--- a/src/parsers/mistral_vibe.rs
+++ b/src/parsers/mistral_vibe.rs
@@ -409,6 +409,13 @@ impl MistralVibeParser {
             if !dir.is_dir() {
                 continue;
             }
+            // Only link children the indexer can actually index. A child with a
+            // `meta.json` but no `messages.jsonl` yet (e.g. a subagent still
+            // starting up) is skipped by `vibe_agent_child_dirs`, so emitting a
+            // link here would dangle until the child becomes indexable.
+            if !dir.join("messages.jsonl").exists() {
+                continue;
+            }
             let Ok(meta) = Self::read_json(&dir.join("meta.json")) else {
                 continue;
             };
@@ -680,6 +687,32 @@ mod tests {
             subagent_item.subagent_id.as_deref(),
             Some(subagent.id.as_str())
         );
+    }
+
+    #[test]
+    fn parse_skips_child_link_when_child_messages_missing() {
+        let temp_dir = TempDir::new().unwrap();
+        let parent_dir = temp_dir.path().join("session_parent");
+        let child_dir = parent_dir.join("agents").join("comique_20260203_191500");
+
+        write_session_meta(&parent_dir, "parent-session", None);
+        // Child directory exists with meta.json but no messages.jsonl yet, so the
+        // indexer cannot index it. The parent must not emit a navigable link to a
+        // session row that does not exist.
+        write_session_meta(&child_dir, "child-session", Some("comique"));
+        write_messages(
+            &parent_dir.join("messages.jsonl"),
+            &[
+                r#"{"role":"user","content":"Ask the comedian"}"#,
+                r#"{"role":"assistant","tool_calls":[{"id":"call_1","function":{"name":"task","arguments":"{\"agent\":\"comique\",\"task\":\"Review the README\"}"},"type":"function"}]}"#,
+            ],
+        );
+
+        let parsed = MistralVibeParser.parse(&parent_dir).unwrap();
+
+        assert_eq!(parsed.subagents.len(), 1);
+        assert_eq!(parsed.subagents[0].agent_id.as_deref(), Some("comique"));
+        assert_eq!(parsed.subagents[0].child_session_id, None);
     }
 
     #[test]

--- a/src/parsers/opencode/mod.rs
+++ b/src/parsers/opencode/mod.rs
@@ -476,6 +476,7 @@ impl OpenCodeParser {
                 }
 
                 let status = match state.and_then(|s| s.get("status")).and_then(|v| v.as_str()) {
+                    Some("pending") => ToolCallStatus::Pending,
                     Some("completed") => ToolCallStatus::Completed,
                     Some("failed") | Some("error") => ToolCallStatus::Error,
                     Some("running") => ToolCallStatus::Running,
@@ -1329,6 +1330,82 @@ mod tests {
             Some("File contents here\nLine 2\nLine 3")
         );
         assert_eq!(parsed.tool_calls[0].status, ToolCallStatus::Completed);
+    }
+
+    #[test]
+    fn tool_part_with_pending_status_stays_pending() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        let session_path = write_session_file(
+            root,
+            "project-a",
+            "session-pending.json",
+            json!({
+                "id": "session-pending",
+                "directory": "/projects/alpha",
+                "time": { "created": 1_704_067_200_000i64, "updated": 1_704_067_260_000i64 }
+            }),
+        );
+
+        write_message_file(
+            root,
+            "session-pending",
+            "msg-user.json",
+            json!({
+                "id": "msg-user",
+                "sessionID": "session-pending",
+                "role": "user",
+                "time": { "created": 1_704_067_200_000i64 }
+            }),
+        );
+
+        write_message_file(
+            root,
+            "session-pending",
+            "msg-tool.json",
+            json!({
+                "id": "msg-tool",
+                "sessionID": "session-pending",
+                "role": "assistant",
+                "time": { "created": 1_704_067_260_000i64 }
+            }),
+        );
+
+        write_part_file(
+            root,
+            "msg-user",
+            "part-user.json",
+            json!({
+                "id": "part-user",
+                "order": 1,
+                "type": "text",
+                "text": "Read file"
+            }),
+        );
+
+        write_part_file(
+            root,
+            "msg-tool",
+            "part-tool.json",
+            json!({
+                "id": "part-tool",
+                "order": 1,
+                "type": "tool",
+                "tool": "read",
+                "state": {
+                    "status": "pending",
+                    "input": { "path": "/tmp/test.txt" },
+                    "raw": ""
+                }
+            }),
+        );
+
+        let parser = OpenCodeParser::new(root);
+        let parsed = parser.parse(&session_path).unwrap();
+
+        assert_eq!(parsed.tool_calls.len(), 1);
+        assert_eq!(parsed.tool_calls[0].status, ToolCallStatus::Pending);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Several AI assistant session formats drifted from what the parsers expected:

- **Codex** now keeps archived rollouts beside the active sessions dir and writes compressed `rollout-*.jsonl.zst` files; some child sessions only carry `parent_thread_id` directly on `session_meta.payload`.
- **OpenCode** emits an official `pending` tool state that was being mapped to `Unknown`.
- **Mistral Vibe** spawns sub-agents as child session directories under `<session>/agents/`. These were never indexed, so delegated work was invisible — and `meta.json.parent_session_id` (the field a first pass relied on) is always `null` in real data.

## Solution

**Codex**
- Index archived rollouts (`archived_sessions/` next to `sessions/`).
- Accept and stream-decode `.jsonl.zst` via `zstd`.
- Fall back to `session_meta.payload.parent_thread_id` for child linkage.

**OpenCode**
- Map `pending` tool state to `ToolCallStatus::Pending`.

**Mistral Vibe sub-agents** (directory-based, the real mechanism)
- Derive the parent from the directory layout (`<parent>/agents/<agent>_*`), not the always-null `parent_session_id`.
- Descend into `agents/` so each child session is indexed (hidden as a sub-agent).
- Surface each `task` tool call as a navigable subagent linked to the child it spawned, paired by `agent` argument ↔ child `agent_profile.name` (chronological for repeats), with the tool result captured as `result_summary`.
- **DB migration v14** clears `file_fingerprints` so existing installs re-parse parents and create the links (otherwise unchanged parents are skipped and children stay orphaned).

**Docs**
- `docs/session-formats/mistral-vibe.md` updated to document the `agents/` layout, the null `parent_session_id`, and the directory/name-based linkage.

Verified against a real local Mistral Vibe session with a sub-agent: child correctly marked `is_subagent` and linked from the parent.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all -- -D warnings`
- `cargo test --all --no-fail-fast` (new parser, indexer, and migration tests added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)