### PR TITLE
feat: add session list sorting

### DIFF
--- a/data/dev.maciz.sessionschronicle.gschema.xml.in
+++ b/data/dev.maciz.sessionschronicle.gschema.xml.in
@@ -18,5 +18,10 @@
       <summary>Terminal emulator for resuming sessions</summary>
       <description>The terminal emulator to use when resuming sessions. Accepted values: auto, ptyxis, ghostty, foot, alacritty, kitty.</description>
     </key>
+    <key name="sort-order" type="s">
+      <default>"recent-activity"</default>
+      <summary>Session list sort order</summary>
+      <description>Named reading order for the session list. Accepted values: recent-activity, oldest-first, newest-first, most-messages.</description>
+    </key>
   </schema>
 </schemalist>

--- a/docs/superpowers/specs/2026-07-21-session-list-sorting-design.md
+++ b/docs/superpowers/specs/2026-07-21-session-list-sorting-design.md
@@ -2,7 +2,7 @@
 
 **Issue:** [#188](https://github.com/supermaciz/sessions-chronicle/issues/188) — Sort options for the session list  
 **Date:** 2026-07-21  
-**Status:** Approved  
+**Status:** Approved — implemented in [#190](https://github.com/supermaciz/sessions-chronicle/pull/190), see section 9 for amendments  
 **Decision source:** `docs/explorations/2026-07-21-session-list-sorting-exploration.md` — Proposal C (named reading orders), rendered on Proposal A's header-bar pill, labelled but never carrying the `accent` CSS class.
 
 ## Summary
@@ -188,3 +188,52 @@ All new user-visible strings use the existing `gettext-rs` setup. This feature d
 ## 8. Scope boundaries
 
 Proposal E (filter-inferred defaults) remains deferred until usage evidence shows that users systematically choose a particular order in a filter context. Proposal B (lenses, including chronology grouping and volume encoding) remains a separate project for which these named orders are the foundation.
+
+## 9. Amendments during implementation
+
+Recorded 2026-07-22, from [#190](https://github.com/supermaciz/sessions-chronicle/pull/190). Sections 1–5 and 8 shipped as designed. What follows is where the implementation departed from this spec, and why. Each entry supersedes the section it names.
+
+### 9.1 The 760sp narrow breakpoint was dropped (supersedes §6 "Narrow widths")
+
+**Spec:** an `adw::Breakpoint` at `max-width: 760sp` on the `adw::ApplicationWindow`, with `connect_apply` / `connect_unapply` sending `SortPillInput::SetNarrow(bool)` to hide the label.
+
+**Shipped:** no breakpoint. The label follows a single rule — visible whenever a non-default order is active, hidden otherwise — at every window width. This is exactly what `DatePill` already does with `self.current_filter.is_active()`, so the two pills sitting side by side in the header now behave identically.
+
+**Why:** the spec treated the new breakpoint as independent of the pre-existing 400sp collapse breakpoint. It is not. libadwaita applies only the **last matching** breakpoint, not the union of all matching ones, so registration order becomes load-bearing as soon as a window has two — and here one condition strictly contains the other. `max-width: 400sp` and `max-width: 760sp` scale together with the text-scaling factor, so any width matching the 400sp condition necessarily also matches the 760sp one. The two are never simultaneously active in the sense of both applying; the later-registered one simply wins and the other's setters never run.
+
+Registering the new breakpoint after the existing one therefore disabled sidebar collapse and the view-switcher bar outright. Because the 400sp condition is only reachable at all above roughly 1.8x text scaling (400sp must exceed the 710 px minimum window width), the regression was invisible at default settings and appeared only in the accessibility path — precisely where the 400sp breakpoint was still doing its only useful work.
+
+Two fixes were attempted before the current one: ordering the breakpoints wide-first and making the 400sp one re-send `SetNarrow` (correct but fragile — the ordering rule is invisible to the next person adding a breakpoint), then deleting the 400sp breakpoint outright (which re-created the regression it was meant to avoid). Aligning on `DatePill` removes the second breakpoint entirely, so no ordering rule is load-bearing and `setup_breakpoints` is byte-identical to its state before this feature.
+
+**Consequences:**
+
+- `SortPillInput::SetNarrow(bool)` does not exist; the interface in §6 is otherwise as specified.
+- §7's GTK test "hidden again when `SetNarrow(true)`" became `label_is_shown_only_for_non_default_orders`, which also covers Relevance-during-FTS as a non-default state.
+- §7's manual step 4 (narrowing below 760sp, repeated under text scaling and long translations) no longer applies and was not performed.
+
+The underlying question the spec was right to raise — a 400sp condition against a 710 px minimum window width is nearly unreachable — is untouched here and left as a follow-up. It predates this feature.
+
+### 9.2 Row selection carries no explicit check icon (resolves §6's open question)
+
+§6 left this conditional: *"if the checkmark shown above is rendered literally rather than being illustrative, each row owns an explicit check icon"*. The checkmark was read as illustrative. Rows are label-only and the effective order is conveyed solely by `gtk::SelectionMode::Browse`, matching `DatePill`'s preset rows.
+
+This is worth revisiting for both pills at once: a `GtkListBox` in Browse mode announces "list item" to assistive technology, where a menu model with radio items would announce a checked radio button. Deliberately out of scope here — changing it for `SortPill` alone would make the two pills inconsistent again.
+
+### 9.3 `SessionQuery` replaces `parse_session_id_query` (extends §5)
+
+§5 described three search contexts and required they be *"derived once and shared by the app state and session-loading path so the pill cannot disagree with the query actually executed"*, but named no type. The implementation gives that requirement a home: `src/models/session_query.rs` exposes `SessionQuery::{None, DirectId, Fts}` with a single `classify()` entry point. `session_list.rs`'s ad hoc `parse_session_id_query` is deleted, and `App` and the loading path now classify through the same function.
+
+Two related mechanisms follow from the same requirement:
+
+- `SessionListMsg::SetSearchQuery(String)` became `SetSearchState { query, sort }`, so a query change and its resolved order reach the list in one message and cannot be observed apart.
+- `App::clear_search_state` encodes "clearing FTS restores the persisted order" once, replacing three copies of that logic.
+
+### 9.4 The query-plan check became an automated test (upgrades §7)
+
+§7 listed `EXPLAIN QUERY PLAN` per order as **manual** step 3. It ships instead as `unfiltered_named_orders_do_not_build_temporary_sort_tables` in `schema.rs`, asserting no `USE TEMP B-TREE FOR ORDER BY` for any of the four unfiltered orders. The filtered-view trade-off documented in §3 is unchanged and remains untested by design.
+
+### 9.5 Minor notes
+
+- The v15 migration is applied to freshly created databases as well, so a new database briefly creates `idx_sessions_top_level_last_updated` (`schema.rs`) before the migration drops it. Harmless, consistent with how earlier migrations in this file behave, but it means the base schema statement is now dead weight.
+- The tooltip uses `gettext("Sort by: {}")` with placeholder substitution rather than `format!`, so translators receive the sentence frame rather than a fragment. §6's reference pattern, `tooltip_for_filter`, interpolates with `format!` and is the weaker of the two.
+- §6's `pack_start` placement next to the `DatePill` shipped as specified. Note that GNOME convention would put sort controls in `pack_end`; the spec's choice was kept deliberately, not by oversight.

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -4,3 +4,4 @@ data/dev.maciz.sessionschronicle.metainfo.xml.in.in
 src/app.rs
 src/main.rs
 src/ui/modals/shortcuts.rs
+src/ui/sort_pill.rs

--- a/src/app/handlers/analytics.rs
+++ b/src/app/handlers/analytics.rs
@@ -57,6 +57,16 @@ impl App {
         .date_filter_visible
     }
 
+    pub(crate) fn is_sort_pill_visible(&self) -> bool {
+        workspace_header_visibility(
+            self.active_workspace,
+            self.detail_visible,
+            self.parent_session.is_some(),
+            self.active_session.is_some(),
+        )
+        .sort_pill_visible
+    }
+
     pub(crate) fn is_pane_controls_visible(&self) -> bool {
         workspace_header_visibility(
             self.active_workspace,

--- a/src/app/handlers/navigation.rs
+++ b/src/app/handlers/navigation.rs
@@ -6,8 +6,8 @@ use crate::ui::session_detail::SessionDetailMsg;
 use crate::ui::session_list::SessionListMsg;
 
 use super::super::helpers::{
-    detail_pop_sync_decision, resolve_escape_action, resolve_search_mode_change,
-    search_query_update_messages, workspace_allows_search,
+    detail_pop_sync_decision, override_after_query_change, resolve_escape_action,
+    resolve_search_mode_change, search_query_update_messages, workspace_allows_search,
 };
 use super::super::types::EscapeResolution;
 use super::super::{App, AppMsg};
@@ -23,8 +23,11 @@ impl App {
         if self.search_visible != resolved_enabled {
             self.search_visible = resolved_enabled;
             if !resolved_enabled {
+                self.search_sort_override = None;
                 self.search_query.clear();
-                let (list_msg, detail_msg) = search_query_update_messages(String::new());
+                self.sync_sort_pill();
+                let (list_msg, detail_msg) =
+                    search_query_update_messages(String::new(), Some(self.sort_order));
                 self.session_list.emit(list_msg);
                 self.session_detail.emit(detail_msg);
                 if !self.detail_visible {
@@ -76,8 +79,11 @@ impl App {
     }
 
     pub(crate) fn handle_search_query_changed(&mut self, query: String) {
+        self.search_sort_override =
+            override_after_query_change(&self.search_query, &query, self.search_sort_override);
         self.search_query = query.clone();
-        let (list_msg, detail_msg) = search_query_update_messages(query);
+        self.sync_sort_pill();
+        let (list_msg, detail_msg) = search_query_update_messages(query, self.effective_sort());
         self.session_list.emit(list_msg);
         self.session_detail.emit(detail_msg);
     }
@@ -121,8 +127,11 @@ impl App {
             EscapeResolution::CloseSearch => {
                 self.search_visible = false;
                 self.sync_search_bar.set(true);
+                self.search_sort_override = None;
                 self.search_query.clear();
-                let (list_msg, detail_msg) = search_query_update_messages(String::new());
+                self.sync_sort_pill();
+                let (list_msg, detail_msg) =
+                    search_query_update_messages(String::new(), Some(self.sort_order));
                 self.session_list.emit(list_msg);
                 self.session_detail.emit(detail_msg);
                 if !self.detail_visible {

--- a/src/app/handlers/navigation.rs
+++ b/src/app/handlers/navigation.rs
@@ -13,6 +13,19 @@ use super::super::types::EscapeResolution;
 use super::super::{App, AppMsg};
 
 impl App {
+    /// Clears the active search query and override, restores the persisted
+    /// sort order in the sort pill, and returns the messages needed to
+    /// propagate the cleared state to the session list and detail
+    /// components. Centralizes the rule "clearing FTS restores the
+    /// persisted order" so it is encoded exactly once.
+    pub(crate) fn clear_search_state(&mut self) -> (SessionListMsg, SessionDetailMsg) {
+        self.search_sort_override =
+            override_after_query_change(&self.search_query, "", self.search_sort_override);
+        self.search_query.clear();
+        self.sync_sort_pill();
+        search_query_update_messages(String::new(), self.effective_sort())
+    }
+
     pub(crate) fn handle_search_mode_changed(&mut self, enabled: bool) {
         let resolved_enabled = resolve_search_mode_change(self.active_workspace, enabled);
 
@@ -23,11 +36,7 @@ impl App {
         if self.search_visible != resolved_enabled {
             self.search_visible = resolved_enabled;
             if !resolved_enabled {
-                self.search_sort_override = None;
-                self.search_query.clear();
-                self.sync_sort_pill();
-                let (list_msg, detail_msg) =
-                    search_query_update_messages(String::new(), Some(self.sort_order));
+                let (list_msg, detail_msg) = self.clear_search_state();
                 self.session_list.emit(list_msg);
                 self.session_detail.emit(detail_msg);
                 if !self.detail_visible {
@@ -127,11 +136,7 @@ impl App {
             EscapeResolution::CloseSearch => {
                 self.search_visible = false;
                 self.sync_search_bar.set(true);
-                self.search_sort_override = None;
-                self.search_query.clear();
-                self.sync_sort_pill();
-                let (list_msg, detail_msg) =
-                    search_query_update_messages(String::new(), Some(self.sort_order));
+                let (list_msg, detail_msg) = self.clear_search_state();
                 self.session_list.emit(list_msg);
                 self.session_detail.emit(detail_msg);
                 if !self.detail_visible {

--- a/src/app/helpers.rs
+++ b/src/app/helpers.rs
@@ -111,6 +111,7 @@ pub(super) fn workspace_header_visibility(
         WorkspaceHeaderVisibility {
             search_ui_visible: false,
             date_filter_visible: false,
+            sort_pill_visible: false,
             pane_controls_visible: false,
             detail_actions_visible: false,
             summary_button_visible: false,
@@ -120,6 +121,7 @@ pub(super) fn workspace_header_visibility(
         WorkspaceHeaderVisibility {
             search_ui_visible: true,
             date_filter_visible: !detail_visible,
+            sort_pill_visible: !detail_visible,
             pane_controls_visible: true,
             detail_actions_visible: detail_visible || parent_session_present,
             summary_button_visible: detail_visible && active_session_present,
@@ -373,12 +375,15 @@ mod tests {
     fn workspace_header_visibility_shows_date_filter_only_on_sessions_list() {
         let analytics = workspace_header_visibility(Workspace::Analytics, false, false, false);
         assert!(!analytics.date_filter_visible);
+        assert!(!analytics.sort_pill_visible);
 
         let sessions_list = workspace_header_visibility(Workspace::Sessions, false, false, false);
         assert!(sessions_list.date_filter_visible);
+        assert!(sessions_list.sort_pill_visible);
 
         let sessions_detail = workspace_header_visibility(Workspace::Sessions, true, false, false);
         assert!(!sessions_detail.date_filter_visible);
+        assert!(!sessions_detail.sort_pill_visible);
     }
 
     #[test]

--- a/src/app/helpers.rs
+++ b/src/app/helpers.rs
@@ -1,4 +1,6 @@
-use crate::models::{PerSourceResult, ProjectFilter, ProjectInfo, SourceStatus};
+use crate::models::{
+    PerSourceResult, ProjectFilter, ProjectInfo, SessionQuery, SortOrder, SourceStatus,
+};
 use crate::ui::{session_detail::SessionDetailMsg, session_list::SessionListMsg};
 
 use super::types::{
@@ -14,13 +16,42 @@ pub(super) fn active_search_query(query: &str) -> Option<String> {
     }
 }
 
-pub(super) fn search_query_update_messages(query: String) -> (SessionListMsg, SessionDetailMsg) {
+pub(super) fn search_query_update_messages(
+    query: String,
+    sort: Option<SortOrder>,
+) -> (SessionListMsg, SessionDetailMsg) {
     let detail_query = active_search_query(&query);
 
     (
-        SessionListMsg::SetSearchQuery(query),
+        SessionListMsg::SetSearchState { query, sort },
         SessionDetailMsg::UpdateSearchQuery(detail_query),
     )
+}
+
+pub(super) fn effective_sort(
+    query: &str,
+    sort_order: SortOrder,
+    search_sort_override: Option<SortOrder>,
+) -> Option<SortOrder> {
+    if SessionQuery::classify(query).is_fts() {
+        search_sort_override
+    } else {
+        Some(sort_order)
+    }
+}
+
+pub(super) fn override_after_query_change(
+    previous_query: &str,
+    next_query: &str,
+    current: Option<SortOrder>,
+) -> Option<SortOrder> {
+    let previous_fts = SessionQuery::classify(previous_query).is_fts();
+    let next_fts = SessionQuery::classify(next_query).is_fts();
+    if previous_fts && next_fts {
+        current
+    } else {
+        None
+    }
 }
 
 pub(super) fn workspace_allows_search(workspace: Workspace) -> bool {
@@ -302,6 +333,40 @@ mod tests {
         );
 
         assert!(target.is_none());
+    }
+
+    #[test]
+    fn effective_sort_is_relevance_only_for_fts_without_override() {
+        let saved = SortOrder::MostMessages;
+        assert_eq!(effective_sort("", saved, None), Some(saved));
+        assert_eq!(effective_sort("id:abc", saved, None), Some(saved));
+        assert_eq!(effective_sort("needle", saved, None), None);
+        assert_eq!(
+            effective_sort("needle", saved, Some(SortOrder::OldestFirst)),
+            Some(SortOrder::OldestFirst)
+        );
+    }
+
+    #[test]
+    fn query_transitions_reset_override_at_fts_boundaries_only() {
+        let selected = Some(SortOrder::MostMessages);
+        assert_eq!(override_after_query_change("", "needle", selected), None);
+        assert_eq!(
+            override_after_query_change("needle", "needles", selected),
+            selected
+        );
+        assert_eq!(override_after_query_change("needle", "", selected), None);
+        assert_eq!(
+            override_after_query_change("needle", "id:abc", selected),
+            None
+        );
+    }
+
+    #[test]
+    fn explicit_relevance_then_clear_returns_to_saved_order() {
+        let saved = SortOrder::MostMessages;
+        assert_eq!(effective_sort("needle", saved, None), None);
+        assert_eq!(effective_sort("", saved, None), Some(saved));
     }
 
     #[test]

--- a/src/app/init.rs
+++ b/src/app/init.rs
@@ -371,18 +371,16 @@ pub(super) fn setup_breakpoints(
     workspace_switcher_bar: &adw::ViewSwitcherBar,
     sort_pill: &Controller<SortPill>,
 ) {
-    // Add responsive collapse breakpoint
-    let breakpoint = adw::Breakpoint::new(adw::BreakpointCondition::new_length(
-        adw::BreakpointConditionLengthType::MaxWidth,
-        400.0,
-        adw::LengthUnit::Sp,
-    ));
-    breakpoint.add_setter(overlay_split, "collapsed", Some(&true.into()));
-    breakpoint.add_setter(workspace_switcher, "visible", Some(&false.into()));
-    breakpoint.add_setter(workspace_switcher_bar, "reveal", Some(&true.into()));
-    root.add_breakpoint(breakpoint);
+    // libadwaita picks the LAST breakpoint that matches the current size
+    // ("If multiple breakpoints can be used for the current size, the last
+    // one is always picked"). Both breakpoint widths are expressed in `sp`,
+    // which scales with the text-scaling factor, so at large scale factors
+    // the narrower (400sp) breakpoint's condition can become wider than the
+    // 760sp one and both can match simultaneously. Registering the WIDER
+    // breakpoint first and the narrower one second ensures the narrower
+    // breakpoint's setters win whenever both match.
 
-    // Add independent breakpoint to collapse the sort pill label to icon-only
+    // Add independent breakpoint to collapse the sort pill label to icon-only.
     let sort_breakpoint = adw::Breakpoint::new(adw::BreakpointCondition::new_length(
         adw::BreakpointConditionLengthType::MaxWidth,
         760.0,
@@ -397,6 +395,29 @@ pub(super) fn setup_breakpoints(
         sort_sender.send(SortPillInput::SetNarrow(false)).ok();
     });
     root.add_breakpoint(sort_breakpoint);
+
+    // Add responsive collapse breakpoint. Below 400sp the sort pill label
+    // must also be hidden (400 < 760), but once this breakpoint is the
+    // current one, the 760sp breakpoint's apply/unapply handlers above no
+    // longer fire (only the last-matching breakpoint is active), so this
+    // breakpoint re-sends SetNarrow itself.
+    let breakpoint = adw::Breakpoint::new(adw::BreakpointCondition::new_length(
+        adw::BreakpointConditionLengthType::MaxWidth,
+        400.0,
+        adw::LengthUnit::Sp,
+    ));
+    breakpoint.add_setter(overlay_split, "collapsed", Some(&true.into()));
+    breakpoint.add_setter(workspace_switcher, "visible", Some(&false.into()));
+    breakpoint.add_setter(workspace_switcher_bar, "reveal", Some(&true.into()));
+    let sort_sender = sort_pill.sender().clone();
+    breakpoint.connect_apply(move |_| {
+        sort_sender.send(SortPillInput::SetNarrow(true)).ok();
+    });
+    let sort_sender = sort_pill.sender().clone();
+    breakpoint.connect_unapply(move |_| {
+        sort_sender.send(SortPillInput::SetNarrow(false)).ok();
+    });
+    root.add_breakpoint(breakpoint);
 }
 
 pub(super) fn register_actions(

--- a/src/app/init.rs
+++ b/src/app/init.rs
@@ -61,7 +61,7 @@ pub(super) fn init_child_components(
     sender: &ComponentSender<App>,
 ) -> ChildComponents {
     let session_list = SessionList::builder()
-        .launch(db_path.to_path_buf())
+        .launch((db_path.to_path_buf(), sort_order))
         .forward(sender.input_sender(), |msg| match msg {
             SessionListOutput::SessionSelected(id) => AppMsg::SessionSelected(id),
             SessionListOutput::TogglePinRequested(id) => AppMsg::TogglePinRequested(id),
@@ -95,7 +95,6 @@ pub(super) fn init_child_components(
             SortPillOutput::RelevancePicked => AppMsg::RelevancePicked,
         },
     );
-    session_list.emit(SessionListMsg::SetSortOrder(Some(sort_order)));
     let sidebar =
         Sidebar::builder()
             .launch(())

--- a/src/app/init.rs
+++ b/src/app/init.rs
@@ -363,23 +363,8 @@ pub(super) fn setup_workspace_stack(
     });
 }
 
-pub(super) fn setup_breakpoints(
-    root: &adw::ApplicationWindow,
-    overlay_split: &adw::OverlaySplitView,
-    workspace_switcher: &adw::ViewSwitcher,
-    workspace_switcher_bar: &adw::ViewSwitcherBar,
-    sort_pill: &Controller<SortPill>,
-) {
-    // libadwaita picks the LAST breakpoint that matches the current size
-    // ("If multiple breakpoints can be used for the current size, the last
-    // one is always picked"). Both breakpoint widths are expressed in `sp`,
-    // which scales with the text-scaling factor, so at large scale factors
-    // the narrower (400sp) breakpoint's condition can become wider than the
-    // 760sp one and both can match simultaneously. Registering the WIDER
-    // breakpoint first and the narrower one second ensures the narrower
-    // breakpoint's setters win whenever both match.
-
-    // Add independent breakpoint to collapse the sort pill label to icon-only.
+pub(super) fn setup_breakpoints(root: &adw::ApplicationWindow, sort_pill: &Controller<SortPill>) {
+    // Collapse the sort pill label to icon-only at narrow widths.
     let sort_breakpoint = adw::Breakpoint::new(adw::BreakpointCondition::new_length(
         adw::BreakpointConditionLengthType::MaxWidth,
         760.0,
@@ -394,29 +379,6 @@ pub(super) fn setup_breakpoints(
         sort_sender.send(SortPillInput::SetNarrow(false)).ok();
     });
     root.add_breakpoint(sort_breakpoint);
-
-    // Add responsive collapse breakpoint. Below 400sp the sort pill label
-    // must also be hidden (400 < 760), but once this breakpoint is the
-    // current one, the 760sp breakpoint's apply/unapply handlers above no
-    // longer fire (only the last-matching breakpoint is active), so this
-    // breakpoint re-sends SetNarrow itself.
-    let breakpoint = adw::Breakpoint::new(adw::BreakpointCondition::new_length(
-        adw::BreakpointConditionLengthType::MaxWidth,
-        400.0,
-        adw::LengthUnit::Sp,
-    ));
-    breakpoint.add_setter(overlay_split, "collapsed", Some(&true.into()));
-    breakpoint.add_setter(workspace_switcher, "visible", Some(&false.into()));
-    breakpoint.add_setter(workspace_switcher_bar, "reveal", Some(&true.into()));
-    let sort_sender = sort_pill.sender().clone();
-    breakpoint.connect_apply(move |_| {
-        sort_sender.send(SortPillInput::SetNarrow(true)).ok();
-    });
-    let sort_sender = sort_pill.sender().clone();
-    breakpoint.connect_unapply(move |_| {
-        sort_sender.send(SortPillInput::SetNarrow(false)).ok();
-    });
-    root.add_breakpoint(breakpoint);
 }
 
 pub(super) fn register_actions(

--- a/src/app/init.rs
+++ b/src/app/init.rs
@@ -24,7 +24,7 @@ use crate::ui::{
     session_detail::{SessionDetail, SessionDetailOutput},
     session_list::{SessionList, SessionListMsg, SessionListOutput},
     sidebar::{Sidebar, SidebarOutput},
-    sort_pill::{SortPill, SortPillInput, SortPillOutput},
+    sort_pill::{SortPill, SortPillOutput},
 };
 
 use super::helpers::workspace_allows_search;
@@ -363,22 +363,22 @@ pub(super) fn setup_workspace_stack(
     });
 }
 
-pub(super) fn setup_breakpoints(root: &adw::ApplicationWindow, sort_pill: &Controller<SortPill>) {
-    // Collapse the sort pill label to icon-only at narrow widths.
-    let sort_breakpoint = adw::Breakpoint::new(adw::BreakpointCondition::new_length(
+pub(super) fn setup_breakpoints(
+    root: &adw::ApplicationWindow,
+    overlay_split: &adw::OverlaySplitView,
+    workspace_switcher: &adw::ViewSwitcher,
+    workspace_switcher_bar: &adw::ViewSwitcherBar,
+) {
+    // Add responsive collapse breakpoint
+    let breakpoint = adw::Breakpoint::new(adw::BreakpointCondition::new_length(
         adw::BreakpointConditionLengthType::MaxWidth,
-        760.0,
+        400.0,
         adw::LengthUnit::Sp,
     ));
-    let sort_sender = sort_pill.sender().clone();
-    sort_breakpoint.connect_apply(move |_| {
-        sort_sender.send(SortPillInput::SetNarrow(true)).ok();
-    });
-    let sort_sender = sort_pill.sender().clone();
-    sort_breakpoint.connect_unapply(move |_| {
-        sort_sender.send(SortPillInput::SetNarrow(false)).ok();
-    });
-    root.add_breakpoint(sort_breakpoint);
+    breakpoint.add_setter(overlay_split, "collapsed", Some(&true.into()));
+    breakpoint.add_setter(workspace_switcher, "visible", Some(&false.into()));
+    breakpoint.add_setter(workspace_switcher_bar, "reveal", Some(&true.into()));
+    root.add_breakpoint(breakpoint);
 }
 
 pub(super) fn register_actions(

--- a/src/app/init.rs
+++ b/src/app/init.rs
@@ -24,15 +24,16 @@ use crate::ui::{
     session_detail::{SessionDetail, SessionDetailOutput},
     session_list::{SessionList, SessionListMsg, SessionListOutput},
     sidebar::{Sidebar, SidebarOutput},
-    sort_pill::{SortPill, SortPillOutput},
+    sort_pill::{SortPill, SortPillInput, SortPillOutput},
 };
 
 use super::helpers::workspace_allows_search;
 use super::types::Workspace;
 use super::{
     AboutAction, App, AppMsg, EscapeAction, IndexingStatusAction, OpenDateFilterAction,
-    PreferencesAction, QuitAction, ShortcutsAction, ShowSearchAction, ToggleFiltersAction,
-    ToggleInspectorAction, TogglePinAction, ToggleSidePaneAction, WindowActionGroup,
+    OpenSortAction, PreferencesAction, QuitAction, ShortcutsAction, ShowSearchAction,
+    ToggleFiltersAction, ToggleInspectorAction, TogglePinAction, ToggleSidePaneAction,
+    WindowActionGroup,
 };
 
 /// Holds all child controllers and workers created during init.
@@ -368,6 +369,7 @@ pub(super) fn setup_breakpoints(
     overlay_split: &adw::OverlaySplitView,
     workspace_switcher: &adw::ViewSwitcher,
     workspace_switcher_bar: &adw::ViewSwitcherBar,
+    sort_pill: &Controller<SortPill>,
 ) {
     // Add responsive collapse breakpoint
     let breakpoint = adw::Breakpoint::new(adw::BreakpointCondition::new_length(
@@ -379,6 +381,22 @@ pub(super) fn setup_breakpoints(
     breakpoint.add_setter(workspace_switcher, "visible", Some(&false.into()));
     breakpoint.add_setter(workspace_switcher_bar, "reveal", Some(&true.into()));
     root.add_breakpoint(breakpoint);
+
+    // Add independent breakpoint to collapse the sort pill label to icon-only
+    let sort_breakpoint = adw::Breakpoint::new(adw::BreakpointCondition::new_length(
+        adw::BreakpointConditionLengthType::MaxWidth,
+        760.0,
+        adw::LengthUnit::Sp,
+    ));
+    let sort_sender = sort_pill.sender().clone();
+    sort_breakpoint.connect_apply(move |_| {
+        sort_sender.send(SortPillInput::SetNarrow(true)).ok();
+    });
+    let sort_sender = sort_pill.sender().clone();
+    sort_breakpoint.connect_unapply(move |_| {
+        sort_sender.send(SortPillInput::SetNarrow(false)).ok();
+    });
+    root.add_breakpoint(sort_breakpoint);
 }
 
 pub(super) fn register_actions(
@@ -474,6 +492,13 @@ pub(super) fn register_actions(
         })
     };
 
+    let open_sort_action = {
+        let sender = sender.clone();
+        RelmAction::<OpenSortAction>::new_stateless(move |_| {
+            sender.input(AppMsg::OpenSortShortcut);
+        })
+    };
+
     let quit_action = {
         let sender = sender.clone();
         RelmAction::<QuitAction>::new_stateless(move |_| {
@@ -498,6 +523,7 @@ pub(super) fn register_actions(
     app.set_accelerators_for_action::<ToggleSidePaneAction>(&["F9"]);
     app.set_accelerators_for_action::<TogglePinAction>(&["<Control>d"]);
     app.set_accelerators_for_action::<OpenDateFilterAction>(&["<Control><Shift>d"]);
+    app.set_accelerators_for_action::<OpenSortAction>(&["<Control><Shift>o"]);
     app.set_accelerators_for_action::<ShowSearchAction>(&["<Control>f"]);
     app.set_accelerators_for_action::<ShortcutsAction>(&["<Control>question"]);
     app.set_accelerators_for_action::<IndexingStatusAction>(&["<Control><Shift>i"]);
@@ -514,6 +540,7 @@ pub(super) fn register_actions(
     actions.add_action(toggle_side_pane_action);
     actions.add_action(toggle_pin_action);
     actions.add_action(open_date_filter_action);
+    actions.add_action(open_sort_action);
     actions.add_action(quit_action);
     actions.add_action(escape_action);
     actions.register_for_widget(main_window);

--- a/src/app/init.rs
+++ b/src/app/init.rs
@@ -12,6 +12,7 @@ use gtk::{gdk, glib};
 
 use crate::analytics_worker::{AnalyticsWorker, AnalyticsWorkerOutput};
 use crate::indexing_worker::{IndexingWorker, IndexingWorkerOutput};
+use crate::models::SortOrder;
 use crate::ui::modals::{
     about::AboutDialog,
     preferences::{PreferencesDialog, PreferencesOutput},
@@ -23,6 +24,7 @@ use crate::ui::{
     session_detail::{SessionDetail, SessionDetailOutput},
     session_list::{SessionList, SessionListMsg, SessionListOutput},
     sidebar::{Sidebar, SidebarOutput},
+    sort_pill::{SortPill, SortPillOutput},
 };
 
 use super::helpers::workspace_allows_search;
@@ -39,6 +41,7 @@ pub(super) struct ChildComponents {
     pub(super) analytics_view: Controller<AnalyticsView>,
     pub(super) session_detail: Controller<SessionDetail>,
     pub(super) date_pill: Controller<DatePill>,
+    pub(super) sort_pill: Controller<SortPill>,
     pub(super) sidebar: Controller<Sidebar>,
     pub(super) preferences_dialog: Controller<PreferencesDialog>,
     pub(super) indexing_worker: WorkerController<IndexingWorker>,
@@ -53,6 +56,7 @@ pub(super) struct NavigationSetup {
 
 pub(super) fn init_child_components(
     db_path: &Path,
+    sort_order: SortOrder,
     sender: &ComponentSender<App>,
 ) -> ChildComponents {
     let session_list = SessionList::builder()
@@ -83,6 +87,14 @@ pub(super) fn init_child_components(
             DatePillOutput::FilterChanged(filter) => AppMsg::DateFilterChanged(filter),
             DatePillOutput::CountsRequested => AppMsg::DateCountsRequested,
         });
+    let sort_pill = SortPill::builder().launch(sort_order).forward(
+        sender.input_sender(),
+        |output| match output {
+            SortPillOutput::OrderPicked(order) => AppMsg::SortOrderPicked(order),
+            SortPillOutput::RelevancePicked => AppMsg::RelevancePicked,
+        },
+    );
+    session_list.emit(SessionListMsg::SetSortOrder(Some(sort_order)));
     let sidebar =
         Sidebar::builder()
             .launch(())
@@ -134,6 +146,7 @@ pub(super) fn init_child_components(
         analytics_view,
         session_detail,
         date_pill,
+        sort_pill,
         sidebar,
         preferences_dialog,
         indexing_worker,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -580,13 +580,7 @@ impl SimpleComponent for App {
             &sender,
         );
 
-        init::setup_breakpoints(
-            &root,
-            &widgets.overlay_split,
-            &widgets.workspace_switcher,
-            &widgets.workspace_switcher_bar,
-            &model.sort_pill,
-        );
+        init::setup_breakpoints(&root, &model.sort_pill);
 
         init::register_actions(
             &root,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -580,7 +580,12 @@ impl SimpleComponent for App {
             &sender,
         );
 
-        init::setup_breakpoints(&root, &model.sort_pill);
+        init::setup_breakpoints(
+            &root,
+            &widgets.overlay_split,
+            &widgets.workspace_switcher,
+            &widgets.workspace_switcher_bar,
+        );
 
         init::register_actions(
             &root,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -24,7 +24,9 @@ use crate::database::{
 };
 use crate::icon_names;
 use crate::indexing_worker::{IndexingWorker, IndexingWorkerInput};
-use crate::models::{DateFilter, ProjectFilter, ProjectInfo, session::AiAssistant};
+use crate::models::{
+    DateFilter, ProjectFilter, ProjectInfo, SessionQuery, SortOrder, session::AiAssistant,
+};
 use crate::session_sources::{SessionSources, select_db_filename};
 use crate::ui::date_pill::{DatePill, DatePillInput};
 use crate::ui::modals::{
@@ -32,6 +34,7 @@ use crate::ui::modals::{
     preferences::PreferencesDialog,
 };
 use crate::ui::session_detail::SessionDetailMsg;
+use crate::ui::sort_pill::{SortPill, SortPillInput};
 use crate::ui::{
     analytics_view::AnalyticsView,
     session_detail::SessionDetail,
@@ -128,6 +131,9 @@ pub(super) struct App {
     analytics_view: Controller<AnalyticsView>,
     session_detail: Controller<SessionDetail>,
     date_pill: Controller<DatePill>,
+    sort_order: SortOrder,
+    search_sort_override: Option<SortOrder>,
+    sort_pill: Controller<SortPill>,
     #[allow(dead_code)] // Controller must stay alive to keep the widget
     sidebar: Controller<Sidebar>,
     preferences_dialog: Controller<PreferencesDialog>,
@@ -205,6 +211,9 @@ pub(super) enum AppMsg {
     AnalyticsLoadFailed(String),
     DateFilterChanged(DateFilter),
     DateCountsRequested,
+    OpenSortShortcut,
+    SortOrderPicked(SortOrder),
+    RelevancePicked,
 }
 
 relm4::new_action_group!(pub(super) WindowActionGroup, "win");
@@ -458,7 +467,9 @@ impl SimpleComponent for App {
         }
 
         // Build child components, navigation, and workspace stack
-        let components = init::init_child_components(&db_path, &sender);
+        let settings = gio::Settings::new(APP_ID);
+        let sort_order = SortOrder::from_setting_str(settings.string("sort-order").as_str());
+        let components = init::init_child_components(&db_path, sort_order, &sender);
         let nav_setup = init::build_navigation(
             components.session_list.widget(),
             components.session_detail.widget(),
@@ -484,6 +495,9 @@ impl SimpleComponent for App {
             analytics_view: components.analytics_view,
             session_detail: components.session_detail,
             date_pill: components.date_pill,
+            sort_order,
+            search_sort_override: None,
+            sort_pill: components.sort_pill,
             sidebar: components.sidebar,
             preferences_dialog: components.preferences_dialog,
             indexing_worker: components.indexing_worker,
@@ -527,6 +541,13 @@ impl SimpleComponent for App {
             .date_pill
             .widget()
             .set_visible(model.is_date_filter_visible());
+
+        widgets.header_bar.pack_start(model.sort_pill.widget());
+        model
+            .sort_pill
+            .widget()
+            .set_visible(model.is_date_filter_visible());
+        model.sync_sort_pill();
 
         // Get the actual ToastOverlay from the root window's content
         if let Some(toast_overlay) = root
@@ -679,6 +700,30 @@ impl SimpleComponent for App {
                     self.date_pill.emit(DatePillInput::OpenViaShortcut);
                 }
             }
+            AppMsg::OpenSortShortcut => {
+                if self.is_date_filter_visible() {
+                    self.sort_pill.emit(SortPillInput::OpenViaShortcut);
+                }
+            }
+            AppMsg::SortOrderPicked(order) => {
+                self.sort_order = order;
+                self.search_sort_override = if SessionQuery::classify(&self.search_query).is_fts() {
+                    Some(order)
+                } else {
+                    None
+                };
+                self.persist_sort_order();
+                self.sync_sort_pill();
+                self.session_list
+                    .emit(SessionListMsg::SetSortOrder(self.effective_sort()));
+            }
+            AppMsg::RelevancePicked => {
+                if SessionQuery::classify(&self.search_query).is_fts() {
+                    self.search_sort_override = None;
+                    self.sync_sort_pill();
+                    self.session_list.emit(SessionListMsg::SetSortOrder(None));
+                }
+            }
             AppMsg::DateFilterChanged(date_filter) => {
                 self.selected_date_filter = date_filter.clone();
                 self.refresh_sidebar_projects();
@@ -773,6 +818,30 @@ impl App {
         }
 
         self.toast_overlay.add_toast(toast);
+    }
+
+    fn effective_sort(&self) -> Option<SortOrder> {
+        helpers::effective_sort(
+            &self.search_query,
+            self.sort_order,
+            self.search_sort_override,
+        )
+    }
+
+    fn sync_sort_pill(&self) {
+        self.sort_pill.emit(SortPillInput::SyncState {
+            sort_order: self.sort_order,
+            fts_search_active: SessionQuery::classify(&self.search_query).is_fts(),
+            override_active: self.search_sort_override.is_some(),
+        });
+    }
+
+    fn persist_sort_order(&self) {
+        if let Err(err) =
+            gio::Settings::new(APP_ID).set_string("sort-order", self.sort_order.as_setting_str())
+        {
+            tracing::warn!("Failed to persist session sort order: {err}");
+        }
     }
 
     fn emit_session_list_filters(&self) {
@@ -1227,13 +1296,14 @@ mod tests {
     fn search_query_update_messages_include_detail_update() {
         let query = "needle".to_string();
 
-        let (list_msg, detail_msg) = search_query_update_messages(query);
+        let (list_msg, detail_msg) = search_query_update_messages(query, None);
 
         match list_msg {
-            SessionListMsg::SetSearchQuery(list_query) => {
-                assert_eq!(list_query, "needle");
+            SessionListMsg::SetSearchState { query, sort } => {
+                assert_eq!(query, "needle");
+                assert_eq!(sort, None);
             }
-            _ => panic!("expected SessionListMsg::SetSearchQuery"),
+            _ => panic!("expected SessionListMsg::SetSearchState"),
         }
 
         match detail_msg {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1298,6 +1298,80 @@ mod tests {
         assert_eq!(parts.model.last_errors_detail, expected_errors);
     }
 
+    #[gtk::test]
+    fn escape_with_active_override_restores_persisted_sort_and_clears_search() {
+        if !schema_is_available() {
+            return;
+        }
+
+        let controller = App::builder().launch(Some(PathBuf::from("tests/fixtures")));
+        pump_main_context(|| !controller.state().get().model.indexing);
+
+        controller.emit(AppMsg::SearchModeChanged(true));
+        pump_main_context(|| controller.state().get().model.search_visible);
+
+        controller.emit(AppMsg::SearchQueryChanged("hello".to_string()));
+        pump_main_context(|| controller.state().get().model.search_query == "hello");
+
+        controller.emit(AppMsg::SortOrderPicked(SortOrder::OldestFirst));
+        pump_main_context(|| {
+            controller.state().get().model.search_sort_override == Some(SortOrder::OldestFirst)
+        });
+
+        {
+            let parts = controller.state().get();
+            assert_eq!(parts.model.sort_order, SortOrder::OldestFirst);
+            assert_eq!(
+                parts.model.search_sort_override,
+                Some(SortOrder::OldestFirst)
+            );
+            assert_eq!(parts.model.search_query, "hello");
+        }
+
+        controller.emit(AppMsg::Escape);
+        pump_main_context(|| controller.state().get().model.search_query.is_empty());
+
+        let parts = controller.state().get();
+        assert!(!parts.model.search_visible);
+        assert!(parts.model.search_query.is_empty());
+        assert_eq!(parts.model.search_sort_override, None);
+        // The persisted sort order (set via the earlier SortOrderPicked while
+        // FTS was active) is preserved and becomes the effective order again
+        // now that the override-only search state has been cleared.
+        assert_eq!(parts.model.sort_order, SortOrder::OldestFirst);
+        assert_eq!(parts.model.effective_sort(), Some(SortOrder::OldestFirst));
+    }
+
+    #[gtk::test]
+    fn search_mode_toggle_with_active_override_restores_persisted_sort_and_clears_search() {
+        if !schema_is_available() {
+            return;
+        }
+
+        let controller = App::builder().launch(Some(PathBuf::from("tests/fixtures")));
+        pump_main_context(|| !controller.state().get().model.indexing);
+
+        controller.emit(AppMsg::SearchModeChanged(true));
+        pump_main_context(|| controller.state().get().model.search_visible);
+
+        controller.emit(AppMsg::SearchQueryChanged("hello".to_string()));
+        pump_main_context(|| controller.state().get().model.search_query == "hello");
+
+        controller.emit(AppMsg::SortOrderPicked(SortOrder::NewestFirst));
+        pump_main_context(|| {
+            controller.state().get().model.search_sort_override == Some(SortOrder::NewestFirst)
+        });
+
+        controller.emit(AppMsg::SearchModeChanged(false));
+        pump_main_context(|| !controller.state().get().model.search_visible);
+
+        let parts = controller.state().get();
+        assert!(parts.model.search_query.is_empty());
+        assert_eq!(parts.model.search_sort_override, None);
+        assert_eq!(parts.model.sort_order, SortOrder::NewestFirst);
+        assert_eq!(parts.model.effective_sort(), Some(SortOrder::NewestFirst));
+    }
+
     #[test]
     fn search_query_update_messages_include_detail_update() {
         let query = "needle".to_string();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -228,6 +228,7 @@ relm4::new_stateless_action!(ToggleInspectorAction, WindowActionGroup, "toggle-i
 relm4::new_stateless_action!(ToggleSidePaneAction, WindowActionGroup, "toggle-side-pane");
 relm4::new_stateless_action!(TogglePinAction, WindowActionGroup, "toggle-pin");
 relm4::new_stateless_action!(OpenDateFilterAction, WindowActionGroup, "open-date-filter");
+relm4::new_stateless_action!(OpenSortAction, WindowActionGroup, "open-sort");
 relm4::new_stateless_action!(ShowSearchAction, WindowActionGroup, "show-search");
 relm4::new_stateless_action!(EscapeAction, WindowActionGroup, "escape");
 
@@ -546,7 +547,7 @@ impl SimpleComponent for App {
         model
             .sort_pill
             .widget()
-            .set_visible(model.is_date_filter_visible());
+            .set_visible(model.is_sort_pill_visible());
         model.sync_sort_pill();
 
         // Get the actual ToastOverlay from the root window's content
@@ -584,6 +585,7 @@ impl SimpleComponent for App {
             &widgets.overlay_split,
             &widgets.workspace_switcher,
             &widgets.workspace_switcher_bar,
+            &model.sort_pill,
         );
 
         init::register_actions(
@@ -701,7 +703,7 @@ impl SimpleComponent for App {
                 }
             }
             AppMsg::OpenSortShortcut => {
-                if self.is_date_filter_visible() {
+                if self.is_sort_pill_visible() {
                     self.sort_pill.emit(SortPillInput::OpenViaShortcut);
                 }
             }
@@ -761,6 +763,10 @@ impl SimpleComponent for App {
         self.date_pill
             .widget()
             .set_visible(self.is_date_filter_visible());
+
+        self.sort_pill
+            .widget()
+            .set_visible(self.is_sort_pill_visible());
     }
 
     fn shutdown(&mut self, widgets: &mut Self::Widgets, _output: relm4::Sender<Self::Output>) {

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -83,6 +83,7 @@ mod tests {
 pub(super) struct WorkspaceHeaderVisibility {
     pub(super) search_ui_visible: bool,
     pub(super) date_filter_visible: bool,
+    pub(super) sort_pill_visible: bool,
     pub(super) pane_controls_visible: bool,
     pub(super) detail_actions_visible: bool,
     pub(super) summary_button_visible: bool,

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -11,8 +11,8 @@ use std::time::Duration;
 
 use crate::models::{
     AiAssistant, DateCounts, DateFilter, MessagePreview, ProjectFilter, ProjectInfo,
-    ReasoningAttachment, ReasoningPreview, Role, Session, Subagent, ToolCall, ToolCallStatus,
-    TranscriptItem, TranscriptItemKind,
+    ReasoningAttachment, ReasoningPreview, Role, Session, SortOrder, Subagent, ToolCall,
+    ToolCallStatus, TranscriptItem, TranscriptItemKind,
 };
 
 pub use indexer::{IndexingStats, SessionIndexer};
@@ -195,6 +195,28 @@ fn project_filter_id(project_filter: &ProjectFilter) -> Option<i64> {
     }
 }
 
+/// SQL `ORDER BY` clause for an ordinary (non-FTS) session query, using
+/// unqualified column names.
+fn sort_sql_clause(sort: SortOrder) -> &'static str {
+    match sort {
+        SortOrder::RecentActivity => "ORDER BY last_updated DESC, id DESC",
+        SortOrder::OldestFirst => "ORDER BY start_time ASC, id ASC",
+        SortOrder::NewestFirst => "ORDER BY start_time DESC, id DESC",
+        SortOrder::MostMessages => "ORDER BY message_count DESC, id DESC",
+    }
+}
+
+/// SQL `ORDER BY` clause for an FTS-joined session query, where columns must
+/// be qualified with `s.` because `id` is otherwise ambiguous.
+fn search_sort_sql_clause(sort: SortOrder) -> &'static str {
+    match sort {
+        SortOrder::RecentActivity => "ORDER BY s.last_updated DESC, s.id DESC",
+        SortOrder::OldestFirst => "ORDER BY s.start_time ASC, s.id ASC",
+        SortOrder::NewestFirst => "ORDER BY s.start_time DESC, s.id DESC",
+        SortOrder::MostMessages => "ORDER BY s.message_count DESC, s.id DESC",
+    }
+}
+
 /// Append the shared filter parameters — AI assistant tool values, an optional
 /// project id, then date bounds — onto `params` in placeholder order. Callers
 /// push any leading placeholders (such as a session id or FTS query) first.
@@ -221,6 +243,7 @@ pub fn search_sessions_for_filter(
     project_filter: &ProjectFilter,
     query: &str,
     date_filter: &DateFilter,
+    sort: Option<SortOrder>,
 ) -> Result<Vec<Session>> {
     if !db_path.exists() {
         return Ok(Vec::new());
@@ -232,12 +255,18 @@ pub fn search_sessions_for_filter(
 
     let query = query.trim();
     if query.is_empty() {
-        return load_sessions_for_filter(db_path, tools, project_filter, date_filter);
+        return load_sessions_for_filter(
+            db_path,
+            tools,
+            project_filter,
+            date_filter,
+            sort.unwrap_or_default(),
+        );
     }
 
     let db = open_connection(db_path)?;
 
-    match search_sessions_with_query(&db, tools, project_filter, query, date_filter) {
+    match search_sessions_with_query(&db, tools, project_filter, query, date_filter, sort) {
         Ok(sessions) => Ok(sessions),
         Err(err) => {
             let sanitized = sanitize_search_query(query);
@@ -253,6 +282,7 @@ pub fn search_sessions_for_filter(
                     project_filter,
                     &sanitized,
                     date_filter,
+                    sort,
                 ) {
                     Ok(sessions) => Ok(sessions),
                     Err(retry_err) => {
@@ -426,10 +456,14 @@ fn search_sessions_with_query(
     project_filter: &ProjectFilter,
     query: &str,
     date_filter: &DateFilter,
+    sort: Option<SortOrder>,
 ) -> Result<Vec<Session>> {
     let (tool_clause, tool_strings) = tool_filter_sql_clause(tools, "s.");
     let project_clause = project_filter_sql_clause(project_filter, "s.");
     let (date_clause, date_values) = date_filter_sql_clause(date_filter, "s.");
+    let sort_clause = sort
+        .map(search_sort_sql_clause)
+        .unwrap_or("ORDER BY rank ASC, s.last_updated DESC, s.id DESC");
 
     let query_sql = format!(
         "SELECT s.id, s.tool, s.project_path, s.project_id, s.start_time, s.message_count, s.file_path,
@@ -443,7 +477,7 @@ fn search_sessions_with_query(
                  JOIN sessions s ON s.id = m.session_id
                  WHERE messages_fts MATCH ?
                    AND s.is_subagent = 0{tool_clause}{project_clause}{date_clause}
-                  ORDER BY rank ASC, s.last_updated DESC"
+                  {sort_clause}"
     );
 
     let mut stmt = db.prepare(&query_sql)?;
@@ -473,6 +507,7 @@ pub fn load_sessions_for_filter(
     tools: &[AiAssistant],
     project_filter: &ProjectFilter,
     date_filter: &DateFilter,
+    sort: SortOrder,
 ) -> Result<Vec<Session>> {
     if !db_path.exists() {
         return Ok(Vec::new());
@@ -486,12 +521,13 @@ pub fn load_sessions_for_filter(
     let (tool_clause, tool_strings) = tool_filter_sql_clause(tools, "");
     let project_clause = project_filter_sql_clause(project_filter, "");
     let (date_clause, date_values) = date_filter_sql_clause(date_filter, "");
+    let sort_clause = sort_sql_clause(sort);
 
     let query = format!(
         "SELECT {SESSION_SELECT_COLUMNS}
                  FROM sessions
                  WHERE is_subagent = 0{tool_clause}{project_clause}{date_clause}
-                  ORDER BY last_updated DESC"
+                 {sort_clause}"
     );
 
     let mut stmt = db.prepare(&query)?;
@@ -1368,4 +1404,49 @@ pub fn load_reasoning_attachment(
     )
     .optional()
     .context("Failed to query reasoning attachment")
+}
+
+#[cfg(test)]
+mod sorting_tests {
+    use super::*;
+
+    #[test]
+    fn named_orders_map_to_stable_sql() {
+        assert_eq!(
+            sort_sql_clause(SortOrder::RecentActivity),
+            "ORDER BY last_updated DESC, id DESC"
+        );
+        assert_eq!(
+            sort_sql_clause(SortOrder::OldestFirst),
+            "ORDER BY start_time ASC, id ASC"
+        );
+        assert_eq!(
+            sort_sql_clause(SortOrder::NewestFirst),
+            "ORDER BY start_time DESC, id DESC"
+        );
+        assert_eq!(
+            sort_sql_clause(SortOrder::MostMessages),
+            "ORDER BY message_count DESC, id DESC"
+        );
+    }
+
+    #[test]
+    fn search_orders_use_qualified_session_columns() {
+        assert_eq!(
+            search_sort_sql_clause(SortOrder::RecentActivity),
+            "ORDER BY s.last_updated DESC, s.id DESC"
+        );
+        assert_eq!(
+            search_sort_sql_clause(SortOrder::OldestFirst),
+            "ORDER BY s.start_time ASC, s.id ASC"
+        );
+        assert_eq!(
+            search_sort_sql_clause(SortOrder::NewestFirst),
+            "ORDER BY s.start_time DESC, s.id DESC"
+        );
+        assert_eq!(
+            search_sort_sql_clause(SortOrder::MostMessages),
+            "ORDER BY s.message_count DESC, s.id DESC"
+        );
+    }
 }

--- a/src/database/schema.rs
+++ b/src/database/schema.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use rusqlite::Connection;
 
 #[cfg(test)]
-const CURRENT_DB_VERSION: i64 = 14;
+const CURRENT_DB_VERSION: i64 = 15;
 
 fn column_exists(conn: &Connection, table_name: &str, column_name: &str) -> Result<bool> {
     Ok(conn.query_row(
@@ -48,6 +48,9 @@ fn table_exists(conn: &Connection, name: &str) -> Result<bool> {
 ///        support: parents must be re-parsed to emit subagent rows linking the
 ///        child sessions now indexed from `<session>/agents/`; add an index on
 ///        sessions.file_path for efficient Vibe subtree pruning
+///   15 – replace the top-level activity index with three deterministic sort
+///        indexes (last_updated, start_time, message_count) to enable
+///        deterministic session-list reading without temporary sort tables
 pub fn initialize_database(conn: &Connection) -> Result<()> {
     let version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
 
@@ -92,6 +95,9 @@ pub fn initialize_database(conn: &Connection) -> Result<()> {
     }
     if version < 14 {
         apply_v14_migration(conn)?;
+    }
+    if version < 15 {
+        apply_v15_migration(conn)?;
     }
 
     Ok(())
@@ -605,6 +611,24 @@ fn apply_v14_migration(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
+/// Migrate from v14 to v15.
+///
+/// Replace the top-level activity index and add indexes for deterministic
+/// session-list reading orders. Filter-specific activity indexes remain intact.
+fn apply_v15_migration(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "DROP INDEX IF EXISTS idx_sessions_top_level_last_updated;
+         CREATE INDEX IF NOT EXISTS idx_sessions_top_level_last_updated_id
+             ON sessions(is_subagent, last_updated DESC, id DESC);
+         CREATE INDEX IF NOT EXISTS idx_sessions_top_level_start_time_id
+             ON sessions(is_subagent, start_time DESC, id DESC);
+         CREATE INDEX IF NOT EXISTS idx_sessions_top_level_message_count_id
+             ON sessions(is_subagent, message_count DESC, id DESC);
+         PRAGMA user_version = 15;",
+    )?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -724,26 +748,27 @@ mod tests {
         let conn = Connection::open_in_memory().unwrap();
         initialize_database(&conn).unwrap();
 
-        assert!(index_exists(&conn, "idx_sessions_top_level_last_updated"));
+        assert!(!index_exists(&conn, "idx_sessions_top_level_last_updated"));
+        for (name, columns) in [
+            (
+                "idx_sessions_top_level_last_updated_id",
+                vec!["is_subagent", "last_updated", "id"],
+            ),
+            (
+                "idx_sessions_top_level_start_time_id",
+                vec!["is_subagent", "start_time", "id"],
+            ),
+            (
+                "idx_sessions_top_level_message_count_id",
+                vec!["is_subagent", "message_count", "id"],
+            ),
+        ] {
+            assert!(index_exists(&conn, name));
+            assert_eq!(index_columns(&conn, name), columns);
+        }
         assert!(index_exists(&conn, "idx_sessions_project_last_updated"));
         assert!(index_exists(&conn, "idx_sessions_tool_last_updated"));
         assert!(index_exists(&conn, "idx_sessions_pinned_last_updated"));
-        assert_eq!(
-            index_columns(&conn, "idx_sessions_top_level_last_updated"),
-            vec!["is_subagent", "last_updated"]
-        );
-        assert_eq!(
-            index_columns(&conn, "idx_sessions_project_last_updated"),
-            vec!["is_subagent", "project_id", "last_updated"]
-        );
-        assert_eq!(
-            index_columns(&conn, "idx_sessions_tool_last_updated"),
-            vec!["is_subagent", "tool", "last_updated"]
-        );
-        assert_eq!(
-            index_columns(&conn, "idx_sessions_pinned_last_updated"),
-            vec!["is_subagent", "pinned_at", "last_updated"]
-        );
     }
 
     #[test]
@@ -751,7 +776,9 @@ mod tests {
         let conn = Connection::open_in_memory().unwrap();
         initialize_database(&conn).unwrap();
         conn.execute_batch(
-            "DROP INDEX idx_sessions_top_level_last_updated;
+            "DROP INDEX idx_sessions_top_level_last_updated_id;
+             DROP INDEX idx_sessions_top_level_start_time_id;
+             DROP INDEX idx_sessions_top_level_message_count_id;
              DROP INDEX idx_sessions_project_last_updated;
              DROP INDEX idx_sessions_tool_last_updated;
              DROP INDEX idx_sessions_pinned_last_updated;
@@ -1631,5 +1658,67 @@ mod tests {
             })
             .unwrap();
         assert_eq!(fingerprint_count, 0);
+    }
+
+    #[test]
+    fn v14_to_v15_replaces_top_level_sort_indexes() {
+        let conn = Connection::open_in_memory().unwrap();
+        initialize_database(&conn).unwrap();
+        conn.execute_batch(
+            "DROP INDEX idx_sessions_top_level_last_updated_id;
+             DROP INDEX idx_sessions_top_level_start_time_id;
+             DROP INDEX idx_sessions_top_level_message_count_id;
+             CREATE INDEX idx_sessions_top_level_last_updated
+                 ON sessions(is_subagent, last_updated DESC);
+             PRAGMA user_version = 14;",
+        )
+        .unwrap();
+
+        initialize_database(&conn).unwrap();
+
+        let version: i64 = conn
+            .query_row("PRAGMA user_version", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(version, 15);
+        assert!(!index_exists(&conn, "idx_sessions_top_level_last_updated"));
+        assert!(index_exists(
+            &conn,
+            "idx_sessions_top_level_last_updated_id"
+        ));
+        assert!(index_exists(&conn, "idx_sessions_top_level_start_time_id"));
+        assert!(index_exists(
+            &conn,
+            "idx_sessions_top_level_message_count_id"
+        ));
+    }
+
+    #[test]
+    fn unfiltered_named_orders_do_not_build_temporary_sort_tables() {
+        let conn = Connection::open_in_memory().unwrap();
+        initialize_database(&conn).unwrap();
+
+        for order_by in [
+            "last_updated DESC, id DESC",
+            "start_time ASC, id ASC",
+            "start_time DESC, id DESC",
+            "message_count DESC, id DESC",
+        ] {
+            let sql = format!(
+                "EXPLAIN QUERY PLAN SELECT id FROM sessions
+                 WHERE is_subagent = 0 ORDER BY {order_by}"
+            );
+            let mut stmt = conn.prepare(&sql).unwrap();
+            let details = stmt
+                .query_map([], |row| row.get::<_, String>(3))
+                .unwrap()
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap();
+            assert!(
+                details
+                    .iter()
+                    .all(|detail| !detail.contains("USE TEMP B-TREE FOR ORDER BY")),
+                "{order_by} used a temporary sort: {details:?}"
+            );
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,6 @@ pub mod utils;
 // Re-export commonly used types
 pub use models::{
     AiAssistant, AnalyticsData, AnalyticsOverview, DateCounts, DateFilter, Message, ProjectFilter,
-    ProjectInfo, Role, Session,
+    ProjectInfo, Role, Session, SortOrder,
 };
 pub use session_sources::SessionSources;

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -6,6 +6,8 @@ pub mod message_preview;
 pub mod project_filter;
 pub mod reasoning;
 pub mod session;
+pub mod session_query;
+pub mod sort_order;
 pub mod subagent;
 pub mod token_usage;
 pub mod tool_call;
@@ -19,6 +21,8 @@ pub use message_preview::MessagePreview;
 pub use project_filter::{ProjectFilter, ProjectInfo};
 pub use reasoning::{ReasoningAttachment, ReasoningPreview};
 pub use session::{AiAssistant, Session, SessionEndingStatus};
+pub use session_query::SessionQuery;
+pub use sort_order::SortOrder;
 pub use subagent::Subagent;
 pub use token_usage::TokenUsage;
 pub use tool_call::{

--- a/src/models/session_query.rs
+++ b/src/models/session_query.rs
@@ -1,0 +1,57 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionQuery<'a> {
+    None,
+    DirectId(&'a str),
+    Fts(&'a str),
+}
+
+impl<'a> SessionQuery<'a> {
+    pub fn classify(query: &'a str) -> Self {
+        let query = query.trim();
+        if query.is_empty() {
+            Self::None
+        } else if let Some(id) = query.strip_prefix("id:") {
+            Self::DirectId(id.trim())
+        } else {
+            Self::Fts(query)
+        }
+    }
+
+    pub fn is_fts(self) -> bool {
+        matches!(self, Self::Fts(_))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_empty_direct_id_and_fts_queries() {
+        assert_eq!(SessionQuery::classify(" \n "), SessionQuery::None);
+        assert_eq!(
+            SessionQuery::classify("id:abc"),
+            SessionQuery::DirectId("abc")
+        );
+        assert_eq!(
+            SessionQuery::classify(" id: abc "),
+            SessionQuery::DirectId("abc")
+        );
+        assert_eq!(SessionQuery::classify("id:   "), SessionQuery::DirectId(""));
+        assert_eq!(
+            SessionQuery::classify("ID:abc"),
+            SessionQuery::Fts("ID:abc")
+        );
+        assert_eq!(
+            SessionQuery::classify(" needle "),
+            SessionQuery::Fts("needle")
+        );
+    }
+
+    #[test]
+    fn only_full_text_queries_report_fts_context() {
+        assert!(!SessionQuery::classify("").is_fts());
+        assert!(!SessionQuery::classify("id:abc").is_fts());
+        assert!(SessionQuery::classify("abc").is_fts());
+    }
+}

--- a/src/models/sort_order.rs
+++ b/src/models/sort_order.rs
@@ -1,5 +1,6 @@
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum SortOrder {
+    #[default]
     RecentActivity,
     OldestFirst,
     NewestFirst,
@@ -33,12 +34,6 @@ impl SortOrder {
             "most-messages" => Self::MostMessages,
             _ => Self::default(),
         }
-    }
-}
-
-impl Default for SortOrder {
-    fn default() -> Self {
-        Self::RecentActivity
     }
 }
 

--- a/src/models/sort_order.rs
+++ b/src/models/sort_order.rs
@@ -1,0 +1,82 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SortOrder {
+    RecentActivity,
+    OldestFirst,
+    NewestFirst,
+    MostMessages,
+}
+
+impl SortOrder {
+    pub fn label_msgid(self) -> &'static str {
+        match self {
+            Self::RecentActivity => "Recent activity",
+            Self::OldestFirst => "Oldest first",
+            Self::NewestFirst => "Newest first",
+            Self::MostMessages => "Most messages",
+        }
+    }
+
+    pub fn as_setting_str(self) -> &'static str {
+        match self {
+            Self::RecentActivity => "recent-activity",
+            Self::OldestFirst => "oldest-first",
+            Self::NewestFirst => "newest-first",
+            Self::MostMessages => "most-messages",
+        }
+    }
+
+    pub fn from_setting_str(value: &str) -> Self {
+        match value {
+            "recent-activity" => Self::RecentActivity,
+            "oldest-first" => Self::OldestFirst,
+            "newest-first" => Self::NewestFirst,
+            "most-messages" => Self::MostMessages,
+            _ => Self::default(),
+        }
+    }
+}
+
+impl Default for SortOrder {
+    fn default() -> Self {
+        Self::RecentActivity
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn setting_values_round_trip() {
+        for (order, value) in [
+            (SortOrder::RecentActivity, "recent-activity"),
+            (SortOrder::OldestFirst, "oldest-first"),
+            (SortOrder::NewestFirst, "newest-first"),
+            (SortOrder::MostMessages, "most-messages"),
+        ] {
+            assert_eq!(order.as_setting_str(), value);
+            assert_eq!(SortOrder::from_setting_str(value), order);
+        }
+    }
+
+    #[test]
+    fn unknown_setting_falls_back_to_recent_activity() {
+        assert_eq!(
+            SortOrder::from_setting_str("relevance"),
+            SortOrder::default()
+        );
+        assert_eq!(
+            SortOrder::from_setting_str("hand-edited"),
+            SortOrder::default()
+        );
+        assert_eq!(SortOrder::default(), SortOrder::RecentActivity);
+    }
+
+    #[test]
+    fn labels_are_stable_untranslated_message_ids() {
+        assert_eq!(SortOrder::RecentActivity.label_msgid(), "Recent activity");
+        assert_eq!(SortOrder::OldestFirst.label_msgid(), "Oldest first");
+        assert_eq!(SortOrder::NewestFirst.label_msgid(), "Newest first");
+        assert_eq!(SortOrder::MostMessages.label_msgid(), "Most messages");
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -11,5 +11,6 @@ pub mod session_detail;
 pub mod session_list;
 pub mod session_row;
 pub mod sidebar;
+pub mod sort_pill;
 pub mod tool_inspector_pane;
 pub mod tool_renderers;

--- a/src/ui/modals/shortcuts.rs
+++ b/src/ui/modals/shortcuts.rs
@@ -50,6 +50,10 @@ impl SimpleComponent for ShortcutsDialog {
             &gettext("Filter by date"),
             "<Control><Shift>d",
         ));
+        search.add(adw::ShortcutsItem::new(
+            &gettext("Sort sessions"),
+            "<Control><Shift>o",
+        ));
         widgets.add(search);
 
         // View section

--- a/src/ui/session_list.rs
+++ b/src/ui/session_list.rs
@@ -487,7 +487,7 @@ fn build_source_results_list(results: &[PerSourceResult]) -> gtk::ListBox {
 
 #[relm4::component(pub)]
 impl SimpleComponent for SessionList {
-    type Init = PathBuf;
+    type Init = (PathBuf, SortOrder);
     type Input = SessionListMsg;
     type Output = SessionListOutput;
     type Widgets = SessionListWidgets;
@@ -527,7 +527,7 @@ impl SimpleComponent for SessionList {
     }
 
     fn init(
-        db_path: Self::Init,
+        (db_path, sort_order): Self::Init,
         root: Self::Root,
         sender: ComponentSender<Self>,
     ) -> ComponentParts<Self> {
@@ -540,7 +540,7 @@ impl SimpleComponent for SessionList {
         let search_query = String::new();
         let project_filter = ProjectFilter::AllSessions;
         let date_filter = DateFilter::AnyTime;
-        let sort = Some(SortOrder::default());
+        let sort = Some(sort_order);
         let fetched = Self::fetch_sessions(
             &db_path,
             &active_tools,
@@ -1561,7 +1561,8 @@ mod tests {
     #[gtk::test]
     fn session_list_activates_on_single_click() {
         let temp_db = tempfile::NamedTempFile::new().expect("temp db");
-        let controller = SessionList::builder().launch(temp_db.path().to_path_buf());
+        let controller =
+            SessionList::builder().launch((temp_db.path().to_path_buf(), SortOrder::default()));
         let root = controller.widget().clone().upcast::<gtk::Widget>();
         let list_box = find_list_box(&root).expect("list box");
 
@@ -1575,7 +1576,7 @@ mod tests {
         let outputs_ref = outputs.clone();
 
         let controller = SessionList::builder()
-            .launch(temp_db.path().to_path_buf())
+            .launch((temp_db.path().to_path_buf(), SortOrder::default()))
             .connect_receiver(move |_, output| {
                 outputs_ref.borrow_mut().push(output);
             });
@@ -1626,7 +1627,8 @@ mod tests {
     #[gtk::test]
     fn session_list_uses_single_selection_mode() {
         let temp_db = tempfile::NamedTempFile::new().expect("temp db");
-        let controller = SessionList::builder().launch(temp_db.path().to_path_buf());
+        let controller =
+            SessionList::builder().launch((temp_db.path().to_path_buf(), SortOrder::default()));
         let root = controller.widget().clone().upcast::<gtk::Widget>();
         let list_box = find_list_box(&root).expect("list box");
 
@@ -1636,7 +1638,8 @@ mod tests {
     #[gtk::test]
     fn session_list_selects_first_row_on_init() {
         let temp_db = tempfile::NamedTempFile::new().expect("temp db");
-        let controller = SessionList::builder().launch(temp_db.path().to_path_buf());
+        let controller =
+            SessionList::builder().launch((temp_db.path().to_path_buf(), SortOrder::default()));
 
         // Add a row
         {
@@ -1683,7 +1686,8 @@ mod tests {
         let temp_db = TempDatabase::new();
         temp_db.seed_project_sidebar_fixture();
 
-        let controller = SessionList::builder().launch(temp_db.path.clone());
+        let controller =
+            SessionList::builder().launch((temp_db.path.clone(), SortOrder::default()));
 
         controller.emit(SessionListMsg::SetFilters {
             tools: vec![AiAssistant::ClaudeCode],
@@ -1965,7 +1969,8 @@ mod tests {
     #[gtk::test]
     fn cancel_post_indexing_batch_invalidates_pending_batch_and_measurement() {
         let temp_db = tempfile::NamedTempFile::new().expect("temp db");
-        let controller = SessionList::builder().launch(temp_db.path().to_path_buf());
+        let controller =
+            SessionList::builder().launch((temp_db.path().to_path_buf(), SortOrder::default()));
         let context = IndexingReloadContext {
             indexed: 1,
             skipped: 0,
@@ -2005,7 +2010,8 @@ mod tests {
     #[gtk::test]
     fn start_post_indexing_measurement_cancels_previous_pending_batch() {
         let temp_db = tempfile::NamedTempFile::new().expect("temp db");
-        let controller = SessionList::builder().launch(temp_db.path().to_path_buf());
+        let controller =
+            SessionList::builder().launch((temp_db.path().to_path_buf(), SortOrder::default()));
         let first_context = IndexingReloadContext {
             indexed: 1,
             skipped: 0,
@@ -2060,7 +2066,8 @@ mod tests {
         let temp_db = TempDatabase::new();
         temp_db.seed_project_sidebar_fixture();
 
-        let controller = SessionList::builder().launch(temp_db.path.clone());
+        let controller =
+            SessionList::builder().launch((temp_db.path.clone(), SortOrder::default()));
 
         pump_main_context(|| {
             let parts = controller.state().get();
@@ -2109,7 +2116,8 @@ mod tests {
         let temp_db = TempDatabase::new();
         temp_db.seed_project_sidebar_fixture();
 
-        let controller = SessionList::builder().launch(temp_db.path.clone());
+        let controller =
+            SessionList::builder().launch((temp_db.path.clone(), SortOrder::default()));
 
         pump_main_context(|| {
             let parts = controller.state().get();
@@ -2150,7 +2158,8 @@ mod tests {
         temp_db.seed_project_sidebar_fixture();
         temp_db.seed_many_claude_sessions(70);
 
-        let controller = SessionList::builder().launch(temp_db.path.clone());
+        let controller =
+            SessionList::builder().launch((temp_db.path.clone(), SortOrder::default()));
 
         pump_main_context(|| {
             let parts = controller.state().get();
@@ -2209,7 +2218,8 @@ mod tests {
         temp_db.seed_project_sidebar_fixture();
         temp_db.seed_many_claude_sessions(130);
 
-        let controller = SessionList::builder().launch(temp_db.path.clone());
+        let controller =
+            SessionList::builder().launch((temp_db.path.clone(), SortOrder::default()));
 
         pump_main_context(|| {
             let parts = controller.state().get();
@@ -2296,7 +2306,8 @@ mod tests {
         temp_db.seed_project_sidebar_fixture();
         temp_db.seed_many_claude_sessions(130);
 
-        let controller = SessionList::builder().launch(temp_db.path.clone());
+        let controller =
+            SessionList::builder().launch((temp_db.path.clone(), SortOrder::default()));
 
         pump_main_context(|| {
             let parts = controller.state().get();
@@ -2356,7 +2367,8 @@ mod tests {
         temp_db.seed_project_sidebar_fixture();
         temp_db.seed_many_claude_sessions(130);
 
-        let controller = SessionList::builder().launch(temp_db.path.clone());
+        let controller =
+            SessionList::builder().launch((temp_db.path.clone(), SortOrder::default()));
 
         pump_main_context(|| {
             let parts = controller.state().get();
@@ -2409,7 +2421,8 @@ mod tests {
         temp_db.seed_project_sidebar_fixture();
         temp_db.seed_many_claude_sessions(130);
 
-        let controller = SessionList::builder().launch(temp_db.path.clone());
+        let controller =
+            SessionList::builder().launch((temp_db.path.clone(), SortOrder::default()));
 
         pump_main_context(|| {
             let parts = controller.state().get();
@@ -2470,7 +2483,8 @@ mod tests {
         let temp_db = TempDatabase::new();
         temp_db.seed_project_sidebar_fixture();
 
-        let controller = SessionList::builder().launch(temp_db.path.clone());
+        let controller =
+            SessionList::builder().launch((temp_db.path.clone(), SortOrder::default()));
 
         pump_main_context(|| {
             let parts = controller.state().get();
@@ -2550,7 +2564,8 @@ mod tests {
             )
             .expect("Failed to pin fixture sessions");
 
-        let controller = SessionList::builder().launch(temp_db.path.clone());
+        let controller =
+            SessionList::builder().launch((temp_db.path.clone(), SortOrder::default()));
 
         controller.emit(SessionListMsg::SetFilters {
             tools: vec![AiAssistant::ClaudeCode],
@@ -2578,7 +2593,8 @@ mod tests {
         let temp_db = TempDatabase::new();
         temp_db.seed_project_sidebar_fixture();
 
-        let controller = SessionList::builder().launch(temp_db.path.clone());
+        let controller =
+            SessionList::builder().launch((temp_db.path.clone(), SortOrder::default()));
 
         controller.emit(SessionListMsg::SetSearchState {
             query: " id: alpha-claude-old ".to_string(),
@@ -2606,7 +2622,8 @@ mod tests {
         let temp_db = TempDatabase::new();
         temp_db.seed_project_sidebar_fixture();
 
-        let controller = SessionList::builder().launch(temp_db.path.clone());
+        let controller =
+            SessionList::builder().launch((temp_db.path.clone(), SortOrder::default()));
 
         controller.emit(SessionListMsg::SetFilters {
             tools: vec![AiAssistant::OpenCode],
@@ -2635,7 +2652,8 @@ mod tests {
         let temp_db = TempDatabase::new();
         temp_db.seed_project_sidebar_fixture();
 
-        let controller = SessionList::builder().launch(temp_db.path.clone());
+        let controller =
+            SessionList::builder().launch((temp_db.path.clone(), SortOrder::default()));
 
         controller.emit(SessionListMsg::SetFilters {
             tools: vec![AiAssistant::ClaudeCode],
@@ -2691,7 +2709,7 @@ mod tests {
         let outputs_ref = outputs.clone();
 
         let controller = SessionList::builder()
-            .launch(temp_db.path().to_path_buf())
+            .launch((temp_db.path().to_path_buf(), SortOrder::default()))
             .connect_receiver(move |_, output| {
                 outputs_ref.borrow_mut().push(output);
             });
@@ -2753,7 +2771,8 @@ mod tests {
         let temp_db = TempDatabase::new();
         temp_db.seed_project_sidebar_fixture();
 
-        let controller = SessionList::builder().launch(temp_db.path.clone());
+        let controller =
+            SessionList::builder().launch((temp_db.path.clone(), SortOrder::default()));
 
         controller.emit(SessionListMsg::DateFilterChanged(DateFilter::Custom {
             from: chrono::NaiveDate::from_ymd_opt(2000, 1, 1).unwrap(),
@@ -2794,7 +2813,8 @@ mod tests {
     #[gtk::test]
     fn move_selection_down_advances_index() {
         let temp_db = tempfile::NamedTempFile::new().expect("temp db");
-        let controller = SessionList::builder().launch(temp_db.path().to_path_buf());
+        let controller =
+            SessionList::builder().launch((temp_db.path().to_path_buf(), SortOrder::default()));
 
         {
             let mut parts = controller.state().get_mut();
@@ -2823,7 +2843,8 @@ mod tests {
     #[gtk::test]
     fn move_selection_clamps_at_boundaries() {
         let temp_db = tempfile::NamedTempFile::new().expect("temp db");
-        let controller = SessionList::builder().launch(temp_db.path().to_path_buf());
+        let controller =
+            SessionList::builder().launch((temp_db.path().to_path_buf(), SortOrder::default()));
 
         {
             let mut parts = controller.state().get_mut();
@@ -2848,7 +2869,8 @@ mod tests {
     #[gtk::test]
     fn move_selection_on_empty_list_is_noop() {
         let temp_db = tempfile::NamedTempFile::new().expect("temp db");
-        let controller = SessionList::builder().launch(temp_db.path().to_path_buf());
+        let controller =
+            SessionList::builder().launch((temp_db.path().to_path_buf(), SortOrder::default()));
 
         let root = controller.widget().clone().upcast::<gtk::Widget>();
         let list_box = find_list_box(&root).expect("list box");
@@ -2927,7 +2949,8 @@ mod tests {
         use crate::models::{AiAssistant, PerSourceResult, SourceStatus};
 
         let temp_db = tempfile::NamedTempFile::new().expect("temp db");
-        let controller = SessionList::builder().launch(temp_db.path().to_path_buf());
+        let controller =
+            SessionList::builder().launch((temp_db.path().to_path_buf(), SortOrder::default()));
 
         controller.emit(SessionListMsg::SetSourceResults(vec![PerSourceResult {
             assistant: AiAssistant::ClaudeCode,
@@ -2955,7 +2978,7 @@ mod tests {
         let outputs_ref = outputs.clone();
 
         let controller = SessionList::builder()
-            .launch(temp_db.path().to_path_buf())
+            .launch((temp_db.path().to_path_buf(), SortOrder::default()))
             .connect_receiver(move |_, output| {
                 outputs_ref.borrow_mut().push(output);
             });
@@ -2991,7 +3014,7 @@ mod tests {
         let outputs_ref = outputs.clone();
 
         let controller = SessionList::builder()
-            .launch(temp_db.path().to_path_buf())
+            .launch((temp_db.path().to_path_buf(), SortOrder::default()))
             .connect_receiver(move |_, output| {
                 outputs_ref.borrow_mut().push(output);
             });

--- a/src/ui/session_list.rs
+++ b/src/ui/session_list.rs
@@ -19,7 +19,7 @@ use crate::database::{
     load_session_by_id_for_filter, load_sessions_for_filter, search_sessions_for_filter,
 };
 use crate::models::{
-    AiAssistant, DateFilter, PerSourceResult, ProjectFilter, Session, SourceStatus,
+    AiAssistant, DateFilter, PerSourceResult, ProjectFilter, Session, SortOrder, SourceStatus,
 };
 use crate::ui::session_row::{SessionRow, SessionRowInit, SessionRowOutput};
 
@@ -838,11 +838,17 @@ impl SessionList {
     ) -> Vec<Session> {
         let query = query.trim();
         let sessions = if query.is_empty() {
-            load_sessions_for_filter(db_path, tools, project_filter, date_filter)
+            load_sessions_for_filter(
+                db_path,
+                tools,
+                project_filter,
+                date_filter,
+                SortOrder::default(),
+            )
         } else if let Some(session_id) = parse_session_id_query(query) {
             load_session_by_id_for_filter(db_path, tools, project_filter, session_id, date_filter)
         } else {
-            search_sessions_for_filter(db_path, tools, project_filter, query, date_filter)
+            search_sessions_for_filter(db_path, tools, project_filter, query, date_filter, None)
         };
 
         match sessions {

--- a/src/ui/session_list.rs
+++ b/src/ui/session_list.rs
@@ -19,7 +19,8 @@ use crate::database::{
     load_session_by_id_for_filter, load_sessions_for_filter, search_sessions_for_filter,
 };
 use crate::models::{
-    AiAssistant, DateFilter, PerSourceResult, ProjectFilter, Session, SortOrder, SourceStatus,
+    AiAssistant, DateFilter, PerSourceResult, ProjectFilter, Session, SessionQuery, SortOrder,
+    SourceStatus,
 };
 use crate::ui::session_row::{SessionRow, SessionRowInit, SessionRowOutput};
 
@@ -30,6 +31,7 @@ pub struct SessionList {
     project_filter: ProjectFilter,
     date_filter: DateFilter,
     search_query: String,
+    sort: Option<SortOrder>,
     all_tools_selected: bool,
     indexing: bool,
     sessions: FactoryVecDeque<SessionRow>,
@@ -47,7 +49,11 @@ pub enum SessionListMsg {
         tools: Vec<AiAssistant>,
         project_filter: ProjectFilter,
     },
-    SetSearchQuery(String),
+    SetSearchState {
+        query: String,
+        sort: Option<SortOrder>,
+    },
+    SetSortOrder(Option<SortOrder>),
     DateFilterChanged(DateFilter),
     Reload,
     ReloadAfterIndexing {
@@ -361,10 +367,6 @@ struct EmptyStateViewModel {
     show_source_results: bool,
 }
 
-fn parse_session_id_query(query: &str) -> Option<&str> {
-    query.trim().strip_prefix("id:").map(str::trim)
-}
-
 fn focus_is_within(widget: &impl IsA<gtk::Widget>) -> bool {
     let widget_ref = widget.upcast_ref::<gtk::Widget>();
     let Some(root) = widget_ref.root() else {
@@ -393,7 +395,10 @@ fn compute_empty_state(
         };
     }
 
-    let session_id_lookup = parse_session_id_query(search_query).is_some();
+    let session_id_lookup = matches!(
+        SessionQuery::classify(search_query),
+        SessionQuery::DirectId(_)
+    );
     let has_search = !search_query.trim().is_empty();
     let pinned_selected = *project_filter == ProjectFilter::Pinned;
 
@@ -535,12 +540,14 @@ impl SimpleComponent for SessionList {
         let search_query = String::new();
         let project_filter = ProjectFilter::AllSessions;
         let date_filter = DateFilter::AnyTime;
+        let sort = Some(SortOrder::default());
         let fetched = Self::fetch_sessions(
             &db_path,
             &active_tools,
             &project_filter,
             &date_filter,
             &search_query,
+            sort,
         );
 
         let sessions: FactoryVecDeque<SessionRow> = FactoryVecDeque::builder()
@@ -558,6 +565,7 @@ impl SimpleComponent for SessionList {
             project_filter,
             date_filter,
             search_query,
+            sort,
             all_tools_selected: true,
             indexing: false,
             sessions,
@@ -630,13 +638,25 @@ impl SimpleComponent for SessionList {
                 self.all_tools_selected = tools.len() == AiAssistant::ALL.len();
                 self.reload_sessions();
             }
-            SessionListMsg::SetSearchQuery(query) => {
-                if !Self::search_query_changed(&self.search_query, &query) {
+            SessionListMsg::SetSearchState { query, sort } => {
+                if self.search_query == query && self.sort == sort {
                     return;
                 }
-
                 self.search_query = query;
+                self.sort = sort;
                 self.reload_sessions();
+            }
+            SessionListMsg::SetSortOrder(sort) => {
+                if self.sort == sort {
+                    return;
+                }
+                self.sort = sort;
+                if !matches!(
+                    SessionQuery::classify(&self.search_query),
+                    SessionQuery::DirectId(_)
+                ) {
+                    self.reload_sessions();
+                }
             }
             SessionListMsg::DateFilterChanged(date_filter) => {
                 if self.date_filter == date_filter {
@@ -779,10 +799,6 @@ impl SessionList {
         current_tools != next_tools || current_project_filter != next_project_filter
     }
 
-    fn search_query_changed(current_query: &str, next_query: &str) -> bool {
-        current_query != next_query
-    }
-
     /// Scroll the ancestor `ScrolledWindow` so that `row` is fully visible.
     fn scroll_row_into_view(row: &gtk::ListBoxRow, list_box: &gtk::ListBox) {
         let Some(adj) = Self::scroll_adjustment(list_box) else {
@@ -835,20 +851,26 @@ impl SessionList {
         project_filter: &ProjectFilter,
         date_filter: &DateFilter,
         query: &str,
+        sort: Option<SortOrder>,
     ) -> Vec<Session> {
-        let query = query.trim();
-        let sessions = if query.is_empty() {
-            load_sessions_for_filter(
+        let sessions = match SessionQuery::classify(query) {
+            SessionQuery::None => load_sessions_for_filter(
                 db_path,
                 tools,
                 project_filter,
                 date_filter,
-                SortOrder::default(),
-            )
-        } else if let Some(session_id) = parse_session_id_query(query) {
-            load_session_by_id_for_filter(db_path, tools, project_filter, session_id, date_filter)
-        } else {
-            search_sessions_for_filter(db_path, tools, project_filter, query, date_filter, None)
+                sort.unwrap_or_default(),
+            ),
+            SessionQuery::DirectId(session_id) => load_session_by_id_for_filter(
+                db_path,
+                tools,
+                project_filter,
+                session_id,
+                date_filter,
+            ),
+            SessionQuery::Fts(query) => {
+                search_sessions_for_filter(db_path, tools, project_filter, query, date_filter, sort)
+            }
         };
 
         match sessions {
@@ -1203,6 +1225,7 @@ impl SessionList {
             &self.project_filter,
             &self.date_filter,
             &self.search_query,
+            self.sort,
         );
         let fetch_duration = fetch_started_at.elapsed();
         let row_count = fetched.len();
@@ -1252,6 +1275,7 @@ impl SessionList {
             &self.project_filter,
             &self.date_filter,
             &self.search_query,
+            self.sort,
         );
 
         let mut guard = self.sessions.guard();
@@ -1707,18 +1731,35 @@ mod tests {
     }
 
     #[test]
-    fn unchanged_search_query_does_not_need_reload() {
-        assert!(!SessionList::search_query_changed("needle", "needle"));
-        assert!(SessionList::search_query_changed("needle", "other"));
-    }
+    fn fetch_sessions_applies_named_sort_only_where_ordering_exists() {
+        let db = TempDatabase::new();
+        db.seed_project_sidebar_fixture();
 
-    #[test]
-    fn parse_session_id_query_recognizes_lowercase_prefix_and_trims_suffix() {
-        assert_eq!(parse_session_id_query("id:abc"), Some("abc"));
-        assert_eq!(parse_session_id_query(" id: abc "), Some("abc"));
-        assert_eq!(parse_session_id_query("id:   "), Some(""));
-        assert_eq!(parse_session_id_query("ID:abc"), None);
-        assert_eq!(parse_session_id_query("abc"), None);
+        let oldest = SessionList::fetch_sessions(
+            &db.path,
+            &AiAssistant::ALL,
+            &ProjectFilter::AllSessions,
+            &DateFilter::AnyTime,
+            "",
+            Some(SortOrder::OldestFirst),
+        );
+        assert_eq!(
+            oldest.first().map(|s| s.id.as_str()),
+            Some("alpha-claude-old")
+        );
+
+        let direct = SessionList::fetch_sessions(
+            &db.path,
+            &AiAssistant::ALL,
+            &ProjectFilter::AllSessions,
+            &DateFilter::AnyTime,
+            "id:alpha-claude-new",
+            None,
+        );
+        assert_eq!(
+            direct.iter().map(|s| s.id.as_str()).collect::<Vec<_>>(),
+            vec!["alpha-claude-new"]
+        );
     }
 
     #[test]
@@ -2339,9 +2380,10 @@ mod tests {
             parts.model.sessions.len() == POST_INDEXING_RELOAD_BATCH_SIZE
         });
 
-        controller.emit(SessionListMsg::SetSearchQuery(
-            "id:alpha-claude-new".to_string(),
-        ));
+        controller.emit(SessionListMsg::SetSearchState {
+            query: "id:alpha-claude-new".to_string(),
+            sort: Some(SortOrder::RecentActivity),
+        });
 
         pump_main_context(|| {
             let parts = controller.state().get();
@@ -2538,9 +2580,10 @@ mod tests {
 
         let controller = SessionList::builder().launch(temp_db.path.clone());
 
-        controller.emit(SessionListMsg::SetSearchQuery(
-            " id: alpha-claude-old ".to_string(),
-        ));
+        controller.emit(SessionListMsg::SetSearchState {
+            query: " id: alpha-claude-old ".to_string(),
+            sort: Some(SortOrder::RecentActivity),
+        });
 
         pump_main_context(|| {
             let parts = controller.state().get();
@@ -2569,9 +2612,10 @@ mod tests {
             tools: vec![AiAssistant::OpenCode],
             project_filter: ProjectFilter::AllSessions,
         });
-        controller.emit(SessionListMsg::SetSearchQuery(
-            "id:alpha-claude-old".to_string(),
-        ));
+        controller.emit(SessionListMsg::SetSearchState {
+            query: "id:alpha-claude-old".to_string(),
+            sort: Some(SortOrder::RecentActivity),
+        });
 
         pump_main_context(|| {
             let parts = controller.state().get();
@@ -2617,7 +2661,10 @@ mod tests {
             )
             .expect("Failed to reorder selected session");
 
-        controller.emit(SessionListMsg::SetSearchQuery("".to_string()));
+        controller.emit(SessionListMsg::SetSearchState {
+            query: "".to_string(),
+            sort: Some(SortOrder::RecentActivity),
+        });
         pump_main_context(|| list_box.selected_row().is_some());
 
         let selected_session_id = {

--- a/src/ui/sort_pill.rs
+++ b/src/ui/sort_pill.rs
@@ -320,6 +320,8 @@ fn tooltip_text(sort_order: SortOrder, fts_search_active: bool, override_active:
 mod tests {
     use super::*;
     use relm4::{Component, ComponentController};
+    use std::cell::RefCell;
+    use std::rc::Rc;
     use std::time::{Duration, Instant};
 
     #[test]
@@ -437,5 +439,88 @@ mod tests {
         controller.emit(SortPillInput::SetNarrow(false));
         pump_main_context(|| label.is_visible());
         assert!(!controller.widget().has_css_class("accent"));
+    }
+
+    fn activate_row(list: &gtk::ListBox, index: i32) {
+        let row = list
+            .row_at_index(index)
+            .unwrap_or_else(|| panic!("row at index {index} should exist"));
+        list.emit_by_name::<()>("row-activated", &[&row]);
+    }
+
+    #[gtk::test]
+    fn row_activation_maps_indices_to_named_orders_without_fts() {
+        let outputs: Rc<RefCell<Vec<SortPillOutput>>> = Rc::new(RefCell::new(Vec::new()));
+        let outputs_ref = outputs.clone();
+        let controller = SortPill::builder()
+            .launch(SortOrder::RecentActivity)
+            .connect_receiver(move |_, output| {
+                outputs_ref.borrow_mut().push(output);
+            });
+        let list = find_list_box(&controller.widget().clone().upcast()).unwrap();
+        assert_eq!(row_count(&list), 4);
+
+        for index in 0..4 {
+            activate_row(&list, index);
+        }
+        pump_main_context(|| outputs.borrow().len() == 4);
+
+        let outputs = outputs.borrow();
+        let expected = [
+            SortOrder::RecentActivity,
+            SortOrder::OldestFirst,
+            SortOrder::NewestFirst,
+            SortOrder::MostMessages,
+        ];
+        for (output, expected_order) in outputs.iter().zip(expected) {
+            match output {
+                SortPillOutput::OrderPicked(order) => assert_eq!(*order, expected_order),
+                SortPillOutput::RelevancePicked => {
+                    panic!("unexpected RelevancePicked in non-FTS state")
+                }
+            }
+        }
+    }
+
+    #[gtk::test]
+    fn row_activation_maps_indices_to_named_orders_with_fts() {
+        let outputs: Rc<RefCell<Vec<SortPillOutput>>> = Rc::new(RefCell::new(Vec::new()));
+        let outputs_ref = outputs.clone();
+        let controller = SortPill::builder()
+            .launch(SortOrder::RecentActivity)
+            .connect_receiver(move |_, output| {
+                outputs_ref.borrow_mut().push(output);
+            });
+        let list = find_list_box(&controller.widget().clone().upcast()).unwrap();
+
+        controller.emit(SortPillInput::SyncState {
+            sort_order: SortOrder::RecentActivity,
+            fts_search_active: true,
+            override_active: false,
+        });
+        pump_main_context(|| row_count(&list) == 5);
+
+        for index in 0..5 {
+            activate_row(&list, index);
+        }
+        pump_main_context(|| outputs.borrow().len() == 5);
+
+        let outputs = outputs.borrow();
+        assert!(matches!(outputs[0], SortPillOutput::RelevancePicked));
+
+        let expected = [
+            SortOrder::RecentActivity,
+            SortOrder::OldestFirst,
+            SortOrder::NewestFirst,
+            SortOrder::MostMessages,
+        ];
+        for (output, expected_order) in outputs[1..].iter().zip(expected) {
+            match output {
+                SortPillOutput::OrderPicked(order) => assert_eq!(*order, expected_order),
+                SortPillOutput::RelevancePicked => {
+                    panic!("unexpected RelevancePicked at index > 0 in FTS state")
+                }
+            }
+        }
     }
 }

--- a/src/ui/sort_pill.rs
+++ b/src/ui/sort_pill.rs
@@ -19,7 +19,6 @@ pub struct SortPill {
     sort_order: SortOrder,
     fts_search_active: bool,
     override_active: bool,
-    narrow: bool,
     listbox: gtk::ListBox,
     popover: gtk::Popover,
     row_activation_fts_flag: Rc<Cell<bool>>,
@@ -35,7 +34,6 @@ pub enum SortPillInput {
         override_active: bool,
     },
     OpenViaShortcut,
-    SetNarrow(bool),
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -113,7 +111,6 @@ impl SimpleComponent for SortPill {
             sort_order: init,
             fts_search_active: false,
             override_active: false,
-            narrow: false,
             listbox: listbox.clone(),
             popover: popover.clone(),
             row_activation_fts_flag: fts_search_active,
@@ -162,9 +159,6 @@ impl SimpleComponent for SortPill {
             SortPillInput::OpenViaShortcut => {
                 self.popover.popup();
                 self.focus_effective_row_when_ready();
-            }
-            SortPillInput::SetNarrow(narrow) => {
-                self.narrow = narrow;
             }
         }
     }
@@ -244,14 +238,9 @@ impl SortPill {
             self.override_active,
         );
         widgets.label.set_label(&effective);
-        widgets.label.set_visible(
-            !self.narrow
-                && should_show_label(
-                    self.sort_order,
-                    self.fts_search_active,
-                    self.override_active,
-                ),
-        );
+        widgets
+            .label
+            .set_visible(should_show_label(self.sort_order, self.fts_search_active));
         widgets.root.set_tooltip_text(Some(&tooltip_text(
             self.sort_order,
             self.fts_search_active,
@@ -285,11 +274,10 @@ fn build_row(label: &str) -> gtk::ListBoxRow {
     row
 }
 
-fn should_show_label(
-    sort_order: SortOrder,
-    fts_search_active: bool,
-    _override_active: bool,
-) -> bool {
+/// Mirrors `DatePill`, which shows its label whenever the filter is active and
+/// hides it otherwise, at every window width. The pill therefore stays
+/// icon-only in the default state and never depends on a window breakpoint.
+fn should_show_label(sort_order: SortOrder, fts_search_active: bool) -> bool {
     fts_search_active || sort_order != SortOrder::RecentActivity
 }
 
@@ -338,9 +326,9 @@ mod tests {
             tooltip_text(SortOrder::RecentActivity, true, false),
             "Sort by: Relevance"
         );
-        assert!(!should_show_label(SortOrder::RecentActivity, false, false));
-        assert!(should_show_label(SortOrder::RecentActivity, true, true));
-        assert!(should_show_label(SortOrder::MostMessages, false, false));
+        assert!(!should_show_label(SortOrder::RecentActivity, false));
+        assert!(should_show_label(SortOrder::RecentActivity, true));
+        assert!(should_show_label(SortOrder::MostMessages, false));
     }
 
     fn pump_main_context(condition: impl Fn() -> bool) {
@@ -422,8 +410,10 @@ mod tests {
         pump_main_context(|| list.selected_row().map(|row| row.index()) == Some(4));
     }
 
+    /// The label tracks only whether a non-default order is active, like
+    /// `DatePill`. Window width never enters into it.
     #[gtk::test]
-    fn label_hides_for_default_and_narrow_states() {
+    fn label_is_shown_only_for_non_default_orders() {
         let controller = SortPill::builder().launch(SortOrder::RecentActivity);
         let label = controller.widgets().label.clone();
         assert!(!label.is_visible());
@@ -434,9 +424,21 @@ mod tests {
             override_active: false,
         });
         pump_main_context(|| label.is_visible());
-        controller.emit(SortPillInput::SetNarrow(true));
+
+        controller.emit(SortPillInput::SyncState {
+            sort_order: SortOrder::RecentActivity,
+            fts_search_active: false,
+            override_active: false,
+        });
         pump_main_context(|| !label.is_visible());
-        controller.emit(SortPillInput::SetNarrow(false));
+
+        // Relevance during FTS is also a non-default state, so the label
+        // returns even though the persisted order is the default one.
+        controller.emit(SortPillInput::SyncState {
+            sort_order: SortOrder::RecentActivity,
+            fts_search_active: true,
+            override_active: false,
+        });
         pump_main_context(|| label.is_visible());
         assert!(!controller.widget().has_css_class("accent"));
     }

--- a/src/ui/sort_pill.rs
+++ b/src/ui/sort_pill.rs
@@ -1,0 +1,442 @@
+use std::cell::Cell;
+use std::rc::Rc;
+
+use gettextrs::gettext;
+use gtk::glib;
+use gtk::prelude::*;
+use relm4::{ComponentParts, ComponentSender, SimpleComponent, gtk};
+
+use crate::models::SortOrder;
+
+const NAMED_ORDERS: [SortOrder; 4] = [
+    SortOrder::RecentActivity,
+    SortOrder::OldestFirst,
+    SortOrder::NewestFirst,
+    SortOrder::MostMessages,
+];
+
+pub struct SortPill {
+    sort_order: SortOrder,
+    fts_search_active: bool,
+    override_active: bool,
+    narrow: bool,
+    listbox: gtk::ListBox,
+    popover: gtk::Popover,
+    row_activation_fts_flag: Rc<Cell<bool>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum SortPillInput {
+    OrderSelected(SortOrder),
+    RelevanceSelected,
+    SyncState {
+        sort_order: SortOrder,
+        fts_search_active: bool,
+        override_active: bool,
+    },
+    OpenViaShortcut,
+    SetNarrow(bool),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum SortPillOutput {
+    OrderPicked(SortOrder),
+    RelevancePicked,
+}
+
+pub struct SortPillWidgets {
+    root: gtk::MenuButton,
+    pub(crate) label: gtk::Label,
+}
+
+impl SimpleComponent for SortPill {
+    type Init = SortOrder;
+    type Input = SortPillInput;
+    type Output = SortPillOutput;
+    type Root = gtk::MenuButton;
+    type Widgets = SortPillWidgets;
+
+    fn init_root() -> Self::Root {
+        gtk::MenuButton::new()
+    }
+
+    fn init(
+        init: Self::Init,
+        root: Self::Root,
+        sender: ComponentSender<Self>,
+    ) -> ComponentParts<Self> {
+        let icon = gtk::Image::from_icon_name("view-sort-descending-symbolic");
+        let label = gtk::Label::new(None);
+        label.set_visible(false);
+
+        let button_content = gtk::Box::new(gtk::Orientation::Horizontal, 6);
+        button_content.append(&icon);
+        button_content.append(&label);
+
+        root.set_child(Some(&button_content));
+        root.add_css_class("flat");
+
+        let popover = gtk::Popover::new();
+        root.set_popover(Some(&popover));
+
+        let listbox = gtk::ListBox::new();
+        listbox.add_css_class("boxed-list");
+        listbox.set_selection_mode(gtk::SelectionMode::Browse);
+
+        let content = gtk::Box::new(gtk::Orientation::Vertical, 0);
+        content.set_margin_top(12);
+        content.set_margin_bottom(12);
+        content.set_margin_start(12);
+        content.set_margin_end(12);
+        content.append(&listbox);
+        popover.set_child(Some(&content));
+
+        let fts_search_active = Rc::new(Cell::new(false));
+
+        let input_sender = sender.input_sender().clone();
+        let fts_flag = fts_search_active.clone();
+        listbox.connect_row_activated(move |_list, row| {
+            let index = row.index() as usize;
+            if fts_flag.get() && index == 0 {
+                input_sender.send(SortPillInput::RelevanceSelected).ok();
+            } else {
+                let offset = usize::from(fts_flag.get());
+                if index >= offset
+                    && let Some(order) = NAMED_ORDERS.get(index - offset).copied()
+                {
+                    input_sender.send(SortPillInput::OrderSelected(order)).ok();
+                }
+            }
+        });
+
+        let model = Self {
+            sort_order: init,
+            fts_search_active: false,
+            override_active: false,
+            narrow: false,
+            listbox: listbox.clone(),
+            popover: popover.clone(),
+            row_activation_fts_flag: fts_search_active,
+        };
+
+        model.rebuild_rows();
+
+        let widgets = SortPillWidgets { root, label };
+
+        model.sync_button(&widgets);
+        model.select_effective_row();
+
+        ComponentParts { model, widgets }
+    }
+
+    fn update(&mut self, message: Self::Input, sender: ComponentSender<Self>) {
+        match message {
+            SortPillInput::OrderSelected(order) => {
+                self.sort_order = order;
+                self.override_active = true;
+                self.select_effective_row();
+                sender.output(SortPillOutput::OrderPicked(order)).ok();
+                self.popover.popdown();
+            }
+            SortPillInput::RelevanceSelected => {
+                self.override_active = false;
+                self.select_effective_row();
+                sender.output(SortPillOutput::RelevancePicked).ok();
+                self.popover.popdown();
+            }
+            SortPillInput::SyncState {
+                sort_order,
+                fts_search_active,
+                override_active,
+            } => {
+                let fts_changed = self.fts_search_active != fts_search_active;
+                self.sort_order = sort_order;
+                self.fts_search_active = fts_search_active;
+                self.override_active = override_active;
+                self.row_activation_fts_flag.set(fts_search_active);
+                if fts_changed {
+                    self.rebuild_rows();
+                }
+                self.select_effective_row();
+            }
+            SortPillInput::OpenViaShortcut => {
+                self.popover.popup();
+                self.focus_effective_row_when_ready();
+            }
+            SortPillInput::SetNarrow(narrow) => {
+                self.narrow = narrow;
+            }
+        }
+    }
+
+    fn update_view(&self, widgets: &mut Self::Widgets, _sender: ComponentSender<Self>) {
+        self.sync_button(widgets);
+    }
+}
+
+impl SortPill {
+    fn rebuild_rows(&self) {
+        while let Some(row) = self.listbox.row_at_index(0) {
+            self.listbox.remove(&row);
+        }
+
+        if self.fts_search_active {
+            self.listbox.append(&build_row(&gettext("Relevance")));
+        }
+
+        for order in NAMED_ORDERS {
+            self.listbox
+                .append(&build_row(&localized_order_label(order)));
+        }
+
+        if self.fts_search_active {
+            self.listbox.set_header_func(|row, before| {
+                if row.index() == 1 && before.is_some() {
+                    row.set_header(Some(&gtk::Separator::new(gtk::Orientation::Horizontal)));
+                } else {
+                    row.set_header(gtk::Widget::NONE);
+                }
+            });
+        } else {
+            self.listbox.unset_header_func();
+        }
+    }
+
+    fn effective_row_index(&self) -> i32 {
+        if self.fts_search_active && !self.override_active {
+            0
+        } else {
+            let offset = usize::from(self.fts_search_active);
+            let named_index = NAMED_ORDERS
+                .iter()
+                .position(|order| *order == self.sort_order)
+                .unwrap_or(0);
+            (named_index + offset) as i32
+        }
+    }
+
+    fn select_effective_row(&self) {
+        let index = self.effective_row_index();
+        if let Some(row) = self.listbox.row_at_index(index) {
+            self.listbox.select_row(Some(&row));
+        }
+    }
+
+    fn focus_effective_row_when_ready(&self) {
+        let listbox = self.listbox.clone();
+        let row_index = self.effective_row_index();
+
+        glib::idle_add_local_once(move || {
+            let Some(row) = listbox.row_at_index(row_index) else {
+                return;
+            };
+
+            listbox.select_row(Some(&row));
+            listbox.grab_focus();
+            row.grab_focus();
+        });
+    }
+
+    fn sync_button(&self, widgets: &SortPillWidgets) {
+        let effective = effective_label(
+            self.sort_order,
+            self.fts_search_active,
+            self.override_active,
+        );
+        widgets.label.set_label(&effective);
+        widgets.label.set_visible(
+            !self.narrow
+                && should_show_label(
+                    self.sort_order,
+                    self.fts_search_active,
+                    self.override_active,
+                ),
+        );
+        widgets.root.set_tooltip_text(Some(&tooltip_text(
+            self.sort_order,
+            self.fts_search_active,
+            self.override_active,
+        )));
+    }
+}
+
+fn localized_order_label(order: SortOrder) -> String {
+    match order.label_msgid() {
+        "Recent activity" => gettext("Recent activity"),
+        "Oldest first" => gettext("Oldest first"),
+        "Newest first" => gettext("Newest first"),
+        "Most messages" => gettext("Most messages"),
+        _ => unreachable!("SortOrder returned an unknown label message ID"),
+    }
+}
+
+fn build_row(label: &str) -> gtk::ListBoxRow {
+    let label = gtk::Label::new(Some(label));
+    label.set_xalign(0.0);
+    let row_box = gtk::Box::new(gtk::Orientation::Horizontal, 12);
+    row_box.set_margin_top(8);
+    row_box.set_margin_bottom(8);
+    row_box.set_margin_start(12);
+    row_box.set_margin_end(12);
+    row_box.append(&label);
+    let row = gtk::ListBoxRow::new();
+    row.set_activatable(true);
+    row.set_focusable(true);
+    row.set_child(Some(&row_box));
+    row
+}
+
+fn should_show_label(
+    sort_order: SortOrder,
+    fts_search_active: bool,
+    _override_active: bool,
+) -> bool {
+    fts_search_active || sort_order != SortOrder::RecentActivity
+}
+
+fn effective_label(
+    sort_order: SortOrder,
+    fts_search_active: bool,
+    override_active: bool,
+) -> String {
+    if fts_search_active && !override_active {
+        gettext("Relevance")
+    } else {
+        localized_order_label(sort_order)
+    }
+}
+
+fn tooltip_text(sort_order: SortOrder, fts_search_active: bool, override_active: bool) -> String {
+    if !fts_search_active && sort_order == SortOrder::RecentActivity {
+        gettext("Sort sessions (Ctrl+Shift+O)")
+    } else {
+        gettext("Sort by: {}").replace(
+            "{}",
+            &effective_label(sort_order, fts_search_active, override_active),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use relm4::{Component, ComponentController};
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn tooltip_and_label_rules_match_effective_order() {
+        assert_eq!(
+            tooltip_text(SortOrder::RecentActivity, false, false),
+            "Sort sessions (Ctrl+Shift+O)"
+        );
+        assert_eq!(
+            tooltip_text(SortOrder::OldestFirst, false, false),
+            "Sort by: Oldest first"
+        );
+        assert_eq!(
+            tooltip_text(SortOrder::RecentActivity, true, false),
+            "Sort by: Relevance"
+        );
+        assert!(!should_show_label(SortOrder::RecentActivity, false, false));
+        assert!(should_show_label(SortOrder::RecentActivity, true, true));
+        assert!(should_show_label(SortOrder::MostMessages, false, false));
+    }
+
+    fn pump_main_context(condition: impl Fn() -> bool) {
+        let context = gtk::glib::MainContext::default();
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while !condition() {
+            assert!(
+                Instant::now() < deadline,
+                "condition not met before timeout"
+            );
+            while context.pending() {
+                context.iteration(false);
+            }
+            // Never block on `iteration(true)`: with no ready source the call
+            // parks forever and the deadline above can never be reached.
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    fn find_list_box(widget: &gtk::Widget) -> Option<gtk::ListBox> {
+        if let Ok(list_box) = widget.clone().downcast::<gtk::ListBox>() {
+            return Some(list_box);
+        }
+        let mut child = widget.first_child();
+        while let Some(child_widget) = child {
+            if let Some(found) = find_list_box(&child_widget) {
+                return Some(found);
+            }
+            child = child_widget.next_sibling();
+        }
+        None
+    }
+
+    /// Count only the rows. `observe_children` also yields the separator
+    /// installed as a row header while FTS is active, which is not a row.
+    fn row_count(list: &gtk::ListBox) -> i32 {
+        let mut count = 0;
+        while list.row_at_index(count).is_some() {
+            count += 1;
+        }
+        count
+    }
+
+    #[gtk::test]
+    fn relevance_row_exists_only_during_fts() {
+        let controller = SortPill::builder().launch(SortOrder::RecentActivity);
+        let list = find_list_box(&controller.widget().clone().upcast()).unwrap();
+        assert_eq!(row_count(&list), 4);
+
+        controller.emit(SortPillInput::SyncState {
+            sort_order: SortOrder::RecentActivity,
+            fts_search_active: true,
+            override_active: false,
+        });
+        pump_main_context(|| row_count(&list) == 5);
+
+        controller.emit(SortPillInput::SyncState {
+            sort_order: SortOrder::RecentActivity,
+            fts_search_active: false,
+            override_active: false,
+        });
+        pump_main_context(|| row_count(&list) == 4);
+    }
+
+    #[gtk::test]
+    fn shortcut_selects_the_effective_row() {
+        let controller = SortPill::builder().launch(SortOrder::RecentActivity);
+        let window = gtk::Window::new();
+        window.set_child(Some(controller.widget()));
+        window.present();
+        let list = find_list_box(&controller.widget().clone().upcast()).unwrap();
+
+        controller.emit(SortPillInput::SyncState {
+            sort_order: SortOrder::MostMessages,
+            fts_search_active: true,
+            override_active: true,
+        });
+        controller.emit(SortPillInput::OpenViaShortcut);
+        pump_main_context(|| list.selected_row().map(|row| row.index()) == Some(4));
+    }
+
+    #[gtk::test]
+    fn label_hides_for_default_and_narrow_states() {
+        let controller = SortPill::builder().launch(SortOrder::RecentActivity);
+        let label = controller.widgets().label.clone();
+        assert!(!label.is_visible());
+
+        controller.emit(SortPillInput::SyncState {
+            sort_order: SortOrder::OldestFirst,
+            fts_search_active: false,
+            override_active: false,
+        });
+        pump_main_context(|| label.is_visible());
+        controller.emit(SortPillInput::SetNarrow(true));
+        pump_main_context(|| !label.is_visible());
+        controller.emit(SortPillInput::SetNarrow(false));
+        pump_main_context(|| label.is_visible());
+        assert!(!controller.widget().has_css_class("accent"));
+    }
+}

--- a/src/ui/sort_pill.rs
+++ b/src/ui/sort_pill.rs
@@ -261,12 +261,11 @@ impl SortPill {
 }
 
 fn localized_order_label(order: SortOrder) -> String {
-    match order.label_msgid() {
-        "Recent activity" => gettext("Recent activity"),
-        "Oldest first" => gettext("Oldest first"),
-        "Newest first" => gettext("Newest first"),
-        "Most messages" => gettext("Most messages"),
-        _ => unreachable!("SortOrder returned an unknown label message ID"),
+    match order {
+        SortOrder::RecentActivity => gettext("Recent activity"),
+        SortOrder::OldestFirst => gettext("Oldest first"),
+        SortOrder::NewestFirst => gettext("Newest first"),
+        SortOrder::MostMessages => gettext("Most messages"),
     }
 }
 

--- a/tests/date_filter.rs
+++ b/tests/date_filter.rs
@@ -6,7 +6,7 @@ use sessions_chronicle::database::{
     count_sessions_per_date_preset, load_session_by_id_for_filter, load_sessions_for_filter,
     search_sessions_for_filter,
 };
-use sessions_chronicle::models::{AiAssistant, DateFilter, ProjectFilter};
+use sessions_chronicle::models::{AiAssistant, DateFilter, ProjectFilter, SortOrder};
 
 /// Local "today at 12:00" converted to UTC, used as a stable anchor for
 /// building date-window fixtures across timezones.
@@ -129,6 +129,7 @@ fn load_sessions_for_filter_applies_date_presets() {
         &[AiAssistant::ClaudeCode],
         &ProjectFilter::AllSessions,
         &DateFilter::Today,
+        SortOrder::RecentActivity,
     )
     .expect("today filter query should succeed");
 
@@ -154,6 +155,7 @@ fn load_sessions_for_filter_applies_date_presets() {
         &[AiAssistant::ClaudeCode],
         &ProjectFilter::AllSessions,
         &DateFilter::Last7Days,
+        SortOrder::RecentActivity,
     )
     .expect("last-7-days filter query should succeed");
 
@@ -187,6 +189,7 @@ fn custom_date_bounds_are_inclusive_and_compose_with_project_and_query() {
         &ProjectFilter::Project(1),
         "alpha",
         &custom,
+        None,
     )
     .expect("composed date/project/query search should succeed");
 
@@ -323,6 +326,7 @@ fn custom_date_bounds_include_both_ends() {
         &[AiAssistant::ClaudeCode],
         &ProjectFilter::AllSessions,
         &DateFilter::Custom { from, to },
+        SortOrder::RecentActivity,
     )
     .expect("custom range query should succeed");
 
@@ -365,6 +369,7 @@ fn load_sessions_for_filter_applies_yesterday_preset() {
         &[AiAssistant::ClaudeCode],
         &ProjectFilter::AllSessions,
         &DateFilter::Yesterday,
+        SortOrder::RecentActivity,
     )
     .expect("yesterday filter query should succeed");
 
@@ -376,6 +381,7 @@ fn load_sessions_for_filter_applies_yesterday_preset() {
         &[AiAssistant::ClaudeCode],
         &ProjectFilter::AllSessions,
         &DateFilter::Today,
+        SortOrder::RecentActivity,
     )
     .expect("today filter query should succeed");
 

--- a/tests/i18n_potfiles.rs
+++ b/tests/i18n_potfiles.rs
@@ -1,11 +1,10 @@
 #[test]
-fn potfiles_includes_shortcuts_rust_file() {
+fn potfiles_includes_rust_files_with_gettext_strings() {
     let potfiles = include_str!("../po/POTFILES.in");
-
-    assert!(
-        potfiles
-            .lines()
-            .any(|line| line.trim() == "src/ui/modals/shortcuts.rs"),
-        "po/POTFILES.in must include src/ui/modals/shortcuts.rs for gettext extraction"
-    );
+    for path in ["src/ui/modals/shortcuts.rs", "src/ui/sort_pill.rs"] {
+        assert!(
+            potfiles.lines().any(|line| line.trim() == path),
+            "po/POTFILES.in must include {path} for gettext extraction"
+        );
+    }
 }

--- a/tests/opencode_search.rs
+++ b/tests/opencode_search.rs
@@ -58,6 +58,7 @@ fn opencode_search_finds_text_part_content() {
         &ProjectFilter::AllSessions,
         "I can help you with that task",
         &DateFilter::AnyTime,
+        None,
     )
     .expect("Search failed");
 
@@ -99,6 +100,7 @@ fn opencode_search_excludes_tool_output() {
         &ProjectFilter::AllSessions,
         "total",
         &DateFilter::AnyTime,
+        None,
     )
     .expect("Search failed");
 
@@ -125,6 +127,7 @@ fn opencode_search_respects_tool_filter() {
         &ProjectFilter::AllSessions,
         "Hello OpenCode",
         &DateFilter::AnyTime,
+        None,
     )
     .expect("Search failed");
 
@@ -152,6 +155,7 @@ fn opencode_dual_read_sqlite_only_session_is_searchable() {
         &ProjectFilter::AllSessions,
         "This session only exists in SQLite",
         &DateFilter::AnyTime,
+        None,
     )
     .expect("Search failed");
 

--- a/tests/pinned_sessions.rs
+++ b/tests/pinned_sessions.rs
@@ -4,7 +4,7 @@ use helpers::TempDatabase;
 use sessions_chronicle::database::{
     count_pinned_sessions, load_sessions_for_filter, search_sessions_for_filter, toggle_pin,
 };
-use sessions_chronicle::models::{AiAssistant, DateFilter, ProjectFilter};
+use sessions_chronicle::models::{AiAssistant, DateFilter, ProjectFilter, SortOrder};
 
 fn insert_session(db: &TempDatabase, id: &str, tool: &str, pinned_at: Option<i64>) {
     db.connection
@@ -63,6 +63,7 @@ fn load_sessions_for_filter_uses_pinned_project_filter() {
         AiAssistant::ALL,
         &ProjectFilter::Pinned,
         &DateFilter::AnyTime,
+        SortOrder::RecentActivity,
     )
     .unwrap();
 
@@ -102,6 +103,7 @@ fn search_sessions_for_filter_uses_pinned_project_filter() {
         &ProjectFilter::Pinned,
         "needle",
         &DateFilter::AnyTime,
+        None,
     )
     .unwrap();
 
@@ -183,6 +185,7 @@ fn pinned_filter_returns_sessions_across_all_projects() {
         AiAssistant::ALL,
         &ProjectFilter::Pinned,
         &DateFilter::AnyTime,
+        SortOrder::RecentActivity,
     )
     .unwrap();
 

--- a/tests/project_sidebar_filtering.rs
+++ b/tests/project_sidebar_filtering.rs
@@ -5,7 +5,7 @@ use sessions_chronicle::database::{
     count_all_sessions, count_unassigned_sessions, has_unassigned_sessions, load_projects,
     load_sessions_for_filter, search_sessions_for_filter,
 };
-use sessions_chronicle::models::{AiAssistant, DateFilter, ProjectFilter};
+use sessions_chronicle::models::{AiAssistant, DateFilter, ProjectFilter, SortOrder};
 
 impl TempDatabase {
     /// Seed the broader multi-project fixture used by count and ordering tests.
@@ -217,6 +217,7 @@ fn load_sessions_for_filter_returns_project_and_tool_intersection() {
         &[AiAssistant::ClaudeCode],
         &ProjectFilter::Project(1),
         &DateFilter::AnyTime,
+        SortOrder::RecentActivity,
     )
     .expect("load sessions");
 
@@ -235,6 +236,7 @@ fn search_sessions_for_filter_returns_only_unassigned_matches() {
         &ProjectFilter::Unassigned,
         "lonely",
         &DateFilter::AnyTime,
+        None,
     )
     .expect("search sessions");
 

--- a/tests/search_sessions.rs
+++ b/tests/search_sessions.rs
@@ -4,9 +4,10 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use sessions_chronicle::database::schema::initialize_database;
 use sessions_chronicle::database::{
-    find_session_match_positions, load_session_by_id_for_filter, search_sessions_for_filter,
+    find_session_match_positions, load_session_by_id_for_filter, load_sessions_for_filter,
+    search_sessions_for_filter,
 };
-use sessions_chronicle::models::{AiAssistant, DateFilter, ProjectFilter};
+use sessions_chronicle::models::{AiAssistant, DateFilter, ProjectFilter, SortOrder};
 
 struct TempDatabase {
     path: PathBuf,
@@ -148,6 +149,14 @@ impl TempDatabase {
                 ],
             )
             .expect("Failed to insert message C1");
+
+        self.connection
+            .execute(
+                "INSERT INTO messages (session_id, message_index, role, content, timestamp, model)
+                 VALUES ('session-a', 1, 'assistant', 'alpha follow-up', 11, NULL)",
+                [],
+            )
+            .expect("Failed to insert message A2");
     }
 }
 
@@ -210,6 +219,7 @@ fn search_sessions_orders_by_relevance() {
         &ProjectFilter::AllSessions,
         "alpha",
         &DateFilter::AnyTime,
+        None,
     )
     .expect("Search failed");
     let ids: Vec<&str> = sessions.iter().map(|session| session.id.as_str()).collect();
@@ -229,6 +239,7 @@ fn search_sessions_respects_tool_filter() {
         &ProjectFilter::AllSessions,
         "alpha",
         &DateFilter::AnyTime,
+        None,
     )
     .expect("Search failed");
 
@@ -248,6 +259,7 @@ fn search_sessions_sanitizes_invalid_query() {
         &ProjectFilter::AllSessions,
         "\"alpha",
         &DateFilter::AnyTime,
+        None,
     )
     .expect("Search failed");
 
@@ -494,4 +506,125 @@ fn find_session_match_positions_empty_query() {
 
     assert!(blank.is_empty());
     assert!(empty.is_empty());
+}
+
+#[test]
+fn load_sessions_follows_each_named_order() {
+    let db = TempDatabase::new();
+    db.seed();
+
+    for (sort, expected) in [
+        (
+            SortOrder::RecentActivity,
+            vec!["session-c", "session-b", "session-a"],
+        ),
+        (
+            SortOrder::OldestFirst,
+            vec!["session-a", "session-b", "session-c"],
+        ),
+        (
+            SortOrder::NewestFirst,
+            vec!["session-c", "session-b", "session-a"],
+        ),
+        (
+            SortOrder::MostMessages,
+            vec!["session-a", "session-b", "session-c"],
+        ),
+    ] {
+        let sessions = load_sessions_for_filter(
+            &db.path,
+            &AiAssistant::ALL,
+            &ProjectFilter::AllSessions,
+            &DateFilter::AnyTime,
+            sort,
+        )
+        .expect("load sessions");
+        assert_eq!(
+            sessions
+                .iter()
+                .map(|session| session.id.as_str())
+                .collect::<Vec<_>>(),
+            expected
+        );
+    }
+}
+
+#[test]
+fn search_deduplicates_sessions_and_follows_named_orders() {
+    let db = TempDatabase::new();
+    db.seed();
+
+    for (sort, expected) in [
+        (SortOrder::RecentActivity, vec!["session-b", "session-a"]),
+        (SortOrder::OldestFirst, vec!["session-a", "session-b"]),
+        (SortOrder::NewestFirst, vec!["session-b", "session-a"]),
+        (SortOrder::MostMessages, vec!["session-a", "session-b"]),
+    ] {
+        let sessions = search_sessions_for_filter(
+            &db.path,
+            &[AiAssistant::ClaudeCode, AiAssistant::OpenCode],
+            &ProjectFilter::AllSessions,
+            "alpha",
+            &DateFilter::AnyTime,
+            Some(sort),
+        )
+        .expect("search sessions");
+        assert_eq!(
+            sessions
+                .iter()
+                .map(|session| session.id.as_str())
+                .collect::<Vec<_>>(),
+            expected
+        );
+    }
+}
+
+#[test]
+fn search_named_orders_use_id_as_the_final_tie_breaker() {
+    let db = TempDatabase::new();
+    for id in ["tie-a", "tie-b"] {
+        db.connection
+            .execute(
+                "INSERT INTO sessions
+             (id, tool, start_time, message_count, file_path, last_updated)
+             VALUES (?1, 'claude_code', 10, 4, ?2, 20)",
+                rusqlite::params![id, format!("/tmp/{id}.jsonl")],
+            )
+            .unwrap();
+        db.connection
+            .execute(
+                "INSERT INTO messages (session_id, message_index, role, content, timestamp)
+             VALUES (?1, 0, 'user', 'tie', 10)",
+                [id],
+            )
+            .unwrap();
+    }
+
+    let descending = search_sessions_for_filter(
+        &db.path,
+        &AiAssistant::ALL,
+        &ProjectFilter::AllSessions,
+        "tie",
+        &DateFilter::AnyTime,
+        Some(SortOrder::MostMessages),
+    )
+    .unwrap();
+    assert_eq!(
+        descending.iter().map(|s| s.id.as_str()).collect::<Vec<_>>(),
+        vec!["tie-b", "tie-a"]
+    );
+
+    let ascending = search_sessions_for_filter(
+        &db.path,
+        &AiAssistant::ALL,
+        &ProjectFilter::AllSessions,
+        "tie",
+        &DateFilter::AnyTime,
+        Some(SortOrder::OldestFirst),
+    )
+    .unwrap();
+    assert_eq!(
+        ascending.iter().map(|s| s.id.as_str()).collect::<Vec<_>>(),
+        vec!["tie-a", "tie-b"]
+    );
 }


### PR DESCRIPTION
## Problem

The session list had a single fixed reading order (most recent activity first), with no way to browse oldest-first, newest-first, or by message count. Closes #188.

## Solution

Adds persistent named sort orders to the session list, while keeping BM25 relevance as derived, FTS-only state.

- **`SortOrder`** is the only persisted sorting type and owns its stable labels and GSettings values. Relevance is never persisted.
- **`SessionQuery`** is a shared classifier distinguishing empty, direct-`id:`, and FTS queries, replacing the previous ad hoc parsing in `session_list.rs`.
- **App** resolves `Option<SortOrder>` atomically with each query update, where `None` means relevance on the FTS database path. A named order picked during FTS becomes both the active override and the persisted preference; clearing FTS or entering an `id:` lookup restores the persisted order.
- **Database** maps each enum value to a constant `ORDER BY` fragment with an explicit `id` tie-breaker. Schema **v15** adds three deterministic top-level sort indexes.
- **`SortPill`** is a new Relm4 menu-button component displaying and changing that state, reachable via <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>O</kbd>. It shows its label whenever a non-default order is active and hides it otherwise, at every window width — the same rule `DatePill` applies to its own label.

Pinned sessions never float — no ordering clause references `pinned_at`.

The design spec prescribed a dedicated 760sp breakpoint to hide the pill label instead. That was dropped: libadwaita applies only the last matching breakpoint, and `max-width: 400sp` is strictly contained in `max-width: 760sp`, so adding the second one stopped the existing collapse breakpoint's setters from ever running — disabling sidebar collapse and the view-switcher bar above ~1.8x text scaling. The window is back to a single breakpoint and `setup_breakpoints` is byte-identical to `main`. Full rationale in [§9.1 of the design spec](docs/superpowers/specs/2026-07-21-session-list-sorting-design.md), along with the other implementation amendments.

## Verification

```
cargo fmt --all -- --check                    # clean
cargo clippy --all -- -D warnings             # zero warnings
xvfb-run -a cargo test --all --no-fail-fast   # 0 failures
```

`unfiltered_named_orders_do_not_build_temporary_sort_tables` is the repeatable query-plan evidence that all four unfiltered orders are index-backed. Filtered queries may still legitimately use a temp b-tree.

`flatpak-builder --user flatpak_app build-aux/dev.maciz.sessionschronicle.Devel.json --force-clean` exited 0 at `bd0bc25`; no packaging or build inputs changed after that commit.

## Known follow-ups

- The 400sp breakpoint predates this PR and has been unreachable at default text scale since `MIN_WINDOW_WIDTH` was introduced (#105, later lowered to 710px). Its value deserves revisiting against the real minimum width.
- The popover uses a custom `GtkListBox` rather than a menu model with radio items, so screen readers announce list items rather than checked radio buttons. This matches `DatePill` and would be worth changing for both at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
