### PR TITLE
fix: preserve scroll and expand messages on the first click

### DIFF
--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -965,8 +965,7 @@ impl SessionDetail {
             (ref_data.clone(), will_expand)
         };
 
-        self.messages.remove(idx);
-        self.messages.insert(idx, clone);
+        self.replace_typed_row_preserving_scroll(idx, clone);
         if let Some((db_path, session_id, message_index)) = load_request {
             sender.spawn_oneshot_command(move || SessionDetailCmd::MessageFullContentReady {
                 item_index,
@@ -1603,8 +1602,7 @@ impl SessionDetail {
 
         let mut clone = item.borrow().clone();
         clone.full_content = Some(content);
-        self.messages.remove(idx);
-        self.messages.insert(idx, clone);
+        self.replace_typed_row_preserving_scroll(idx, clone);
     }
 
     fn reset_typed_message_expansion(&mut self, item_index: usize) {
@@ -1618,8 +1616,7 @@ impl SessionDetail {
             Self::reset_message_expansion_after_full_content_failure(&item);
             item.clone()
         };
-        self.messages.remove(idx);
-        self.messages.insert(idx, clone);
+        self.replace_typed_row_preserving_scroll(idx, clone);
     }
 
     fn reset_message_expansion_after_full_content_failure(item: &TranscriptItemData) {
@@ -1816,12 +1813,7 @@ impl SessionDetail {
     /// GTK re-bind (propagating in-place `highlight_query` mutations), then
     /// restore scroll position via idle callback.
     fn refresh_typed_rows_preserving_scroll(&mut self) {
-        let saved_vadj = self
-            .messages
-            .view
-            .ancestor(gtk::ScrolledWindow::static_type())
-            .and_then(|w| w.downcast::<gtk::ScrolledWindow>().ok())
-            .map(|sw| sw.vadjustment().value());
+        let saved_vadj = self.transcript_scroll_value();
 
         let items: Vec<TranscriptItemData> = self
             .messages
@@ -1832,6 +1824,25 @@ impl SessionDetail {
         self.messages.clear();
         self.messages.extend_from_iter(items);
 
+        self.restore_transcript_scroll_value_later(saved_vadj);
+    }
+
+    fn replace_typed_row_preserving_scroll(&mut self, index: u32, item: TranscriptItemData) {
+        let saved_vadj = self.transcript_scroll_value();
+        self.messages.remove(index);
+        self.messages.insert(index, item);
+        self.restore_transcript_scroll_value_later(saved_vadj);
+    }
+
+    fn transcript_scroll_value(&self) -> Option<f64> {
+        self.messages
+            .view
+            .ancestor(gtk::ScrolledWindow::static_type())
+            .and_then(|w| w.downcast::<gtk::ScrolledWindow>().ok())
+            .map(|sw| sw.vadjustment().value())
+    }
+
+    fn restore_transcript_scroll_value_later(&self, saved_vadj: Option<f64>) {
         if let Some(saved_value) = saved_vadj {
             let view = self.messages.view.clone();
             glib::idle_add_local_once(move || {
@@ -1839,10 +1850,17 @@ impl SessionDetail {
                     .ancestor(gtk::ScrolledWindow::static_type())
                     .and_then(|w| w.downcast::<gtk::ScrolledWindow>().ok())
                 {
-                    sw.vadjustment().set_value(saved_value);
+                    let adjustment = sw.vadjustment();
+                    adjustment.set_value(Self::clamped_scroll_value(&adjustment, saved_value));
                 }
             });
         }
+    }
+
+    fn clamped_scroll_value(adj: &gtk::Adjustment, value: f64) -> f64 {
+        let lower = adj.lower();
+        let max = (adj.upper() - adj.page_size()).max(lower);
+        value.clamp(lower, max)
     }
 
     fn scroll_widget_into_view(widget: &gtk::Widget, scroll_child: &gtk::Widget) {

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -160,7 +160,10 @@ pub enum SessionDetailMsg {
     /// Indicates that a transcript row failed to expand to its full content and
     /// should trigger the shared toast notification path.
     ShowExpandLoadFailure,
-    ToggleMessageExpand {
+    /// Request the lazy load of a message's full content after the row expanded
+    /// it in place. The toggle itself is handled by the row widget; this only
+    /// triggers the (off-thread) database read.
+    RequestMessageFullContent {
         item_index: usize,
     },
     RowBuilt {
@@ -560,8 +563,8 @@ impl Component for SessionDetail {
             SessionDetailMsg::ShowExpandLoadFailure => {
                 self.show_expand_load_failure();
             }
-            SessionDetailMsg::ToggleMessageExpand { item_index } => {
-                self.toggle_message_expand(item_index, &sender);
+            SessionDetailMsg::RequestMessageFullContent { item_index } => {
+                self.request_message_full_content(item_index, &sender);
             }
             SessionDetailMsg::RowBuilt {
                 item_index: _,
@@ -938,34 +941,41 @@ impl SessionDetail {
         self.pending_toast.set(true);
     }
 
-    fn toggle_message_expand(&mut self, item_index: usize, sender: &ComponentSender<Self>) {
+    /// Kick off the off-thread load of a message's full content.
+    ///
+    /// The row widget already toggled its expansion state and re-rendered in
+    /// place (showing the preview meanwhile); here we only resolve the load
+    /// target from the stored item and spawn the database read. The result is
+    /// applied back in place via [`Self::set_typed_message_full_content`], so the
+    /// surrounding scroll position is never disturbed.
+    fn request_message_full_content(&self, item_index: usize, sender: &ComponentSender<Self>) {
         let idx = item_index as u32;
         let Some(item) = self.messages.get(idx) else {
-            tracing::debug!(item_index, "Typed message expand ignored: item not found");
+            tracing::debug!(
+                item_index,
+                "Full message content load ignored: item not found"
+            );
             return;
         };
 
-        let mut load_request = None;
-        let (clone, will_expand) = {
+        let load_request = {
             let ref_data = item.borrow();
-            let will_expand = !ref_data.expanded.get();
-            ref_data.expanded.set(will_expand);
-            if will_expand
-                && ref_data.full_content.is_none()
-                && let crate::ui::session_detail::transcript::item_data::TranscriptItemKind::Message(
-                    message,
-                ) = &ref_data.kind
+            if ref_data.full_content.borrow().is_some() {
+                None
+            } else if let crate::ui::session_detail::transcript::item_data::TranscriptItemKind::Message(
+                message,
+            ) = &ref_data.kind
             {
-                load_request = Some((
+                Some((
                     message.db_path.clone(),
                     message.preview.session_id.clone(),
                     message.preview.message_index,
-                ));
+                ))
+            } else {
+                None
             }
-            (ref_data.clone(), will_expand)
         };
 
-        self.replace_typed_row_preserving_scroll(idx, clone);
         if let Some((db_path, session_id, message_index)) = load_request {
             sender.spawn_oneshot_command(move || SessionDetailCmd::MessageFullContentReady {
                 item_index,
@@ -974,9 +984,8 @@ impl SessionDetail {
                 result: load_message_full_content(&db_path, &session_id, message_index)
                     .map_err(|err| format!("{err:#}")),
             });
+            tracing::debug!(item_index, "Full message content load requested");
         }
-
-        tracing::debug!(item_index, will_expand, "Typed message expand requested");
     }
 
     fn clear_search(&mut self) {
@@ -1600,9 +1609,13 @@ impl SessionDetail {
             return;
         };
 
-        let mut clone = item.borrow().clone();
-        clone.full_content = Some(content);
-        self.replace_typed_row_preserving_scroll(idx, clone);
+        // Store the loaded body and pulse the revision so the bound row re-renders
+        // in place. Both the stored item and the realized widget share the same
+        // `full_content`/`content_revision`, so no list-model churn is needed and
+        // the scroll position is preserved (#170).
+        let item = item.borrow();
+        *item.full_content.borrow_mut() = Some(content);
+        Self::bump_content_revision(&item);
     }
 
     fn reset_typed_message_expansion(&mut self, item_index: usize) {
@@ -1611,12 +1624,13 @@ impl SessionDetail {
             return;
         };
 
-        let clone = {
-            let item = item.borrow();
-            Self::reset_message_expansion_after_full_content_failure(&item);
-            item.clone()
-        };
-        self.replace_typed_row_preserving_scroll(idx, clone);
+        let item = item.borrow();
+        Self::reset_message_expansion_after_full_content_failure(&item);
+        Self::bump_content_revision(&item);
+    }
+
+    fn bump_content_revision(item: &TranscriptItemData) {
+        item.content_revision.set(!item.content_revision.get());
     }
 
     fn reset_message_expansion_after_full_content_failure(item: &TranscriptItemData) {
@@ -1824,13 +1838,6 @@ impl SessionDetail {
         self.messages.clear();
         self.messages.extend_from_iter(items);
 
-        self.restore_transcript_scroll_value_later(saved_vadj);
-    }
-
-    fn replace_typed_row_preserving_scroll(&mut self, index: u32, item: TranscriptItemData) {
-        let saved_vadj = self.transcript_scroll_value();
-        self.messages.remove(index);
-        self.messages.insert(index, item);
         self.restore_transcript_scroll_value_later(saved_vadj);
     }
 

--- a/src/ui/session_detail.rs
+++ b/src/ui/session_detail.rs
@@ -22,7 +22,7 @@ use crate::models::Session;
 use crate::ui::session_detail::transcript::display::{
     DisplayTranscriptItem, group_transcript_rows,
 };
-use crate::ui::session_detail::transcript::item_data::TranscriptItemData;
+use crate::ui::session_detail::transcript::item_data::{TranscriptItemData, TranscriptItemKind};
 use crate::ui::session_detail::transcript::item_init::{
     TranscriptItemInit, TranscriptRowBuildKind, transcript_item_init_from_display_item,
 };
@@ -962,10 +962,7 @@ impl SessionDetail {
             let ref_data = item.borrow();
             if ref_data.full_content.borrow().is_some() {
                 None
-            } else if let crate::ui::session_detail::transcript::item_data::TranscriptItemKind::Message(
-                message,
-            ) = &ref_data.kind
-            {
+            } else if let TranscriptItemKind::Message(message) = &ref_data.kind {
                 Some((
                     message.db_path.clone(),
                     message.preview.session_id.clone(),
@@ -1669,9 +1666,7 @@ impl SessionDetail {
             return false;
         }
 
-        let crate::ui::session_detail::transcript::item_data::TranscriptItemKind::Message(message) =
-            &item.kind
-        else {
+        let TranscriptItemKind::Message(message) = &item.kind else {
             return false;
         };
 
@@ -1682,10 +1677,7 @@ impl SessionDetail {
         let matched_item_indexes = self.current_match_item_indexes();
         for item in self.messages.iter() {
             let mut data = item.borrow_mut();
-            let is_message = matches!(
-                data.kind,
-                crate::ui::session_detail::transcript::item_data::TranscriptItemKind::Message(_)
-            );
+            let is_message = matches!(data.kind, TranscriptItemKind::Message(_));
             let item_query = match data.transcript_item_index {
                 Some(transcript_item_index) => highlight_query_for_navigable_row(
                     is_message,

--- a/src/ui/session_detail/tests.rs
+++ b/src/ui/session_detail/tests.rs
@@ -766,6 +766,15 @@ fn row_widget_matches_display_index_uses_bound_row_identity() {
     assert!(!SessionDetail::row_widget_matches_display_index(&row, 8));
 }
 
+#[gtk::test]
+fn clamped_scroll_value_preserves_valid_value_and_caps_overflow() {
+    let adjustment = gtk::Adjustment::new(25.0, 0.0, 100.0, 1.0, 10.0, 30.0);
+
+    assert_eq!(SessionDetail::clamped_scroll_value(&adjustment, 25.0), 25.0);
+    assert_eq!(SessionDetail::clamped_scroll_value(&adjustment, -10.0), 0.0);
+    assert_eq!(SessionDetail::clamped_scroll_value(&adjustment, 90.0), 70.0);
+}
+
 #[test]
 fn message_full_content_target_rejects_stale_session_or_message() {
     let (sender, _receiver) = relm4::channel::<SessionDetailMsg>();

--- a/src/ui/session_detail/transcript/item_data.rs
+++ b/src/ui/session_detail/transcript/item_data.rs
@@ -1,4 +1,6 @@
+use std::cell::RefCell;
 use std::fmt;
+use std::rc::Rc;
 
 use relm4::Sender;
 use relm4::binding::{Binding, BoolBinding};
@@ -15,7 +17,16 @@ pub struct TranscriptItemData {
     pub transcript_item_index: Option<i64>,
     pub kind: TranscriptItemKind,
     pub expanded: BoolBinding,
-    pub full_content: Option<String>,
+    /// Full message body, loaded lazily on first expansion. Shared via `Rc` so
+    /// the realized row widget and the stored model item observe the same value:
+    /// expansion mutates this in place rather than replacing the list item, which
+    /// would reset the surrounding scroll position (see [`content_revision`]).
+    pub full_content: Rc<RefCell<Option<String>>>,
+    /// Pulse binding bumped whenever the message body must re-render in place
+    /// (expand/collapse toggle, full-content arrival, load-failure rollback).
+    /// The bound row connects to its `value` notify and re-renders without any
+    /// list-model churn.
+    pub content_revision: BoolBinding,
     pub highlight_query: Option<String>,
     pub sender: Sender<SessionDetailMsg>,
 }
@@ -45,7 +56,7 @@ impl fmt::Debug for TranscriptItemData {
             .field("item_index", &self.item_index)
             .field("kind", &self.kind)
             .field("expanded", &self.expanded.get())
-            .field("has_full_content", &self.full_content.is_some())
+            .field("has_full_content", &self.full_content.borrow().is_some())
             .field("highlight_query", &self.highlight_query)
             .finish_non_exhaustive()
     }
@@ -97,7 +108,8 @@ impl TranscriptItemData {
             transcript_item_index,
             kind,
             expanded,
-            full_content: None,
+            full_content: Rc::new(RefCell::new(None)),
+            content_revision: BoolBinding::new(false),
             highlight_query,
             sender,
         }

--- a/src/ui/session_detail/transcript/typed_row.rs
+++ b/src/ui/session_detail/transcript/typed_row.rs
@@ -504,6 +504,12 @@ fn build_message_page() -> MessagePageWidgets {
     expand_button.set_halign(gtk::Align::Start);
     expand_button.set_margin_top(4);
     expand_button.set_visible(false);
+    // The button sits at the bottom of the message row, so it is often only
+    // partially visible. Grabbing focus on click made GtkListView scroll the row
+    // into view mid-press, moving the button out from under the pointer so the
+    // release landed elsewhere and no `clicked` fired — the user had to click
+    // twice. Keep keyboard focus (Tab) but do not grab it on click.
+    expand_button.set_focus_on_click(false);
     root.append(&expand_button);
 
     MessagePageWidgets {

--- a/src/ui/session_detail/transcript/typed_row.rs
+++ b/src/ui/session_detail/transcript/typed_row.rs
@@ -507,7 +507,7 @@ fn build_message_page() -> MessagePageWidgets {
     // The button sits at the bottom of the message row, so it is often only
     // partially visible. Grabbing focus on click made GtkListView scroll the row
     // into view mid-press, moving the button out from under the pointer so the
-    // release landed elsewhere and no `clicked` fired — the user had to click
+    // release landed elsewhere and no `clicked` fired - the user had to click
     // twice. Keep keyboard focus (Tab) but do not grab it on click.
     expand_button.set_focus_on_click(false);
     root.append(&expand_button);

--- a/src/ui/session_detail/transcript/typed_row.rs
+++ b/src/ui/session_detail/transcript/typed_row.rs
@@ -11,7 +11,7 @@ use crate::ui::format::format_duration_ms;
 use crate::ui::highlight;
 use crate::ui::session_detail::SessionDetailMsg;
 use crate::ui::session_detail::transcript::item_data::{TranscriptItemData, TranscriptItemKind};
-use crate::ui::session_detail::transcript::item_init::TranscriptRowBuildKind;
+use crate::ui::session_detail::transcript::item_init::{MessageItemInit, TranscriptRowBuildKind};
 use crate::ui::session_detail::transcript::row_rendering::{
     format_reasoning_burst_label, format_tool_burst_accessible_label,
     format_tool_burst_match_badge_accessible_label, model_label_text, populate_tool_burst_children,
@@ -201,34 +201,57 @@ impl TranscriptItemData {
             widgets.reasoning_box.append(&encrypted_reasoning_pill());
         }
 
-        let content = if self.expanded.get() {
-            self.full_content
-                .as_deref()
-                .unwrap_or(&message.preview.content_preview)
-        } else {
-            &message.preview.content_preview
-        };
-
-        render_content(
+        render_message_body(
             &widgets.content,
-            content,
-            message.preview.role,
+            &widgets.expand_button,
+            message,
+            self.expanded.get(),
+            &self.full_content.borrow(),
             self.highlight_query.as_deref(),
         );
 
         let can_expand = message.preview.is_truncated() && message.preview.role != Role::ToolResult;
-        widgets.expand_button.set_visible(can_expand);
-        widgets.expand_button.set_label(if self.expanded.get() {
-            "Collapse"
-        } else {
-            "Show full message"
-        });
-
         if can_expand {
+            // Expand/collapse and lazy full-content loading mutate this row in
+            // place rather than replacing the list item: replacing it makes
+            // GtkListView reset the surrounding scroll back to the top (#170).
+            // Re-render whenever `content_revision` is bumped (toggle, content
+            // arrival, load-failure rollback).
+            let revision_handler = {
+                let content = widgets.content.clone();
+                let expand_button = widgets.expand_button.clone();
+                let message = message.clone();
+                let expanded = self.expanded.clone();
+                let full_content = self.full_content.clone();
+                let highlight_query = self.highlight_query.clone();
+                self.content_revision
+                    .connect_notify_local(Some("value"), move |_, _| {
+                        render_message_body(
+                            &content,
+                            &expand_button,
+                            &message,
+                            expanded.get(),
+                            &full_content.borrow(),
+                            highlight_query.as_deref(),
+                        );
+                    })
+            };
+            widgets
+                .connected_handlers
+                .push((self.content_revision.clone().upcast(), revision_handler));
+
             let sender = self.sender.clone();
             let item_index = self.item_index;
+            let expanded = self.expanded.clone();
+            let full_content = self.full_content.clone();
+            let content_revision = self.content_revision.clone();
             let id = widgets.expand_button.connect_clicked(move |_| {
-                sender.emit(SessionDetailMsg::ToggleMessageExpand { item_index });
+                let now_expanded = !expanded.get();
+                expanded.set(now_expanded);
+                if now_expanded && full_content.borrow().is_none() {
+                    sender.emit(SessionDetailMsg::RequestMessageFullContent { item_index });
+                }
+                content_revision.set(!content_revision.get());
             });
             widgets
                 .connected_handlers
@@ -495,6 +518,35 @@ fn build_message_page() -> MessagePageWidgets {
         expand_button,
         connected_handlers: Vec::new(),
     }
+}
+
+/// Render the message body and expand-toggle label for the current expansion
+/// state. Called both on initial bind and on every in-place re-render, so it must
+/// be idempotent (`render_content` clears the container first).
+fn render_message_body(
+    content: &gtk::Box,
+    expand_button: &gtk::Button,
+    message: &MessageItemInit,
+    expanded: bool,
+    full_content: &Option<String>,
+    highlight_query: Option<&str>,
+) {
+    let body = if expanded {
+        full_content
+            .as_deref()
+            .unwrap_or(&message.preview.content_preview)
+    } else {
+        &message.preview.content_preview
+    };
+    render_content(content, body, message.preview.role, highlight_query);
+
+    let can_expand = message.preview.is_truncated() && message.preview.role != Role::ToolResult;
+    expand_button.set_visible(can_expand);
+    expand_button.set_label(if expanded {
+        "Collapse"
+    } else {
+        "Show full message"
+    });
 }
 
 fn set_role_css_class(widget: &impl IsA<gtk::Widget>, role: Role) {
@@ -1128,7 +1180,7 @@ mod tests {
     }
 
     #[gtk::test]
-    fn message_expand_button_emits_parent_toggle_message() {
+    fn message_expand_button_toggles_in_place_and_requests_full_content() {
         let (sender, receiver) = relm4::channel::<SessionDetailMsg>();
         let mut message = TranscriptItemData::from_init(
             TranscriptItemInit::Message(truncated_message_init()),
@@ -1155,12 +1207,24 @@ mod tests {
 
         expand_button.emit_clicked();
 
+        // The row toggles and re-renders in place (no list-model replacement),
+        // so the expansion state and button label update synchronously...
+        assert!(message.expanded.get());
+        assert_eq!(expand_button.label().as_deref(), Some("Collapse"));
+
+        // ...and the only message emitted is the off-thread full-content request,
+        // because the body has not been loaded yet.
         assert!(matches!(
             gtk::glib::MainContext::default()
                 .block_on(receiver.recv())
-                .expect("message expand toggle"),
-            SessionDetailMsg::ToggleMessageExpand { item_index: 1 }
+                .expect("full content request"),
+            SessionDetailMsg::RequestMessageFullContent { item_index: 1 }
         ));
+
+        // Collapsing again toggles back in place and emits nothing further.
+        expand_button.emit_clicked();
+        assert!(!message.expanded.get());
+        assert_eq!(expand_button.label().as_deref(), Some("Show full message"));
     }
 
     #[gtk::test]
@@ -1172,7 +1236,7 @@ mod tests {
         init.preview.content_len = 42;
         let mut message = TranscriptItemData::from_init(TranscriptItemInit::Message(init), sender);
         message.expanded.set(true);
-        message.full_content = Some("loaded full message body".to_string());
+        *message.full_content.borrow_mut() = Some("loaded full message body".to_string());
 
         let list_item: gtk::ListItem = gtk::glib::Object::builder().build();
         let (_, mut widgets) = TranscriptItemData::setup(&list_item);


### PR DESCRIPTION
## Problem

Two bugs on "Show full message" in `SessionDetail`:

1. **#170** — clicking "Show full message" reset the scroll back to the top of the session.
2. **Click twice** — expanding a message usually required two clicks.

## Solution

**1. In-place expansion (#170)** — expansion no longer touches the list model. Following the pattern already used by tool bursts: `full_content` is shared via `Rc<RefCell<_>>` between the stored item and the realized row, a `content_revision` (`BoolBinding`) acts as a re-render pulse, and the message body is re-rendered in place on every change (toggle, content arrival, load-failure rollback). The button toggles the shared `expanded` binding and only triggers the off-thread content load; the result is applied to the shared state. No more `remove`/`insert`, so no scroll reset — and it works whether or not the row is currently realized. Removes the old row-replacement and scroll-restore-on-expand paths.

**2. First click (click twice)** — the "Show full message" button sits at the bottom of a row that is often only partially visible. Because it grabbed focus on click, `GtkListView` scrolled the row into view mid-press, moving the button out from under the pointer; the release landed elsewhere and no `clicked` was emitted. `set_focus_on_click(false)` removes the triggering scroll so the click lands on the first try, while keyboard focus (Tab) is preserved.

## Investigation

The "click twice" issue was first suspected to be a GTK measurement problem (#168, clipping). A deferred `queue_resize` attempt fixed nothing. Instrumentation settled it: the click handler only fired on the second click — so it was not measurement but the event being stolen by the scroll-on-focus.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all -- -D warnings`
- `cargo test --all --no-fail-fast`
- Manual: scroll preserved on expansion; message expands on the first click.

Fixes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)