### PR TITLE
feat: scroll markdown tables with wheel gestures

### DIFF
--- a/docs/superpowers/specs/2026-07-14-markdown-table-horizontal-scroll-design.md
+++ b/docs/superpowers/specs/2026-07-14-markdown-table-horizontal-scroll-design.md
@@ -237,6 +237,18 @@ not move.
 Read the **No horizontal delta** rule as applying to unlocked classification
 only.
 
+### A locked gesture keeps its initial delta source
+
+The modifier state used for the first non-zero emission is part of the gesture
+lock. A horizontal gesture started without `Shift` keeps using `dx` through
+`scroll-end`; a gesture started with `Shift` keeps using `dy`. Pressing or
+releasing `Shift` mid-sequence must not switch the delta source, which would make
+the table jump according to incidental movement on the other axis.
+
+Outside a continuous gesture, each event still uses its current modifier state.
+In particular, `Shift` with only a non-zero `dx` swaps that movement away from
+the table's horizontal axis and propagates, matching `GtkScrolledWindow`.
+
 ## Implementation Notes
 
 Background, not rules. Nothing here changes the behavior specified above.

--- a/docs/superpowers/specs/2026-07-14-markdown-table-horizontal-scroll-design.md
+++ b/docs/superpowers/specs/2026-07-14-markdown-table-horizontal-scroll-design.md
@@ -210,3 +210,60 @@ keeps the custom widget's adjustment, clamp, and queue-allocate machinery.
 Wrapping the table in a `GtkScrolledWindow` was rejected because the custom
 widget exists precisely to avoid that scroller's height-for-width blank-space
 problems.
+
+## Amendments (2026-07-16)
+
+**Normative.** The design above is left as approved on 2026-07-14. Where an
+amendment conflicts with it, the amendment is the current behavior. Later
+amendments go below this one under their own date.
+
+### A locked gesture reporting no horizontal delta stays consumed
+
+The **Continuous gesture lock** rule keeps a horizontal sequence horizontal
+"even if later emissions are slightly more vertical". The **No horizontal delta**
+rule returns `false` unconditionally. A frame in the middle of a locked
+horizontal pan reporting `dx == 0.0` with a non-zero `dy` satisfies both: the
+lock says consume, the zero-delta rule says propagate.
+
+The first implementation followed the zero-delta rule literally, so that frame
+bubbled to the transcript scroller and moved the page vertically mid-pan.
+Resolved in favor of the lock: the guard returns the gesture's active state, so a
+locked gesture consumes until `scroll-end`, while a discrete wheel event with
+`dx == 0.0` still propagates (it is classified `Vertical` and returns one branch
+earlier). This matches the **Otherwise** rule's own rationale for consuming at
+the edge — a locked gesture must not jerk the page even when the adjustment does
+not move.
+
+Read the **No horizontal delta** rule as applying to unlocked classification
+only.
+
+## Implementation Notes
+
+Background, not rules. Nothing here changes the behavior specified above.
+
+### The gesture lock has no equivalent on GTK's scroll path
+
+Worth knowing for anyone tempted to delete `ScrollGesture` as
+not-invented-by-GTK: `GtkScrolledWindow` does no axis locking in
+`scroll_controller_scroll`. It applies both axes independently every frame,
+because it owns both adjustments and never has to decide whether to propagate.
+
+GTK does have the concept, but only for touch. `GtkGesturePan` is defined as
+drags "locked to happen along one axis", and rejects off-axis sequences with
+`GTK_EVENT_SEQUENCE_DENIED`. `GtkScrolledWindow` attaches it in
+`gtk_scrolled_window_check_attach_pan_gesture()` only when scrolling is
+restricted to a single axis — our exact situation — so that nested scrollers win
+perpendicular drags.
+
+The lock lives in the `GtkGesture` claimed/denied machinery, which
+`GtkEventControllerScroll` does not have. `ScrollGesture` reimplements
+`GtkGesturePan`'s semantics on the one path where GTK does not offer them; the
+active-state return above is the analogue of a claimed sequence.
+
+The same model is standard on the web, under the name *scroll latching*: WebKit
+and Chromium pick the target scroller at gesture begin and do not re-decide
+mid-gesture, rubber-banding at the extent instead of chaining to the parent.
+
+- <https://gitlab.gnome.org/GNOME/gtk/-/raw/main/gtk/gtkgesturepan.c>
+- <https://gitlab.gnome.org/GNOME/gtk/-/raw/main/gtk/gtkscrolledwindow.c>
+- <https://trac.webkit.org/wiki/Scrolling>

--- a/src/ui/markdown_table.rs
+++ b/src/ui/markdown_table.rs
@@ -1,7 +1,6 @@
-use gtk::glib;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
-use relm4::gtk;
+use relm4::gtk::{self, gdk, glib};
 use std::cell::{Cell, RefCell};
 
 pub(crate) const COLUMN_MIN_WIDTH: i32 = 160;
@@ -83,6 +82,50 @@ pub(crate) fn total_table_width(column_count: usize) -> i32 {
     }
 
     (column_count as i32 * COLUMN_MIN_WIDTH) + ((column_count as i32 - 1) * COLUMN_SPACING)
+}
+
+/// Mirrors GTK's current `MAGIC_SCROLL_FACTOR` for surface-pixel scrolling.
+/// This is application behavior, not a stable public GTK constant.
+const SURFACE_SCROLL_FACTOR: f64 = 2.5;
+
+#[derive(Debug, Default)]
+struct ScrollGesture;
+
+/// Apply a scroll delta to the table's horizontal adjustment.
+/// Returns `true` when the event must not bubble to the transcript scroller.
+fn apply_horizontal_scroll(
+    adjustment: &gtk::Adjustment,
+    dx: f64,
+    dy: f64,
+    shift: bool,
+    unit: gdk::ScrollUnit,
+    _gesture: &mut ScrollGesture,
+) -> bool {
+    let lower = adjustment.lower();
+    let max_value = adjustment.upper() - adjustment.page_size();
+    if max_value <= lower {
+        return false;
+    }
+
+    let delta = if shift {
+        dy
+    } else if dx.abs() > dy.abs() {
+        dx
+    } else {
+        return false;
+    };
+    if delta == 0.0 {
+        return false;
+    }
+
+    let normalized = match unit {
+        gdk::ScrollUnit::Wheel => delta * adjustment.page_size().powf(2.0 / 3.0),
+        gdk::ScrollUnit::Surface => delta * SURFACE_SCROLL_FACTOR,
+        _ => delta,
+    };
+    let value = (adjustment.value() + normalized).clamp(lower, max_value);
+    adjustment.set_value(value);
+    true
 }
 
 fn calculate_layout(
@@ -393,6 +436,215 @@ impl MarkdownTable {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn scroll_adjustment(value: f64, upper: f64, page_size: f64) -> gtk::Adjustment {
+        gtk::Adjustment::new(value, 0.0, upper, 1.0, page_size * 0.9, page_size)
+    }
+
+    fn assert_approx_eq(actual: f64, expected: f64) {
+        assert!(
+            (actual - expected).abs() < 1e-9,
+            "expected {expected}, got {actual}"
+        );
+    }
+
+    #[gtk::test]
+    fn dominant_horizontal_surface_delta_moves_right() {
+        let adjustment = scroll_adjustment(100.0, 1000.0, 100.0);
+        let mut gesture = ScrollGesture::default();
+
+        let consumed = apply_horizontal_scroll(
+            &adjustment,
+            4.0,
+            1.0,
+            false,
+            gdk::ScrollUnit::Surface,
+            &mut gesture,
+        );
+
+        assert!(consumed);
+        assert_approx_eq(adjustment.value(), 110.0);
+    }
+
+    #[gtk::test]
+    fn negative_horizontal_delta_clamps_at_lower_bound() {
+        let adjustment = scroll_adjustment(5.0, 1000.0, 100.0);
+        let mut gesture = ScrollGesture::default();
+
+        let consumed = apply_horizontal_scroll(
+            &adjustment,
+            -4.0,
+            0.0,
+            false,
+            gdk::ScrollUnit::Surface,
+            &mut gesture,
+        );
+
+        assert!(consumed);
+        assert_eq!(adjustment.value(), adjustment.lower());
+    }
+
+    #[gtk::test]
+    fn shift_remaps_vertical_delta_to_horizontal() {
+        let adjustment = scroll_adjustment(100.0, 1000.0, 100.0);
+        let mut gesture = ScrollGesture::default();
+
+        let consumed = apply_horizontal_scroll(
+            &adjustment,
+            0.0,
+            4.0,
+            true,
+            gdk::ScrollUnit::Surface,
+            &mut gesture,
+        );
+
+        assert!(consumed);
+        assert_approx_eq(adjustment.value(), 110.0);
+    }
+
+    #[gtk::test]
+    fn plain_vertical_delta_propagates_without_moving_table() {
+        let adjustment = scroll_adjustment(100.0, 1000.0, 100.0);
+        let mut gesture = ScrollGesture::default();
+
+        let consumed = apply_horizontal_scroll(
+            &adjustment,
+            0.0,
+            4.0,
+            false,
+            gdk::ScrollUnit::Surface,
+            &mut gesture,
+        );
+
+        assert!(!consumed);
+        assert_eq!(adjustment.value(), 100.0);
+    }
+
+    #[gtk::test]
+    fn dominant_vertical_delta_with_diagonal_noise_propagates() {
+        let adjustment = scroll_adjustment(100.0, 1000.0, 100.0);
+        let mut gesture = ScrollGesture::default();
+
+        let consumed = apply_horizontal_scroll(
+            &adjustment,
+            1.0,
+            4.0,
+            false,
+            gdk::ScrollUnit::Surface,
+            &mut gesture,
+        );
+
+        assert!(!consumed);
+        assert_eq!(adjustment.value(), 100.0);
+    }
+
+    #[gtk::test]
+    fn equal_axis_deltas_favor_vertical_propagation() {
+        let adjustment = scroll_adjustment(100.0, 1000.0, 100.0);
+        let mut gesture = ScrollGesture::default();
+
+        let consumed = apply_horizontal_scroll(
+            &adjustment,
+            4.0,
+            4.0,
+            false,
+            gdk::ScrollUnit::Surface,
+            &mut gesture,
+        );
+
+        assert!(!consumed);
+        assert_eq!(adjustment.value(), 100.0);
+    }
+
+    #[gtk::test]
+    fn horizontal_delta_propagates_when_table_does_not_overflow() {
+        let adjustment = scroll_adjustment(0.0, 100.0, 100.0);
+        let mut gesture = ScrollGesture::default();
+
+        let consumed = apply_horizontal_scroll(
+            &adjustment,
+            4.0,
+            0.0,
+            false,
+            gdk::ScrollUnit::Surface,
+            &mut gesture,
+        );
+
+        assert!(!consumed);
+        assert_eq!(adjustment.value(), 0.0);
+    }
+
+    #[gtk::test]
+    fn overflowing_table_clamps_delta_past_right_edge() {
+        let adjustment = scroll_adjustment(895.0, 1000.0, 100.0);
+        let mut gesture = ScrollGesture::default();
+
+        let consumed = apply_horizontal_scroll(
+            &adjustment,
+            4.0,
+            0.0,
+            false,
+            gdk::ScrollUnit::Surface,
+            &mut gesture,
+        );
+
+        assert!(consumed);
+        assert_eq!(adjustment.value(), 900.0);
+    }
+
+    #[gtk::test]
+    fn overflowing_table_consumes_horizontal_delta_when_already_at_edge() {
+        let adjustment = scroll_adjustment(900.0, 1000.0, 100.0);
+        let mut gesture = ScrollGesture::default();
+
+        let consumed = apply_horizontal_scroll(
+            &adjustment,
+            4.0,
+            0.0,
+            false,
+            gdk::ScrollUnit::Surface,
+            &mut gesture,
+        );
+
+        assert!(consumed);
+        assert_eq!(adjustment.value(), 900.0);
+    }
+
+    #[gtk::test]
+    fn wheel_delta_scales_with_page_size() {
+        let adjustment = scroll_adjustment(100.0, 1000.0, 125.0);
+        let mut gesture = ScrollGesture::default();
+
+        let consumed = apply_horizontal_scroll(
+            &adjustment,
+            1.0,
+            0.0,
+            false,
+            gdk::ScrollUnit::Wheel,
+            &mut gesture,
+        );
+
+        assert!(consumed);
+        assert_approx_eq(adjustment.value(), 100.0 + 125.0_f64.powf(2.0 / 3.0));
+    }
+
+    #[gtk::test]
+    fn surface_delta_uses_gtk_scroll_factor() {
+        let adjustment = scroll_adjustment(100.0, 1000.0, 100.0);
+        let mut gesture = ScrollGesture::default();
+
+        let consumed = apply_horizontal_scroll(
+            &adjustment,
+            4.0,
+            0.0,
+            false,
+            gdk::ScrollUnit::Surface,
+            &mut gesture,
+        );
+
+        assert!(consumed);
+        assert_approx_eq(adjustment.value(), 100.0 + 4.0 * SURFACE_SCROLL_FACTOR);
+    }
 
     #[gtk::test]
     fn shared_table_label_can_be_non_wrapping_for_existing_renderer() {

--- a/src/ui/markdown_table.rs
+++ b/src/ui/markdown_table.rs
@@ -95,7 +95,7 @@ enum ScrollAxis {
 }
 
 #[derive(Debug, Default)]
-struct ScrollGesture {
+pub(crate) struct ScrollGesture {
     active: bool,
     axis: Option<ScrollAxis>,
 }
@@ -220,6 +220,7 @@ mod imp {
         pub row_count: Cell<usize>,
         pub match_count: Cell<usize>,
         pub adjustment: gtk::Adjustment,
+        pub scroll_gesture: RefCell<ScrollGesture>,
         pub separator: gtk::Separator,
         pub scrollbar: gtk::Scrollbar,
     }
@@ -243,6 +244,7 @@ mod imp {
                 row_count: Cell::new(0),
                 match_count: Cell::new(0),
                 adjustment,
+                scroll_gesture: RefCell::new(ScrollGesture::default()),
                 separator,
                 scrollbar,
             }
@@ -255,6 +257,47 @@ mod imp {
             let obj = self.obj();
             self.separator.set_parent(&*obj);
             self.scrollbar.set_parent(&*obj);
+
+            let controller =
+                gtk::EventControllerScroll::new(gtk::EventControllerScrollFlags::BOTH_AXES);
+
+            let weak = obj.downgrade();
+            controller.connect_scroll_begin(move |_| {
+                if let Some(obj) = weak.upgrade() {
+                    obj.imp().scroll_gesture.borrow_mut().begin();
+                }
+            });
+
+            let weak = obj.downgrade();
+            controller.connect_scroll(move |ctrl, dx, dy| {
+                let Some(obj) = weak.upgrade() else {
+                    return glib::Propagation::Proceed;
+                };
+                let shift = ctrl
+                    .current_event_state()
+                    .contains(gdk::ModifierType::SHIFT_MASK);
+                if apply_horizontal_scroll(
+                    &obj.imp().adjustment,
+                    dx,
+                    dy,
+                    shift,
+                    ctrl.unit(),
+                    &mut obj.imp().scroll_gesture.borrow_mut(),
+                ) {
+                    glib::Propagation::Stop
+                } else {
+                    glib::Propagation::Proceed
+                }
+            });
+
+            let weak = obj.downgrade();
+            controller.connect_scroll_end(move |_| {
+                if let Some(obj) = weak.upgrade() {
+                    obj.imp().scroll_gesture.borrow_mut().end();
+                }
+            });
+
+            obj.add_controller(controller);
 
             // The cell offset is derived from the adjustment value during
             // size_allocate, so scrolling must queue a fresh allocation;
@@ -751,6 +794,29 @@ mod tests {
             gdk::ScrollUnit::Surface,
             &mut gesture,
         ));
+    }
+
+    #[gtk::test]
+    fn markdown_table_attaches_both_axes_scroll_controller() {
+        let table = MarkdownTable::new(
+            &["A".to_string(), "B".to_string()],
+            &[vec!["1".to_string(), "2".to_string()]],
+            "",
+        );
+        let controllers = table.observe_controllers();
+        let scroll_controller = (0..controllers.n_items())
+            .filter_map(|index| controllers.item(index))
+            .find_map(|controller| controller.downcast::<gtk::EventControllerScroll>().ok())
+            .expect("MarkdownTable should own an EventControllerScroll");
+
+        assert_eq!(
+            scroll_controller.flags(),
+            gtk::EventControllerScrollFlags::BOTH_AXES
+        );
+        assert_eq!(
+            scroll_controller.propagation_phase(),
+            gtk::PropagationPhase::Bubble
+        );
     }
 
     #[gtk::test]

--- a/src/ui/markdown_table.rs
+++ b/src/ui/markdown_table.rs
@@ -88,8 +88,48 @@ pub(crate) fn total_table_width(column_count: usize) -> i32 {
 /// This is application behavior, not a stable public GTK constant.
 const SURFACE_SCROLL_FACTOR: f64 = 2.5;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ScrollAxis {
+    Horizontal,
+    Vertical,
+}
+
 #[derive(Debug, Default)]
-struct ScrollGesture;
+struct ScrollGesture {
+    active: bool,
+    axis: Option<ScrollAxis>,
+}
+
+impl ScrollGesture {
+    fn begin(&mut self) {
+        self.active = true;
+        self.axis = None;
+    }
+
+    fn end(&mut self) {
+        self.active = false;
+        self.axis = None;
+    }
+
+    fn classify(&mut self, dx: f64, dy: f64, shift: bool) -> Option<ScrollAxis> {
+        if dx == 0.0 && dy == 0.0 {
+            return None;
+        }
+        if self.active && self.axis.is_some() {
+            return self.axis;
+        }
+
+        let axis = if shift || dx.abs() > dy.abs() {
+            ScrollAxis::Horizontal
+        } else {
+            ScrollAxis::Vertical
+        };
+        if self.active {
+            self.axis = Some(axis);
+        }
+        Some(axis)
+    }
+}
 
 /// Apply a scroll delta to the table's horizontal adjustment.
 /// Returns `true` when the event must not bubble to the transcript scroller.
@@ -99,7 +139,7 @@ fn apply_horizontal_scroll(
     dy: f64,
     shift: bool,
     unit: gdk::ScrollUnit,
-    _gesture: &mut ScrollGesture,
+    gesture: &mut ScrollGesture,
 ) -> bool {
     let lower = adjustment.lower();
     let max_value = adjustment.upper() - adjustment.page_size();
@@ -107,13 +147,10 @@ fn apply_horizontal_scroll(
         return false;
     }
 
-    let delta = if shift {
-        dy
-    } else if dx.abs() > dy.abs() {
-        dx
-    } else {
+    if gesture.classify(dx, dy, shift) != Some(ScrollAxis::Horizontal) {
         return false;
-    };
+    }
+    let delta = if shift { dy } else { dx };
     if delta == 0.0 {
         return false;
     }
@@ -644,6 +681,76 @@ mod tests {
 
         assert!(consumed);
         assert_approx_eq(adjustment.value(), 100.0 + 4.0 * SURFACE_SCROLL_FACTOR);
+    }
+
+    #[gtk::test]
+    fn continuous_vertical_gesture_stays_unconsumed_until_end() {
+        let adjustment = scroll_adjustment(100.0, 1000.0, 100.0);
+        let mut gesture = ScrollGesture::default();
+        gesture.begin();
+
+        assert!(!apply_horizontal_scroll(
+            &adjustment,
+            1.0,
+            8.0,
+            false,
+            gdk::ScrollUnit::Surface,
+            &mut gesture,
+        ));
+        assert!(!apply_horizontal_scroll(
+            &adjustment,
+            9.0,
+            2.0,
+            false,
+            gdk::ScrollUnit::Surface,
+            &mut gesture,
+        ));
+        assert_eq!(adjustment.value(), 100.0);
+
+        gesture.end();
+        assert!(apply_horizontal_scroll(
+            &adjustment,
+            9.0,
+            2.0,
+            false,
+            gdk::ScrollUnit::Surface,
+            &mut gesture,
+        ));
+    }
+
+    #[gtk::test]
+    fn continuous_horizontal_gesture_stays_consumed_until_end() {
+        let adjustment = scroll_adjustment(100.0, 1000.0, 100.0);
+        let mut gesture = ScrollGesture::default();
+        gesture.begin();
+
+        assert!(apply_horizontal_scroll(
+            &adjustment,
+            8.0,
+            1.0,
+            false,
+            gdk::ScrollUnit::Surface,
+            &mut gesture,
+        ));
+        assert!(apply_horizontal_scroll(
+            &adjustment,
+            1.0,
+            6.0,
+            false,
+            gdk::ScrollUnit::Surface,
+            &mut gesture,
+        ));
+        assert_approx_eq(adjustment.value(), 100.0 + (8.0 + 1.0) * 2.5);
+
+        gesture.end();
+        assert!(!apply_horizontal_scroll(
+            &adjustment,
+            1.0,
+            6.0,
+            false,
+            gdk::ScrollUnit::Surface,
+            &mut gesture,
+        ));
     }
 
     #[gtk::test]

--- a/src/ui/markdown_table.rs
+++ b/src/ui/markdown_table.rs
@@ -95,20 +95,23 @@ enum ScrollAxis {
 }
 
 #[derive(Debug, Default)]
-pub(crate) struct ScrollGesture {
+struct ScrollGesture {
     active: bool,
     axis: Option<ScrollAxis>,
+    remaps_vertical_delta: bool,
 }
 
 impl ScrollGesture {
     fn begin(&mut self) {
         self.active = true;
         self.axis = None;
+        self.remaps_vertical_delta = false;
     }
 
     fn end(&mut self) {
         self.active = false;
         self.axis = None;
+        self.remaps_vertical_delta = false;
     }
 
     fn classify(&mut self, dx: f64, dy: f64, shift: bool) -> Option<ScrollAxis> {
@@ -126,8 +129,18 @@ impl ScrollGesture {
         };
         if self.active {
             self.axis = Some(axis);
+            self.remaps_vertical_delta = shift;
         }
         Some(axis)
+    }
+
+    fn horizontal_delta(&self, dx: f64, dy: f64, shift: bool) -> f64 {
+        let remaps_vertical_delta = if self.active && self.axis.is_some() {
+            self.remaps_vertical_delta
+        } else {
+            shift
+        };
+        if remaps_vertical_delta { dy } else { dx }
     }
 }
 
@@ -150,7 +163,7 @@ fn apply_horizontal_scroll(
     if gesture.classify(dx, dy, shift) != Some(ScrollAxis::Horizontal) {
         return false;
     }
-    let delta = if shift { dy } else { dx };
+    let delta = gesture.horizontal_delta(dx, dy, shift);
     if delta == 0.0 {
         // A locked gesture keeps consuming events until `scroll-end`, otherwise
         // this frame's other axis would bubble to the transcript scroller.
@@ -222,7 +235,7 @@ mod imp {
         pub row_count: Cell<usize>,
         pub match_count: Cell<usize>,
         pub adjustment: gtk::Adjustment,
-        pub scroll_gesture: RefCell<ScrollGesture>,
+        scroll_gesture: RefCell<ScrollGesture>,
         pub separator: gtk::Separator,
         pub scrollbar: gtk::Scrollbar,
     }
@@ -585,6 +598,24 @@ mod tests {
     }
 
     #[gtk::test]
+    fn shift_with_only_horizontal_delta_propagates() {
+        let adjustment = scroll_adjustment(100.0, 1000.0, 100.0);
+        let mut gesture = ScrollGesture::default();
+
+        let consumed = apply_horizontal_scroll(
+            &adjustment,
+            4.0,
+            0.0,
+            true,
+            gdk::ScrollUnit::Surface,
+            &mut gesture,
+        );
+
+        assert!(!consumed);
+        assert_eq!(adjustment.value(), 100.0);
+    }
+
+    #[gtk::test]
     fn plain_vertical_delta_propagates_without_moving_table() {
         let adjustment = scroll_adjustment(100.0, 1000.0, 100.0);
         let mut gesture = ScrollGesture::default();
@@ -796,6 +827,56 @@ mod tests {
             gdk::ScrollUnit::Surface,
             &mut gesture,
         ));
+    }
+
+    #[gtk::test]
+    fn continuous_horizontal_gesture_keeps_delta_source_when_shift_changes() {
+        let adjustment = scroll_adjustment(100.0, 1000.0, 100.0);
+        let mut gesture = ScrollGesture::default();
+        gesture.begin();
+
+        assert!(apply_horizontal_scroll(
+            &adjustment,
+            8.0,
+            1.0,
+            false,
+            gdk::ScrollUnit::Surface,
+            &mut gesture,
+        ));
+        assert!(apply_horizontal_scroll(
+            &adjustment,
+            3.0,
+            9.0,
+            true,
+            gdk::ScrollUnit::Surface,
+            &mut gesture,
+        ));
+        assert_approx_eq(adjustment.value(), 100.0 + (8.0 + 3.0) * 2.5);
+    }
+
+    #[gtk::test]
+    fn continuous_shift_gesture_keeps_delta_source_when_shift_is_released() {
+        let adjustment = scroll_adjustment(100.0, 1000.0, 100.0);
+        let mut gesture = ScrollGesture::default();
+        gesture.begin();
+
+        assert!(apply_horizontal_scroll(
+            &adjustment,
+            1.0,
+            8.0,
+            true,
+            gdk::ScrollUnit::Surface,
+            &mut gesture,
+        ));
+        assert!(apply_horizontal_scroll(
+            &adjustment,
+            9.0,
+            3.0,
+            false,
+            gdk::ScrollUnit::Surface,
+            &mut gesture,
+        ));
+        assert_approx_eq(adjustment.value(), 100.0 + (8.0 + 3.0) * 2.5);
     }
 
     #[gtk::test]

--- a/src/ui/markdown_table.rs
+++ b/src/ui/markdown_table.rs
@@ -152,7 +152,9 @@ fn apply_horizontal_scroll(
     }
     let delta = if shift { dy } else { dx };
     if delta == 0.0 {
-        return false;
+        // A locked gesture keeps consuming events until `scroll-end`, otherwise
+        // this frame's other axis would bubble to the transcript scroller.
+        return gesture.active;
     }
 
     let normalized = match unit {
@@ -794,6 +796,47 @@ mod tests {
             gdk::ScrollUnit::Surface,
             &mut gesture,
         ));
+    }
+
+    #[gtk::test]
+    fn locked_horizontal_gesture_consumes_frames_without_horizontal_delta() {
+        let adjustment = scroll_adjustment(100.0, 1000.0, 100.0);
+        let mut gesture = ScrollGesture::default();
+        gesture.begin();
+
+        assert!(apply_horizontal_scroll(
+            &adjustment,
+            8.0,
+            1.0,
+            false,
+            gdk::ScrollUnit::Surface,
+            &mut gesture,
+        ));
+        assert!(apply_horizontal_scroll(
+            &adjustment,
+            0.0,
+            6.0,
+            false,
+            gdk::ScrollUnit::Surface,
+            &mut gesture,
+        ));
+        assert_approx_eq(adjustment.value(), 100.0 + 8.0 * 2.5);
+    }
+
+    #[gtk::test]
+    fn wheel_without_horizontal_delta_stays_unconsumed() {
+        let adjustment = scroll_adjustment(100.0, 1000.0, 100.0);
+        let mut gesture = ScrollGesture::default();
+
+        assert!(!apply_horizontal_scroll(
+            &adjustment,
+            0.0,
+            6.0,
+            false,
+            gdk::ScrollUnit::Wheel,
+            &mut gesture,
+        ));
+        assert_eq!(adjustment.value(), 100.0);
     }
 
     #[gtk::test]


### PR DESCRIPTION
## Summary
- drive MarkdownTable’s existing horizontal adjustment from a BOTH_AXES GTK scroll controller
- support horizontal trackpad/wheel input and Shift + vertical wheel while preserving vertical transcript scrolling
- lock continuous gestures to their initial dominant axis and cover normalization, bounds, propagation, and wiring
- keep a locked horizontal gesture consumed on frames that report no horizontal delta, so a mid-pan frame cannot bubble to the transcript scroller and jump the page vertically
- record the resolution and its background in the design doc

## Design doc
`docs/superpowers/specs/2026-07-14-markdown-table-horizontal-scroll-design.md` states two rules that both apply to a locked gesture reporting `dx == 0.0`: the gesture lock keeps the sequence horizontal, while "no horizontal delta → return `false`" propagates. The first implementation followed the latter literally, which is the bug fixed here.

The approved design is left untouched. Two sections are appended instead:

- **Amendments (2026-07-16)** — normative. Resolves the collision in favour of the lock, consistent with the doc's own "consume even at the edge" rationale, and states that the zero-delta rule applies to unlocked classification only.
- **Implementation Notes** — background. Why `ScrollGesture` exists at all: `GtkScrolledWindow` does no axis locking on the scroll path, whereas `GtkGesturePan` is defined as drags locked to one axis and is attached by `gtk_scrolled_window_check_attach_pan_gesture()` precisely so nested scrollers win perpendicular drags. That lock lives in the `GtkGesture` claimed/denied machinery, which `GtkEventControllerScroll` does not have — so `ScrollGesture` reimplements those semantics on the one path GTK leaves uncovered. WebKit and Chromium call the same model *scroll latching*.

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --all -- -D warnings`
- `cargo test --all --no-fail-fast`

## Manual verification
- Not performed: this environment cannot provide GUI input for trackpad and wheel gestures.

## Follow-up
- Unrelated flaky test observed while verifying: `session_list_reload_preserves_selected_session_when_order_changes` (`src/ui/session_list.rs:2515`) failed once in four runs on a `has_focus()` assertion. Pre-existing, introduced in #148; not touched here.
