### PR TITLE
feat: wire MarkdownTable widget into production renderer

### DIFF
--- a/docs/superpowers/specs/2026-07-11-markdown-table-column-readability-design.md
+++ b/docs/superpowers/specs/2026-07-11-markdown-table-column-readability-design.md
@@ -1,0 +1,133 @@
+# Markdown Table Column Readability Design
+
+**Date:** 2026-07-11  
+**Status:** Approved, pending implementation plan
+
+## Goal
+
+Make fixed-width markdown table columns readable in production by increasing
+their width from 120 px to 160 px and removing the one-character label width
+constraints that can make ordinary text wrap character by character.
+
+## Context
+
+Manual verification of the `MarkdownTable` production wiring showed that the
+custom widget scrolls horizontally, does not leave blank space below large
+tables, and works with the outer transcript scroll. It also exposed unreadable
+cells in a nine-column table: values such as `Projet Alpha` could render as one
+character per line.
+
+`create_table_label` currently combines wrapping with `width_chars = 1` and
+`max_width_chars = 1`. Those properties constrain the label's requested width
+to one character and are not needed because `MarkdownTable` measures and
+allocates every cell at the fixed column width itself.
+
+The current 120 px column rule also leaves too little text space after cell
+padding. Manual comparison favored 160 px fixed columns over content-adaptive
+columns. Fixed sizing preserves the custom widget's stable height-for-width
+boundary and avoids reintroducing content-dependent column measurement.
+
+## Scope
+
+- Change `COLUMN_MIN_WIDTH` from `120` to `160`.
+- Remove `set_width_chars(1)` and `set_max_width_chars(1)` from wrapping table
+  labels.
+- Keep wrapping enabled with `gtk::pango::WrapMode::WordChar` so genuinely long
+  unbroken text can still wrap.
+- Keep equal fixed widths for every column.
+- Let existing width, row-height, scrollbar, clipping, and allocation logic use
+  the revised constant without adding a second sizing path.
+- Add regression coverage proving ordinary multi-word text is not constrained
+  to a one-character requested width and remains readable at the fixed column
+  allocation.
+- Repeat focused automated tests and fixture-driven visual verification.
+
+## Non-goals
+
+- Do not add content-adaptive or per-column widths.
+- Do not add minimum/maximum width heuristics based on header or cell content.
+- Do not change markdown parsing semantics.
+- Do not add a vertical table scroller.
+- Do not add `Shift`+mouse-wheel handling; track that as a separate issue.
+- Do not change the existing horizontal scrollbar interaction.
+
+## Architecture
+
+`MarkdownTable` continues to use one fixed width as the single source of truth:
+
+```text
+COLUMN_MIN_WIDTH = 160
+  -> total_table_width(column_count)
+  -> horizontal minimum/natural measurement
+  -> per-cell vertical measurement
+  -> per-cell size allocation
+  -> horizontal adjustment upper bound
+```
+
+No content measurement influences column width. This keeps row height derived
+from wrapping at a known width and keeps the table's custom `WidgetImpl`
+responsible for the height-for-width boundary.
+
+`create_table_label(..., wraps = true)` configures labels with wrapping and
+`WordChar`, but leaves `width_chars` and `max_width_chars` at their GTK defaults.
+The custom widget's explicit 160 px measurement and allocation provide the
+actual wrapping width.
+
+## Behavior To Preserve
+
+- All columns have equal fixed width.
+- The widget remains shrinkable to one column width.
+- Natural width remains the full fixed-width table plus column spacing.
+- Tables wider than their viewport expose the internal horizontal scrollbar.
+- Cells and headers keep their existing CSS classes and Pango highlighting.
+- Header separator measurement and pinned allocation remain unchanged.
+- Large wrapped tables report their honest content height without blank space.
+- Search match counts remain unchanged.
+
+## Testing
+
+Update focused tests in `src/ui/markdown_table.rs`:
+
+- `total_table_width_uses_fixed_column_width_and_spacing` continues to derive
+  expectations from `COLUMN_MIN_WIDTH` and therefore verifies the 160 px source
+  of truth.
+- Wrapping-label coverage asserts `width_chars() == -1` and
+  `max_width_chars() == -1`, the GTK defaults, instead of allowing the
+  one-character request to return.
+- Add a regression test using `Projet Alpha` in a body cell. Allocate the table
+  at its full width and assert the cell receives `COLUMN_MIN_WIDTH` bounds and
+  its Pango layout does not split the value into one-character lines.
+- Keep stable-height, scrollbar visibility, clipping, separator, and horizontal
+  adjustment tests unchanged except for expectations derived from the revised
+  constant.
+
+Run:
+
+```sh
+cargo test markdown_table::tests -- --nocapture
+cargo fmt --all -- --check
+cargo clippy --all -- -D warnings
+cargo test --all --no-fail-fast
+```
+
+## Manual Verification
+
+Open the previously reported session and inspect both the short ten-column
+table and the prose-heavy nine-column table:
+
+- ordinary values such as `Projet Alpha`, dates, statuses, and tags do not wrap
+  character by character;
+- prose cells wrap at a visibly more readable width;
+- the horizontal scrollbar appears and remains functional for wide tables;
+- the pinned separator, absence of blank trailing space, and outer transcript
+  scrolling remain correct.
+
+Capture an updated screenshot of the nine-column table for the follow-up issue
+or pull request.
+
+## Decision
+
+Use 160 px equal fixed-width columns and remove the one-character GTK label
+width hints. This is the smallest change that fixes the observed readability
+problem while preserving the stable custom layout architecture. Adaptive
+column sizing and `Shift`+mouse-wheel support remain separate follow-ups.

--- a/src/ui/markdown.rs
+++ b/src/ui/markdown.rs
@@ -1,3 +1,4 @@
+use crate::ui::markdown_table::MarkdownTable;
 use pulldown_cmark::{CodeBlockKind, Event, Options, Parser, Tag, TagEnd};
 use relm4::adw;
 use relm4::gtk;
@@ -742,7 +743,7 @@ impl MarkdownBufferWriter {
         }
     }
 
-    /// Flush the current buffer as a text segment and store the table widget.
+    /// Flush the current buffer and append the custom table widget.
     fn render_table(&mut self) {
         if self.table_headers.is_empty() {
             return;
@@ -750,57 +751,11 @@ impl MarkdownBufferWriter {
 
         self.flush_buffer_before_widget();
 
-        // Build the table grid.
-        let grid = gtk::Grid::new();
-        // Do NOT hexpand the grid. With non-wrapping cells, hexpand=true
-        // would propagate the grid's full natural width up through the
-        // ScrolledWindow into the message bubble, pushing layout off the
-        // window. The SW handles horizontal scrolling for content wider
-        // than its allocation.
-        grid.set_halign(gtk::Align::Start);
-        grid.add_css_class("markdown-table");
-        grid.set_row_spacing(4);
-        grid.set_column_spacing(12);
         let query = self.highlight_query.as_deref().unwrap_or("");
-        let mut table_match_count = 0usize;
+        let table = MarkdownTable::new(&self.table_headers, &self.table_rows, query);
 
-        for (col, header) in self.table_headers.iter().enumerate() {
-            let (label, match_count) =
-                crate::ui::markdown_table::create_table_label(header, query, true, false);
-            table_match_count += match_count;
-            grid.attach(&label, col as i32, 0, 1, 1);
-        }
-
-        let separator = gtk::Separator::new(gtk::Orientation::Horizontal);
-        separator.set_hexpand(true);
-        grid.attach(&separator, 0, 1, self.table_headers.len() as i32, 1);
-
-        for (row_idx, row) in self.table_rows.iter().enumerate() {
-            for (col_idx, cell) in row.iter().enumerate() {
-                let (label, match_count) =
-                    crate::ui::markdown_table::create_table_label(cell, query, false, false);
-                table_match_count += match_count;
-                grid.attach(&label, col_idx as i32, row_idx as i32 + 2, 1, 1);
-            }
-        }
-
-        // Wrap in ScrolledWindow for horizontal scrolling of wide tables.
-        // The cells use non-wrapping labels (see `create_table_label`), so the
-        // grid's height is independent of its allocated width — that avoids
-        // GTK4's buggy height-for-width measurement on `ScrolledWindow` that
-        // would otherwise produce excess blank space below tables.
-        let table_widget = gtk::ScrolledWindow::builder()
-            .hexpand(true)
-            .vexpand(false)
-            .valign(gtk::Align::Start)
-            .hscrollbar_policy(gtk::PolicyType::Automatic)
-            .vscrollbar_policy(gtk::PolicyType::Never)
-            .propagate_natural_height(true)
-            .child(&grid)
-            .build();
-
-        self.table_match_count += table_match_count;
-        self.append_segment(table_widget.upcast::<gtk::Widget>());
+        self.table_match_count += table.match_count();
+        self.append_segment(table.upcast::<gtk::Widget>());
     }
 
     /// Strip leading newlines from a text buffer.
@@ -1273,26 +1228,18 @@ mod tests {
             .expect("expected GtkSourceBuffer")
     }
 
-    /// Collect all table widgets (ScrolledWindows containing Grids) from
-    /// the rendered output. For the Box-based layout, these are direct
-    /// children that are ScrolledWindows.
-    fn find_table_widgets(widget: &gtk::Widget) -> Vec<gtk::Widget> {
-        let mut tables = Vec::new();
-        let mut child = widget.first_child();
-        while let Some(c) = child {
-            if c.clone().downcast::<gtk::ScrolledWindow>().is_ok() {
-                tables.push(c.clone());
-            }
-            child = c.next_sibling();
-        }
-        tables
+    /// Collect all custom table widgets recursively from the rendered output.
+    fn find_table_widgets(widget: &gtk::Widget) -> Vec<MarkdownTable> {
+        find_widgets_of_type::<MarkdownTable>(widget)
     }
 
     /// Collect label texts from all table widgets in the rendered output.
     fn table_label_texts(widget: &gtk::Widget) -> Vec<String> {
         find_table_widgets(widget)
             .iter()
-            .flat_map(collect_label_text_from_widget_tree)
+            .flat_map(|table| {
+                collect_label_text_from_widget_tree(table.upcast_ref::<gtk::Widget>())
+            })
             .collect()
     }
 
@@ -1563,10 +1510,7 @@ mod tests {
         let md = "| A | B |\n|---|---|\n| 1 | 2 |";
         let (widget, _) = render_markdown(md, None);
         let tables = find_table_widgets(&widget);
-        assert!(
-            !tables.is_empty(),
-            "expected table to produce a ScrolledWindow in the output"
-        );
+        assert_eq!(tables.len(), 1, "expected one MarkdownTable in the output");
     }
 
     #[gtk::test]
@@ -1581,23 +1525,24 @@ mod tests {
     }
 
     #[gtk::test]
-    fn table_scroller_does_not_expand_vertically() {
+    fn table_widget_does_not_expand_vertically() {
         let md = "| A | B |\n|---|---|\n| 1 | 2 |\n\nBelow";
         let (widget, _) = render_markdown(md, None);
         let table = find_table_widgets(&widget)
             .into_iter()
             .next()
-            .expect("expected rendered table scroller");
-        let table = table
-            .downcast::<gtk::ScrolledWindow>()
-            .expect("expected GtkScrolledWindow");
+            .expect("expected rendered MarkdownTable");
 
         assert_eq!(table.valign(), gtk::Align::Start);
-        assert!(!table.vexpands(), "table scroller should not vexpand");
+        assert!(
+            table.hexpands(),
+            "table widget should fill its viewport width"
+        );
+        assert!(!table.vexpands(), "table widget should not vexpand");
     }
 
     #[gtk::test]
-    fn table_cells_do_not_wrap() {
+    fn table_cells_wrap() {
         let md = "| A | B |\n|---|---|\n| 1 | 2 |";
         let (widget, _) = render_markdown(md, None);
         let labels: Vec<gtk::Label> = find_widgets_of_type::<gtk::Label>(&widget)
@@ -1606,10 +1551,8 @@ mod tests {
             .collect();
         assert!(!labels.is_empty(), "expected table cell labels");
         for label in labels {
-            assert!(
-                !label.wraps(),
-                "table cell labels must not wrap (issue #149)"
-            );
+            assert!(label.wraps(), "table cell labels must wrap");
+            assert_eq!(label.wrap_mode(), gtk::pango::WrapMode::WordChar);
         }
     }
 
@@ -1720,8 +1663,8 @@ mod tests {
             quotes.len()
         );
         assert!(
-            !find_widgets_of_type::<gtk::Grid>(&quotes[0]).is_empty(),
-            "blockquote group container should contain a table grid"
+            !find_widgets_of_type::<MarkdownTable>(&quotes[0]).is_empty(),
+            "blockquote group container should contain a MarkdownTable"
         );
     }
 
@@ -1756,8 +1699,8 @@ mod tests {
 
         assert_eq!(quotes.len(), 1);
         assert!(
-            !find_widgets_of_type::<gtk::Grid>(&quotes[0]).is_empty(),
-            "blockquote should contain table grid"
+            !find_widgets_of_type::<MarkdownTable>(&quotes[0]).is_empty(),
+            "blockquote should contain MarkdownTable"
         );
         assert!(
             !find_widgets_of_type::<sourceview5::View>(&quotes[0]).is_empty(),
@@ -1794,56 +1737,6 @@ mod tests {
             non_empty.len(),
             4,
             "expected 4 labels (2 headers + 2 data cells), got: {non_empty:?}"
-        );
-    }
-
-    fn collect_grid_positions(widget: &gtk::Widget, out: &mut Vec<(String, i32, i32)>) {
-        if let Some(grid) = widget.parent().and_then(|p| p.downcast::<gtk::Grid>().ok()) {
-            if let Ok(label) = widget.clone().downcast::<gtk::Label>() {
-                let layout_child = grid
-                    .layout_manager()
-                    .unwrap()
-                    .layout_child(widget)
-                    .downcast::<gtk::GridLayoutChild>()
-                    .unwrap();
-                out.push((
-                    label.text().to_string(),
-                    layout_child.column(),
-                    layout_child.row(),
-                ));
-            }
-        }
-        let mut child = widget.first_child();
-        while let Some(c) = child {
-            collect_grid_positions(&c, out);
-            child = c.next_sibling();
-        }
-    }
-
-    #[gtk::test]
-    fn table_grid_positions_correct() {
-        let md = "| A | B |\n|---|---|\n| 1 | 2 |";
-        let (widget, _) = render_markdown(md, None);
-        let tables = find_table_widgets(&widget);
-        assert_eq!(tables.len(), 1);
-        let mut positions = Vec::new();
-        collect_grid_positions(&tables[0], &mut positions);
-        // Should have: A at (0,0), B at (1,0), 1 at (0,2), 2 at (1,2)
-        assert!(
-            positions.contains(&("A".to_string(), 0, 0)),
-            "expected A at (0,0), got: {positions:?}"
-        );
-        assert!(
-            positions.contains(&("B".to_string(), 1, 0)),
-            "expected B at (1,0), got: {positions:?}"
-        );
-        assert!(
-            positions.contains(&("1".to_string(), 0, 2)),
-            "expected 1 at (0,2), got: {positions:?}"
-        );
-        assert!(
-            positions.contains(&("2".to_string(), 1, 2)),
-            "expected 2 at (1,2), got: {positions:?}"
         );
     }
 

--- a/src/ui/markdown_table.rs
+++ b/src/ui/markdown_table.rs
@@ -4,7 +4,7 @@ use gtk::subclass::prelude::*;
 use relm4::gtk;
 use std::cell::{Cell, RefCell};
 
-pub(crate) const COLUMN_MIN_WIDTH: i32 = 120;
+pub(crate) const COLUMN_MIN_WIDTH: i32 = 160;
 
 pub(crate) fn create_table_label(
     text: &str,
@@ -20,8 +20,6 @@ pub(crate) fn create_table_label(
     label.set_single_line_mode(false);
     if wraps {
         label.set_wrap_mode(gtk::pango::WrapMode::WordChar);
-        label.set_width_chars(1);
-        label.set_max_width_chars(1);
     }
     label.add_css_class("markdown-table-cell");
     if is_header {
@@ -409,12 +407,15 @@ mod tests {
         assert!(label.uses_markup());
         assert!(label.wraps());
         assert_eq!(label.wrap_mode(), gtk::pango::WrapMode::WordChar);
+        assert_eq!(label.width_chars(), -1);
+        assert_eq!(label.max_width_chars(), -1);
         assert!(label.has_css_class("markdown-table-cell"));
         assert!(!label.has_css_class("markdown-table-header"));
     }
 
     #[test]
     fn total_table_width_uses_fixed_column_width_and_spacing() {
+        assert_eq!(COLUMN_MIN_WIDTH, 160);
         assert_eq!(total_table_width(0), 0);
         assert_eq!(total_table_width(1), COLUMN_MIN_WIDTH);
         assert_eq!(
@@ -483,6 +484,25 @@ mod tests {
         assert_eq!(labels.len(), 4);
         assert!(labels.iter().all(|label| label.wraps()));
         assert!(labels[0].has_css_class("markdown-table-header"));
+    }
+
+    #[gtk::test]
+    fn markdown_table_does_not_wrap_ordinary_text_character_by_character() {
+        let table = MarkdownTable::new(
+            &["Nom".to_string()],
+            &[vec!["Projet Alpha".to_string()]],
+            "",
+        );
+        let full_width = total_table_width(1);
+        let (_, natural_height, _, _) = table.measure(gtk::Orientation::Vertical, full_width);
+        table.size_allocate(&gtk::Allocation::new(0, 0, full_width, natural_height), -1);
+
+        let body_label = table.imp().labels.borrow()[1].clone();
+        assert_eq!(
+            body_label.layout().line_count(),
+            1,
+            "ordinary text should fit on one line at the fixed column width"
+        );
     }
 
     #[gtk::test]

--- a/src/ui/markdown_table.rs
+++ b/src/ui/markdown_table.rs
@@ -60,6 +60,16 @@ fn measured_scrollbar_height(scrollbar: &gtk::Scrollbar) -> i32 {
     }
 }
 
+/// The vertical space reserved for the themed header/data separator.
+fn measured_separator_height(separator: &gtk::Separator) -> i32 {
+    let natural = separator.measure(gtk::Orientation::Vertical, -1).1;
+    if natural > 0 {
+        natural
+    } else {
+        HEADER_SEPARATOR_HEIGHT
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct TableLayout {
     pub total_width: i32,
@@ -83,6 +93,7 @@ fn calculate_layout(
     row_count: usize,
     allocated_width: i32,
     scrollbar_height: i32,
+    separator_height: i32,
 ) -> TableLayout {
     let mut row_heights = Vec::with_capacity(row_count);
 
@@ -101,12 +112,8 @@ fn calculate_layout(
 
     let rows_height: i32 = row_heights.iter().sum();
     let row_spacing = row_count.saturating_sub(1) as i32 * ROW_SPACING;
-    let separator_height = if row_count > 1 {
-        HEADER_SEPARATOR_HEIGHT
-    } else {
-        0
-    };
-    let content_height = rows_height + row_spacing + separator_height;
+    let reserved_separator_height = if row_count > 1 { separator_height } else { 0 };
+    let content_height = rows_height + row_spacing + reserved_separator_height;
     let total_width = total_table_width(column_count);
     let scrollbar_visible = allocated_width > 0 && allocated_width < total_width;
     let allocated_height = content_height
@@ -135,6 +142,7 @@ mod imp {
         pub row_count: Cell<usize>,
         pub match_count: Cell<usize>,
         pub adjustment: gtk::Adjustment,
+        pub separator: gtk::Separator,
         pub scrollbar: gtk::Scrollbar,
     }
 
@@ -146,6 +154,8 @@ mod imp {
 
         fn new() -> Self {
             let adjustment = gtk::Adjustment::new(0.0, 0.0, 0.0, 1.0, 24.0, 0.0);
+            let separator = gtk::Separator::new(gtk::Orientation::Horizontal);
+            separator.set_visible(false);
             let scrollbar = gtk::Scrollbar::new(gtk::Orientation::Horizontal, Some(&adjustment));
             scrollbar.set_visible(false);
 
@@ -155,6 +165,7 @@ mod imp {
                 row_count: Cell::new(0),
                 match_count: Cell::new(0),
                 adjustment,
+                separator,
                 scrollbar,
             }
         }
@@ -164,6 +175,7 @@ mod imp {
         fn constructed(&self) {
             self.parent_constructed();
             let obj = self.obj();
+            self.separator.set_parent(&*obj);
             self.scrollbar.set_parent(&*obj);
 
             // The cell offset is derived from the adjustment value during
@@ -182,6 +194,7 @@ mod imp {
             for label in self.labels.borrow_mut().drain(..) {
                 label.unparent();
             }
+            self.separator.unparent();
             self.scrollbar.unparent();
         }
     }
@@ -214,12 +227,14 @@ mod imp {
                 }
                 gtk::Orientation::Vertical => {
                     let scrollbar_height = measured_scrollbar_height(&self.scrollbar);
+                    let separator_height = measured_separator_height(&self.separator);
                     let layout = calculate_layout(
                         &labels,
                         column_count,
                         row_count,
                         for_size,
                         scrollbar_height,
+                        separator_height,
                     );
                     (layout.allocated_height, layout.allocated_height, -1, -1)
                 }
@@ -232,8 +247,15 @@ mod imp {
             let row_count = self.row_count.get();
             let labels = self.labels.borrow();
             let scrollbar_height = measured_scrollbar_height(&self.scrollbar);
-            let layout =
-                calculate_layout(&labels, column_count, row_count, width, scrollbar_height);
+            let separator_height = measured_separator_height(&self.separator);
+            let layout = calculate_layout(
+                &labels,
+                column_count,
+                row_count,
+                width,
+                scrollbar_height,
+                separator_height,
+            );
 
             self.adjustment.set_lower(0.0);
             self.adjustment.set_upper(layout.total_width as f64);
@@ -242,6 +264,7 @@ mod imp {
             self.adjustment
                 .set_page_increment(width.max(0) as f64 * 0.9);
             self.scrollbar.set_visible(layout.scrollbar_visible);
+            self.separator.set_visible(row_count > 1);
 
             let max_value = (layout.total_width - width).max(0) as f64;
             if self.adjustment.value() > max_value {
@@ -265,12 +288,15 @@ mod imp {
 
                 y += row_height;
                 if row == 0 && row_count > 1 {
-                    // The header/data separator space is reserved in the height
-                    // math but not painted in this spike. Drawing it (a themed
-                    // gtk::Separator child, like the current grid renderer) is
-                    // deferred to the render_table wiring follow-up, where the
-                    // result can be validated against UI screenshots.
-                    y += HEADER_SEPARATOR_HEIGHT;
+                    let transform = gtk::gsk::Transform::new()
+                        .translate(&gtk::graphene::Point::new(0.0, y as f32));
+                    self.separator.allocate(
+                        width.max(0),
+                        separator_height,
+                        baseline,
+                        Some(transform),
+                    );
+                    y += separator_height;
                 }
                 if row + 1 < row_count {
                     y += ROW_SPACING;
@@ -354,6 +380,10 @@ impl MarkdownTable {
     pub(crate) fn scrollbar(&self) -> gtk::Scrollbar {
         self.imp().scrollbar.clone()
     }
+
+    pub(crate) fn separator(&self) -> gtk::Separator {
+        self.imp().separator.clone()
+    }
 }
 
 #[cfg(test)]
@@ -403,8 +433,22 @@ mod tests {
         ];
 
         let total = total_table_width(2);
-        let fitting = calculate_layout(&labels, 2, 2, total, SCROLLBAR_HEIGHT);
-        let overflowing = calculate_layout(&labels, 2, 2, total - 1, SCROLLBAR_HEIGHT);
+        let fitting = calculate_layout(
+            &labels,
+            2,
+            2,
+            total,
+            SCROLLBAR_HEIGHT,
+            HEADER_SEPARATOR_HEIGHT,
+        );
+        let overflowing = calculate_layout(
+            &labels,
+            2,
+            2,
+            total - 1,
+            SCROLLBAR_HEIGHT,
+            HEADER_SEPARATOR_HEIGHT,
+        );
 
         assert!(!fitting.scrollbar_visible);
         assert!(overflowing.scrollbar_visible);
@@ -454,6 +498,68 @@ mod tests {
             gtk::Orientation::Horizontal
         );
         assert_eq!(table.scrollbar().adjustment(), table.adjustment());
+    }
+
+    #[gtk::test]
+    fn markdown_table_shows_separator_only_with_body_rows() {
+        let with_body = MarkdownTable::new(
+            &["A".to_string(), "B".to_string()],
+            &[vec!["1".to_string(), "2".to_string()]],
+            "",
+        );
+        let header_only = MarkdownTable::new(&["A".to_string()], &[], "");
+
+        let (_, body_height, _, _) =
+            with_body.measure(gtk::Orientation::Vertical, total_table_width(2));
+        with_body.size_allocate(
+            &gtk::Allocation::new(0, 0, total_table_width(2), body_height),
+            -1,
+        );
+        let (_, header_height, _, _) =
+            header_only.measure(gtk::Orientation::Vertical, total_table_width(1));
+        header_only.size_allocate(
+            &gtk::Allocation::new(0, 0, total_table_width(1), header_height),
+            -1,
+        );
+
+        assert_eq!(
+            with_body.separator().orientation(),
+            gtk::Orientation::Horizontal
+        );
+        assert!(with_body.separator().is_visible());
+        assert!(!header_only.separator().is_visible());
+    }
+
+    #[gtk::test]
+    fn layout_reserves_measured_separator_height_once() {
+        let table = MarkdownTable::new(
+            &["A".to_string(), "B".to_string()],
+            &[vec!["1".to_string(), "2".to_string()]],
+            "",
+        );
+        let labels = table.imp().labels.borrow();
+        let scrollbar_height = measured_scrollbar_height(&table.scrollbar());
+        let separator_height = measured_separator_height(&table.separator());
+        let with_separator = calculate_layout(
+            &labels,
+            2,
+            2,
+            total_table_width(2),
+            scrollbar_height,
+            separator_height,
+        );
+        let without_separator =
+            calculate_layout(&labels, 2, 2, total_table_width(2), scrollbar_height, 0);
+
+        assert!(separator_height > 0);
+        assert_eq!(
+            with_separator.content_height,
+            without_separator.content_height + separator_height
+        );
+        assert_eq!(
+            with_separator.allocated_height,
+            without_separator.allocated_height + separator_height
+        );
     }
 
     fn prose_heavy_markdown_table() -> MarkdownTable {
@@ -566,6 +672,7 @@ mod tests {
             rows.len() + 1,
             full_width,
             scrollbar_height,
+            measured_separator_height(&table.separator()),
         )
         .allocated_height;
 
@@ -656,7 +763,7 @@ mod tests {
     }
 
     #[gtk::test]
-    fn markdown_table_repositions_cells_when_scroll_value_changes() {
+    fn markdown_table_scrolls_cells_but_keeps_separator_pinned() {
         let table = MarkdownTable::new(
             &["A".to_string(), "B".to_string(), "C".to_string()],
             &[vec!["1".to_string(), "2".to_string(), "3".to_string()]],
@@ -683,6 +790,10 @@ mod tests {
             .compute_bounds(&table)
             .expect("label bounds")
             .x();
+        let separator_before = table
+            .separator()
+            .compute_bounds(&table)
+            .expect("separator bounds before scrolling");
 
         // Scrolling changes the adjustment value; the value-changed handler
         // must queue a fresh allocation so the cells shift left.
@@ -692,10 +803,18 @@ mod tests {
             .compute_bounds(&table)
             .expect("label bounds")
             .x();
+        let separator_after = table
+            .separator()
+            .compute_bounds(&table)
+            .expect("separator bounds after scrolling");
 
         assert!(
             after < before,
             "cells should shift left when the scroll value increases: before_x={before}, after_x={after}"
         );
+        assert_eq!(separator_before.x(), 0.0);
+        assert_eq!(separator_after.x(), 0.0);
+        assert_eq!(separator_before.width(), narrow as f32);
+        assert_eq!(separator_after.width(), narrow as f32);
     }
 }

--- a/src/ui/markdown_table.rs
+++ b/src/ui/markdown_table.rs
@@ -336,6 +336,12 @@ impl MarkdownTable {
         let imp = table.imp();
         imp.column_count.set(headers.len());
         imp.row_count.set(rows.len() + 1);
+        // Decide the separator's visibility up front so the very first
+        // `measure` sees a visible widget. GTK4's `gtk_widget_measure` returns
+        // 0 for a non-visible child, so measuring it while hidden would yield
+        // the `HEADER_SEPARATOR_HEIGHT` fallback and under-reserve its themed
+        // height on the first layout pass. `size_allocate` keeps this in sync.
+        imp.separator.set_visible(!rows.is_empty());
 
         let mut labels = Vec::new();
         // Aggregate the per-cell search-hit counts so the count survives when


### PR DESCRIPTION
## Problem

The production markdown table renderer (`src/ui/markdown.rs::render_table`) still built a `GtkScrolledWindow -> GtkGrid -> GtkLabel` table with non-wrapping cells, keeping the old #149 height workaround. The #181 spike widget was not visible in the shipping UI. Manual verification also showed unreadable cells in wide tables: values like `Projet Alpha` rendered one character per line due to `width_chars(1)`/`max_width_chars(1)` label hints and 120 px columns being too narrow after padding.

## Solution

- **Complete the `MarkdownTable` separator contract** (`abc0295`): add a themed `gtk::Separator` child, measure its natural height (not the `HEADER_SEPARATOR_HEIGHT = 1` placeholder), reserve it once in layout, and pin it at `x = 0` spanning the viewport while cells scroll horizontally.
- **Wire production rendering** (`afee54c`): replace `render_table` with a narrow adapter that constructs `MarkdownTable::new(headers, rows, query)`, adds `match_count()`, and appends it as a segment. Migrate all table renderer tests and helpers away from `gtk::Grid`, `GridLayoutChild`, and table `gtk::ScrolledWindow` assumptions. Code-block scrollers remain unchanged.
- **Fix column readability** (`4e8eb1f`): increase `COLUMN_MIN_WIDTH` from 120 to 160 and remove the one-character GTK label width hints so ordinary multi-word text wraps at a readable width. Keep equal fixed-width columns and `WordChar` wrapping.

## Verification

```sh
cargo fmt --all -- --check
cargo clippy --all -- -D warnings
cargo test --all --no-fail-fast
```

All pass: 703 unit tests + all integration tests, no warnings.

Manual verification on session `ses_2f32e201affe8hcYinS43NCIZR` (rebuilt via `meson compile && meson install`):
- ✅ Cells render words, not character-by-character
- ✅ Horizontal scrollbar functional for wide tables
- ✅ Header separator pinned during horizontal scroll
- ✅ No blank space below large tables
- ✅ Outer transcript scroll usable

No internal vertical table scroller added; fixture-driven verification found the outer transcript scroll usable with the honest wrapped table height.

## Related

- Closes #182
- Spike: #181
- Design specs: `docs/superpowers/specs/2026-07-09-markdown-table-production-wiring-design.md`, `docs/superpowers/specs/2026-07-11-markdown-table-column-readability-design.md`
- `Shift`+mouse-wheel horizontal scrolling tracked as a separate follow-up issue