### PR TITLE
feat: open indexed sessions via app action

### DIFF
--- a/build-aux/validate-activation-metadata.py
+++ b/build-aux/validate-activation-metadata.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import sys
+
+
+desktop_path = Path(sys.argv[1])
+service_path = Path(sys.argv[2])
+app_id = sys.argv[3]
+bindir = Path(sys.argv[4])
+
+desktop = desktop_path.read_text(encoding="utf-8").splitlines()
+service = service_path.read_text(encoding="utf-8").splitlines()
+
+assert desktop_path.name == f"{app_id}.desktop"
+assert service_path.name == f"{app_id}.service"
+assert "DBusActivatable=true" in desktop
+assert "Exec=sessions-chronicle" in desktop
+assert f"Name={app_id}" in service
+assert f"Exec={bindir / 'sessions-chronicle'} --gapplication-service" in service
+assert all("--sessions-dir" not in line for line in service)

--- a/data/dev.maciz.sessionschronicle.desktop.in.in
+++ b/data/dev.maciz.sessionschronicle.desktop.in.in
@@ -3,6 +3,7 @@ Name=Sessions Chronicle
 Comment=Browse and search AI coding sessions
 Type=Application
 Exec=sessions-chronicle
+DBusActivatable=true
 Terminal=false
 Categories=Development;GTK;
 # Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!

--- a/data/dev.maciz.sessionschronicle.service.in
+++ b/data/dev.maciz.sessionschronicle.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=@APP_ID@
+Exec=@BINDIR@/sessions-chronicle --gapplication-service

--- a/data/meson.build
+++ b/data/meson.build
@@ -27,6 +27,30 @@ if desktop_file_validate.found()
   )
 endif
 
+service_conf = configuration_data()
+service_conf.set('APP_ID', application_id)
+service_conf.set('BINDIR', bindir)
+service_file = configure_file(
+  input: '@0@.service.in'.format(base_id),
+  output: '@0@.service'.format(application_id),
+  configuration: service_conf,
+  install: true,
+  install_dir: datadir / 'dbus-1' / 'services',
+)
+
+test(
+  'validate-activation-metadata',
+  python,
+  args: [
+    meson.project_source_root() / 'build-aux' / 'validate-activation-metadata.py',
+    desktop_file.full_path(),
+    service_file.full_path(),
+    application_id,
+    bindir,
+  ],
+  depends: desktop_file,
+)
+
 # Appdata
 appdata_conf = configuration_data()
 appdata_conf.set('app-id', application_id)

--- a/docs/DEVELOPMENT_WORKFLOW.md
+++ b/docs/DEVELOPMENT_WORKFLOW.md
@@ -16,6 +16,56 @@ flatpak-builder --run flatpak_app build-aux/dev.maciz.sessionschronicle.Devel.js
 
 Use this path when you want the closest match to the packaged app environment.
 
+### Testing session deep links
+
+The private `open-session` GApplication action opens an indexed top-level
+session by ID. It uses the same command whether Sessions Chronicle is closed or
+already running.
+
+Cold activation requires an installed Flatpak so the profile-specific D-Bus
+service is exported. A `flatpak-builder --run` build alone is not sufficient:
+
+```bash
+flatpak-builder --user --install flatpak_app \
+  build-aux/dev.maciz.sessionschronicle.Devel.json --force-clean
+```
+
+Select a recent top-level session from the default development index and
+activate it:
+
+```bash
+DB_PATH="$(flatpak run dev.maciz.sessionschronicle.Devel --print-db-path)"
+SESSION_ID="$(sqlite3 "$DB_PATH" \
+  'SELECT id FROM sessions WHERE is_subagent = 0 ORDER BY last_updated DESC LIMIT 1;')"
+test -n "$SESSION_ID"
+
+gapplication action dev.maciz.sessionschronicle.Devel \
+  open-session "'$SESSION_ID'"
+```
+
+Run the final command with the application closed to verify cold D-Bus
+activation. Run it again with the application open to verify that the existing
+window is presented and its detail is replaced. The nested quotes around the ID
+are required because `gapplication` expects a GVariant string.
+
+For an installed stable build, select the ID from its own database and use the
+stable App ID:
+
+```bash
+DB_PATH="$(flatpak run dev.maciz.sessionschronicle --print-db-path)"
+SESSION_ID="$(sqlite3 "$DB_PATH" \
+  'SELECT id FROM sessions WHERE is_subagent = 0 ORDER BY last_updated DESC LIMIT 1;')"
+test -n "$SESSION_ID"
+
+gapplication action dev.maciz.sessionschronicle \
+  open-session "'$SESSION_ID'"
+```
+
+`open-session` is an internal protocol for components shipped with Sessions
+Chronicle, not a stable public API. It accepts only IDs from the profile's
+default index. Instances started with `--sessions-dir` are non-unique, own no
+application bus name, and do not receive deep-link actions.
+
 ### Via Meson (faster inner loop)
 
 ```bash

--- a/docs/superpowers/specs/2026-08-01-deep-link-session-design.md
+++ b/docs/superpowers/specs/2026-08-01-deep-link-session-design.md
@@ -1,7 +1,7 @@
 # Open Session by ID — Design Spec
 
 **Date:** 2026-08-01  
-**Status:** Approved design for [issue #197](https://github.com/supermaciz/sessions-chronicle/issues/197)  
+**Status:** Implemented by [PR #200](https://github.com/supermaciz/sessions-chronicle/pull/200)  
 **Issue:** [#197 — deep-linking: open a session by ID from outside the app](https://github.com/supermaciz/sessions-chronicle/issues/197)  
 **Blocks:** [#189 — expose session search in GNOME Activities](https://github.com/supermaciz/sessions-chronicle/issues/189)  
 **Related exploration:** [`docs/explorations/2026-08-01-gnome-search-configurability-exploration.md`](../../explorations/2026-08-01-gnome-search-configurability-exploration.md)
@@ -281,6 +281,17 @@ flatpak-builder --user flatpak_app build-aux/dev.maciz.sessionschronicle.Devel.j
 ```
 
 The Flatpak must also be installed for the cold host-to-sandbox D-Bus checks; a build alone does not prove service activation.
+
+## Implementation differences
+
+The implementation preserves the protocol, fail-fast lookup behavior, user-visible messages, and navigation guarantees described above. The following details changed while implementing and verifying the design:
+
+| Area | Planned design | Final implementation | Rationale and impact |
+|---|---|---|---|
+| Index availability | Distinguish a missing index from a missing row by checking whether the database exists before lookup. | `App::init` captures `index_available` before `SessionIndexer::new` can create the database, and a successful indexing pass sets it to `true`. | The name describes whether an index can be queried, not whether it reflects the latest files on disk. Existing indexed results still open immediately while incremental indexing runs; no retry or deferred opening was added. |
+| Lookup outcomes | Classify lookup as `Found`, `IndexMissing`, `Unavailable`, or `Failed`, then map failures to user feedback. | `lookup_external_session` returns `Result<Session, ExternalOpenFailure>`, with the SQLite error retained by `Failed(anyhow::Error)`. | This removes duplicate outcome enums and the boxed success payload without changing classification, logging, or toast text. Unknown, empty, and subagent IDs remain `Unavailable`. |
+| Application-action test | Activate `open-session` through the application action map and verify broker delivery. | The GTK unit test looks up the typed `SimpleAction` and activates it directly. Installed-Flatpak acceptance checks exercise the real host-to-sandbox GApplication route. | The test application is not registered on the session bus, so `GApplication::activate_action` rejects activation there. Direct action activation still tests the callback and broker boundary; cold and warm D-Bus routing are verified at the installed-process level. |
+| Popover preservation test | Assert that unavailable targets preserve the visible summary popover together with model navigation and search state. | The headless regression asserts the model, search, inspector, detail, parent, and navigation-stack state; popover preservation was verified during installed-Flatpak acceptance instead. | Under Xvfb, iterating the main context unmaps the popover because the test GApplication has not emitted normal startup, even for a no-op handler. Keeping that assertion would test the harness artifact rather than the failure path. |
 
 ## Success criteria
 

--- a/meson.build
+++ b/meson.build
@@ -8,6 +8,7 @@ project(
 
 i18n = import('i18n')
 gnome = import('gnome')
+python = import('python').find_installation()
 
 base_id = 'dev.maciz.sessionschronicle'
 

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,7 +1,7 @@
 data/dev.maciz.sessionschronicle.desktop.in.in
 data/dev.maciz.sessionschronicle.gschema.xml.in
 data/dev.maciz.sessionschronicle.metainfo.xml.in.in
-src/app.rs
+src/app/handlers/sessions.rs
 src/main.rs
 src/ui/date_pill.rs
 src/ui/modals/shortcuts.rs

--- a/src/app/handlers/indexing.rs
+++ b/src/app/handlers/indexing.rs
@@ -57,7 +57,7 @@ impl App {
             skipped,
             removed
         );
-        self.index_ready = true;
+        self.index_available = true;
         self.indexing = false;
         self.session_list.emit(SessionListMsg::SetIndexing(false));
         self.last_per_source = per_source.clone();

--- a/src/app/handlers/indexing.rs
+++ b/src/app/handlers/indexing.rs
@@ -57,6 +57,7 @@ impl App {
             skipped,
             removed
         );
+        self.index_ready = true;
         self.indexing = false;
         self.session_list.emit(SessionListMsg::SetIndexing(false));
         self.last_per_source = per_source.clone();

--- a/src/app/handlers/sessions.rs
+++ b/src/app/handlers/sessions.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use gettextrs::gettext;
 use relm4::ComponentController;
 use relm4::gtk::prelude::WidgetExt;
 
@@ -10,6 +11,44 @@ use crate::ui::session_detail::SessionDetailMsg;
 use super::super::App;
 use super::super::helpers::{active_search_query, parent_session_load_failure_message};
 use super::super::types::ActiveSessionRef;
+
+#[derive(Debug)]
+enum ExternalSessionLookup {
+    Found(Session),
+    IndexMissing,
+    Unavailable,
+    Failed(anyhow::Error),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ExternalOpenFailure {
+    IndexMissing,
+    Unavailable,
+    Failed,
+}
+
+fn lookup_external_session(db_path: &Path, id: &str, index_ready: bool) -> ExternalSessionLookup {
+    if id.is_empty() {
+        return ExternalSessionLookup::Unavailable;
+    }
+    if !index_ready || !db_path.exists() {
+        return ExternalSessionLookup::IndexMissing;
+    }
+
+    match load_session(db_path, id) {
+        Ok(Some(session)) if !session.is_subagent => ExternalSessionLookup::Found(session),
+        Ok(Some(_)) | Ok(None) => ExternalSessionLookup::Unavailable,
+        Err(error) => ExternalSessionLookup::Failed(error),
+    }
+}
+
+fn external_open_failure_title(failure: ExternalOpenFailure) -> String {
+    match failure {
+        ExternalOpenFailure::Unavailable => gettext("Session not found"),
+        ExternalOpenFailure::IndexMissing => gettext("Sessions are not indexed yet"),
+        ExternalOpenFailure::Failed => gettext("Could not open session"),
+    }
+}
 
 impl App {
     fn project_name_from_session(session: &Session) -> String {
@@ -122,5 +161,104 @@ impl App {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::schema::initialize_database;
+    use rusqlite::Connection;
+
+    fn seeded_database() -> (tempfile::TempDir, std::path::PathBuf) {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("sessions.db");
+        let connection = Connection::open(&path).unwrap();
+        initialize_database(&connection).unwrap();
+        connection
+            .execute(
+                "INSERT INTO sessions
+                 (id, tool, project_path, start_time, message_count, file_path,
+                  last_updated, is_subagent)
+                 VALUES (?1, 'claude_code', '/projects/demo', 1, 1, '/tmp/demo.jsonl', 1, ?2)",
+                rusqlite::params!["top-level", false],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO sessions
+                 (id, tool, project_path, start_time, message_count, file_path,
+                  last_updated, is_subagent)
+                 VALUES (?1, 'claude_code', '/projects/demo', 1, 1, '/tmp/child.jsonl', 1, ?2)",
+                rusqlite::params!["subagent", true],
+            )
+            .unwrap();
+        drop(connection);
+        (directory, path)
+    }
+
+    #[test]
+    fn lookup_accepts_only_existing_top_level_session() {
+        let (_directory, path) = seeded_database();
+
+        match lookup_external_session(&path, "top-level", true) {
+            ExternalSessionLookup::Found(session) => assert_eq!(session.id, "top-level"),
+            outcome => panic!("expected found, got {outcome:?}"),
+        }
+        assert!(matches!(
+            lookup_external_session(&path, "subagent", true),
+            ExternalSessionLookup::Unavailable
+        ));
+        assert!(matches!(
+            lookup_external_session(&path, "missing", true),
+            ExternalSessionLookup::Unavailable
+        ));
+        assert!(matches!(
+            lookup_external_session(&path, "", true),
+            ExternalSessionLookup::Unavailable
+        ));
+    }
+
+    #[test]
+    fn lookup_distinguishes_missing_index_from_missing_row() {
+        let directory = tempfile::tempdir().unwrap();
+        let missing_path = directory.path().join("not-created.db");
+
+        assert!(matches!(
+            lookup_external_session(&missing_path, "stale-id", true),
+            ExternalSessionLookup::IndexMissing
+        ));
+
+        let (_seed_directory, seeded_path) = seeded_database();
+        assert!(matches!(
+            lookup_external_session(&seeded_path, "top-level", false),
+            ExternalSessionLookup::IndexMissing
+        ));
+    }
+
+    #[test]
+    fn lookup_distinguishes_sqlite_failure() {
+        let directory = tempfile::tempdir().unwrap();
+
+        assert!(matches!(
+            lookup_external_session(directory.path(), "any-id", true),
+            ExternalSessionLookup::Failed(_)
+        ));
+    }
+
+    #[test]
+    fn failure_titles_match_the_three_user_outcomes() {
+        assert_eq!(
+            external_open_failure_title(ExternalOpenFailure::Unavailable),
+            "Session not found"
+        );
+        assert_eq!(
+            external_open_failure_title(ExternalOpenFailure::IndexMissing),
+            "Sessions are not indexed yet"
+        );
+        assert_eq!(
+            external_open_failure_title(ExternalOpenFailure::Failed),
+            "Could not open session"
+        );
     }
 }

--- a/src/app/handlers/sessions.rs
+++ b/src/app/handlers/sessions.rs
@@ -27,11 +27,15 @@ enum ExternalOpenFailure {
     Failed,
 }
 
-fn lookup_external_session(db_path: &Path, id: &str, index_ready: bool) -> ExternalSessionLookup {
+fn lookup_external_session(
+    db_path: &Path,
+    id: &str,
+    index_available: bool,
+) -> ExternalSessionLookup {
     if id.is_empty() {
         return ExternalSessionLookup::Unavailable;
     }
-    if !index_ready || !db_path.exists() {
+    if !index_available || !db_path.exists() {
         return ExternalSessionLookup::IndexMissing;
     }
 
@@ -175,7 +179,7 @@ impl App {
     pub(crate) fn handle_external_session_open(&mut self, id: String) {
         tracing::debug!(session_id = %id, "External session open requested");
 
-        let session = match lookup_external_session(&self.db_path, &id, self.index_ready) {
+        let session = match lookup_external_session(&self.db_path, &id, self.index_available) {
             ExternalSessionLookup::Found(session) => *session,
             ExternalSessionLookup::IndexMissing => {
                 self.show_external_open_failure(ExternalOpenFailure::IndexMissing);

--- a/src/app/handlers/sessions.rs
+++ b/src/app/handlers/sessions.rs
@@ -74,6 +74,16 @@ impl App {
         });
     }
 
+    fn push_detail_page(&mut self) {
+        if !self.detail_visible {
+            self.filters_open_before_detail = self.filters_open;
+            self.filters_open = false;
+            self.nav_view.push(&self.detail_page);
+            self.detail_visible = true;
+            self.banner.set_revealed(false);
+        }
+    }
+
     pub(crate) fn handle_session_selected(&mut self, id: String) {
         tracing::debug!("Session selected: {}", id);
 
@@ -98,13 +108,7 @@ impl App {
             }
         }
 
-        if !self.detail_visible {
-            self.filters_open_before_detail = self.filters_open;
-            self.filters_open = false;
-            self.nav_view.push(&self.detail_page);
-            self.detail_visible = true;
-            self.banner.set_revealed(false);
-        }
+        self.push_detail_page();
     }
 
     pub(crate) fn handle_open_child_session(&mut self, child_session_id: String) {
@@ -194,13 +198,7 @@ impl App {
         self.session_detail.widget().set_visible(true);
         self.set_active_session_and_detail(session, None);
 
-        if !self.detail_visible {
-            self.filters_open_before_detail = self.filters_open;
-            self.filters_open = false;
-            self.nav_view.push(&self.detail_page);
-            self.detail_visible = true;
-            self.banner.set_revealed(false);
-        }
+        self.push_detail_page();
     }
 }
 

--- a/src/app/handlers/sessions.rs
+++ b/src/app/handlers/sessions.rs
@@ -10,7 +10,7 @@ use crate::ui::session_detail::SessionDetailMsg;
 
 use super::super::App;
 use super::super::helpers::{active_search_query, parent_session_load_failure_message};
-use super::super::types::ActiveSessionRef;
+use super::super::types::{ActiveSessionRef, Workspace};
 
 #[derive(Debug)]
 enum ExternalSessionLookup {
@@ -160,6 +160,56 @@ impl App {
                         .emit(parent_session_load_failure_message());
                 }
             }
+        }
+    }
+
+    fn show_external_open_failure(&self, failure: ExternalOpenFailure) {
+        let toast = relm4::adw::Toast::builder()
+            .title(external_open_failure_title(failure))
+            .build();
+        self.toast_overlay.add_toast(toast);
+    }
+
+    pub(crate) fn handle_external_session_open(&mut self, id: String) {
+        tracing::debug!(session_id = %id, "External session open requested");
+
+        let session = match lookup_external_session(&self.db_path, &id, self.index_ready) {
+            ExternalSessionLookup::Found(session) => session,
+            ExternalSessionLookup::IndexMissing => {
+                self.show_external_open_failure(ExternalOpenFailure::IndexMissing);
+                return;
+            }
+            ExternalSessionLookup::Unavailable => {
+                self.show_external_open_failure(ExternalOpenFailure::Unavailable);
+                return;
+            }
+            ExternalSessionLookup::Failed(error) => {
+                tracing::error!(session_id = %id, error = %error, "External session lookup failed");
+                self.show_external_open_failure(ExternalOpenFailure::Failed);
+                return;
+            }
+        };
+
+        self.dismiss_summary_popover();
+        self.search_visible = false;
+        self.sync_search_bar.set(true);
+        let (list_msg, detail_msg) = self.clear_search_state();
+        self.session_list.emit(list_msg);
+        self.session_detail.emit(detail_msg);
+
+        self.handle_workspace_changed(Workspace::Sessions);
+        self.workspace_stack
+            .set_visible_child_name(Workspace::Sessions.stack_name());
+        self.parent_session = None;
+        self.session_detail.widget().set_visible(true);
+        self.set_active_session_and_detail(session, None);
+
+        if !self.detail_visible {
+            self.filters_open_before_detail = self.filters_open;
+            self.filters_open = false;
+            self.nav_view.push(&self.detail_page);
+            self.detail_visible = true;
+            self.banner.set_revealed(false);
         }
     }
 }

--- a/src/app/handlers/sessions.rs
+++ b/src/app/handlers/sessions.rs
@@ -13,46 +13,36 @@ use super::super::helpers::{active_search_query, parent_session_load_failure_mes
 use super::super::types::{ActiveSessionRef, Workspace};
 
 #[derive(Debug)]
-enum ExternalSessionLookup {
-    Found(Box<Session>),
-    IndexMissing,
-    Unavailable,
-    Failed(anyhow::Error),
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ExternalOpenFailure {
     IndexMissing,
     Unavailable,
-    Failed,
+    Failed(anyhow::Error),
 }
 
 fn lookup_external_session(
     db_path: &Path,
     id: &str,
     index_available: bool,
-) -> ExternalSessionLookup {
+) -> Result<Session, ExternalOpenFailure> {
     if id.is_empty() {
-        return ExternalSessionLookup::Unavailable;
+        return Err(ExternalOpenFailure::Unavailable);
     }
     if !index_available || !db_path.exists() {
-        return ExternalSessionLookup::IndexMissing;
+        return Err(ExternalOpenFailure::IndexMissing);
     }
 
     match load_session(db_path, id) {
-        Ok(Some(session)) if !session.is_subagent => {
-            ExternalSessionLookup::Found(Box::new(session))
-        }
-        Ok(Some(_)) | Ok(None) => ExternalSessionLookup::Unavailable,
-        Err(error) => ExternalSessionLookup::Failed(error),
+        Ok(Some(session)) if !session.is_subagent => Ok(session),
+        Ok(Some(_)) | Ok(None) => Err(ExternalOpenFailure::Unavailable),
+        Err(error) => Err(ExternalOpenFailure::Failed(error)),
     }
 }
 
-fn external_open_failure_title(failure: ExternalOpenFailure) -> String {
+fn external_open_failure_title(failure: &ExternalOpenFailure) -> String {
     match failure {
         ExternalOpenFailure::Unavailable => gettext("Session not found"),
         ExternalOpenFailure::IndexMissing => gettext("Sessions are not indexed yet"),
-        ExternalOpenFailure::Failed => gettext("Could not open session"),
+        ExternalOpenFailure::Failed(_) => gettext("Could not open session"),
     }
 }
 
@@ -169,7 +159,7 @@ impl App {
         }
     }
 
-    fn show_external_open_failure(&self, failure: ExternalOpenFailure) {
+    fn show_external_open_failure(&self, failure: &ExternalOpenFailure) {
         let toast = relm4::adw::Toast::builder()
             .title(external_open_failure_title(failure))
             .build();
@@ -180,18 +170,12 @@ impl App {
         tracing::debug!(session_id = %id, "External session open requested");
 
         let session = match lookup_external_session(&self.db_path, &id, self.index_available) {
-            ExternalSessionLookup::Found(session) => *session,
-            ExternalSessionLookup::IndexMissing => {
-                self.show_external_open_failure(ExternalOpenFailure::IndexMissing);
-                return;
-            }
-            ExternalSessionLookup::Unavailable => {
-                self.show_external_open_failure(ExternalOpenFailure::Unavailable);
-                return;
-            }
-            ExternalSessionLookup::Failed(error) => {
-                tracing::error!(session_id = %id, error = %error, "External session lookup failed");
-                self.show_external_open_failure(ExternalOpenFailure::Failed);
+            Ok(session) => session,
+            Err(failure) => {
+                if let ExternalOpenFailure::Failed(error) = &failure {
+                    tracing::error!(session_id = %id, error = %error, "External session lookup failed");
+                }
+                self.show_external_open_failure(&failure);
                 return;
             }
         };
@@ -258,20 +242,20 @@ mod tests {
         let (_directory, path) = seeded_database();
 
         match lookup_external_session(&path, "top-level", true) {
-            ExternalSessionLookup::Found(session) => assert_eq!(session.id, "top-level"),
+            Ok(session) => assert_eq!(session.id, "top-level"),
             outcome => panic!("expected found, got {outcome:?}"),
         }
         assert!(matches!(
             lookup_external_session(&path, "subagent", true),
-            ExternalSessionLookup::Unavailable
+            Err(ExternalOpenFailure::Unavailable)
         ));
         assert!(matches!(
             lookup_external_session(&path, "missing", true),
-            ExternalSessionLookup::Unavailable
+            Err(ExternalOpenFailure::Unavailable)
         ));
         assert!(matches!(
             lookup_external_session(&path, "", true),
-            ExternalSessionLookup::Unavailable
+            Err(ExternalOpenFailure::Unavailable)
         ));
     }
 
@@ -282,13 +266,13 @@ mod tests {
 
         assert!(matches!(
             lookup_external_session(&missing_path, "stale-id", true),
-            ExternalSessionLookup::IndexMissing
+            Err(ExternalOpenFailure::IndexMissing)
         ));
 
         let (_seed_directory, seeded_path) = seeded_database();
         assert!(matches!(
             lookup_external_session(&seeded_path, "top-level", false),
-            ExternalSessionLookup::IndexMissing
+            Err(ExternalOpenFailure::IndexMissing)
         ));
     }
 
@@ -298,22 +282,22 @@ mod tests {
 
         assert!(matches!(
             lookup_external_session(directory.path(), "any-id", true),
-            ExternalSessionLookup::Failed(_)
+            Err(ExternalOpenFailure::Failed(_))
         ));
     }
 
     #[test]
     fn failure_titles_match_the_three_user_outcomes() {
         assert_eq!(
-            external_open_failure_title(ExternalOpenFailure::Unavailable),
+            external_open_failure_title(&ExternalOpenFailure::Unavailable),
             "Session not found"
         );
         assert_eq!(
-            external_open_failure_title(ExternalOpenFailure::IndexMissing),
+            external_open_failure_title(&ExternalOpenFailure::IndexMissing),
             "Sessions are not indexed yet"
         );
         assert_eq!(
-            external_open_failure_title(ExternalOpenFailure::Failed),
+            external_open_failure_title(&ExternalOpenFailure::Failed(anyhow::anyhow!("database"))),
             "Could not open session"
         );
     }

--- a/src/app/handlers/sessions.rs
+++ b/src/app/handlers/sessions.rs
@@ -14,7 +14,7 @@ use super::super::types::{ActiveSessionRef, Workspace};
 
 #[derive(Debug)]
 enum ExternalSessionLookup {
-    Found(Session),
+    Found(Box<Session>),
     IndexMissing,
     Unavailable,
     Failed(anyhow::Error),
@@ -36,7 +36,9 @@ fn lookup_external_session(db_path: &Path, id: &str, index_ready: bool) -> Exter
     }
 
     match load_session(db_path, id) {
-        Ok(Some(session)) if !session.is_subagent => ExternalSessionLookup::Found(session),
+        Ok(Some(session)) if !session.is_subagent => {
+            ExternalSessionLookup::Found(Box::new(session))
+        }
         Ok(Some(_)) | Ok(None) => ExternalSessionLookup::Unavailable,
         Err(error) => ExternalSessionLookup::Failed(error),
     }
@@ -174,7 +176,7 @@ impl App {
         tracing::debug!(session_id = %id, "External session open requested");
 
         let session = match lookup_external_session(&self.db_path, &id, self.index_ready) {
-            ExternalSessionLookup::Found(session) => session,
+            ExternalSessionLookup::Found(session) => *session,
             ExternalSessionLookup::IndexMissing => {
                 self.show_external_open_failure(ExternalOpenFailure::IndexMissing);
                 return;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1874,7 +1874,7 @@ mod tests {
     #[gtk::test]
     fn typed_application_action_reaches_root_component_through_broker() {
         use gtk::glib::variant::{StaticVariantType, ToVariant};
-        use gtk::prelude::{ActionExt, ActionGroupExt, ActionMapExt};
+        use gtk::prelude::{ActionExt, ActionMapExt};
 
         if !schema_is_available() {
             return;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -149,7 +149,7 @@ pub(super) struct App {
     toast_overlay: adw::ToastOverlay,
     filter_state: FilterState,
     db_path: PathBuf,
-    index_ready: bool,
+    index_available: bool,
     sources: SessionSources,
     indexing: bool,
     pending_reindex_feedback: bool,
@@ -456,7 +456,7 @@ impl SimpleComponent for App {
         let sources = SessionSources::resolve(sessions_dir.as_deref());
         let db_dir = glib::user_data_dir().join(APP_ID);
         let db_path = db_dir.join(select_db_filename(sources.override_mode));
-        let index_ready = db_path.exists();
+        let index_available = db_path.exists();
 
         tracing::info!(
             "Session sources (override={}): claude={}, opencode={}, codex={}, vibe={}, kimi={}",
@@ -521,7 +521,7 @@ impl SimpleComponent for App {
             toast_overlay: adw::ToastOverlay::new(),
             filter_state: FilterState::default(),
             db_path,
-            index_ready,
+            index_available,
             sources,
             indexing: true,
             pending_reindex_feedback: false,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -149,6 +149,7 @@ pub(super) struct App {
     toast_overlay: adw::ToastOverlay,
     filter_state: FilterState,
     db_path: PathBuf,
+    index_ready: bool,
     sources: SessionSources,
     indexing: bool,
     pending_reindex_feedback: bool,
@@ -179,6 +180,7 @@ pub(super) enum AppMsg {
         project_filter: ProjectFilter,
     },
     SessionSelected(String),
+    OpenExternalSession(String),
     /// User-requested navigation back from detail to list.
     RequestNavigateBack,
     /// Detail page popped signal from `NavigationView`.
@@ -452,6 +454,7 @@ impl SimpleComponent for App {
         let sources = SessionSources::resolve(sessions_dir.as_deref());
         let db_dir = glib::user_data_dir().join(APP_ID);
         let db_path = db_dir.join(select_db_filename(sources.override_mode));
+        let index_ready = db_path.exists();
 
         tracing::info!(
             "Session sources (override={}): claude={}, opencode={}, codex={}, vibe={}, kimi={}",
@@ -516,6 +519,7 @@ impl SimpleComponent for App {
             toast_overlay: adw::ToastOverlay::new(),
             filter_state: FilterState::default(),
             db_path,
+            index_ready,
             sources,
             indexing: true,
             pending_reindex_feedback: false,
@@ -647,6 +651,7 @@ impl SimpleComponent for App {
                 ));
             }
             AppMsg::SessionSelected(id) => self.handle_session_selected(id),
+            AppMsg::OpenExternalSession(id) => self.handle_external_session_open(id),
             AppMsg::RequestNavigateBack => self.handle_request_navigate_back(),
             AppMsg::NavigateBack => self.handle_navigate_back(),
             AppMsg::ShowPreferences => {
@@ -1675,5 +1680,192 @@ mod tests {
             result.is_err(),
             "expected loading sidebar project data to fail for a directory path"
         );
+    }
+
+    #[gtk::test]
+    fn external_session_opens_detail_and_replaces_it_without_another_push() {
+        if !schema_is_available() {
+            return;
+        }
+
+        let controller = App::builder().launch(Some(PathBuf::from("tests/fixtures")));
+        pump_main_context(|| !controller.state().get().model.indexing);
+        controller.emit(AppMsg::OpenExternalSession("abc123".to_string()));
+        pump_main_context(|| {
+            controller
+                .state()
+                .get()
+                .model
+                .active_session
+                .as_ref()
+                .is_some_and(|session| session.id == "abc123")
+        });
+
+        let stack_size = controller
+            .state()
+            .get()
+            .model
+            .nav_view
+            .navigation_stack()
+            .n_items();
+        controller.emit(AppMsg::OpenExternalSession("session-001".to_string()));
+        pump_main_context(|| {
+            controller
+                .state()
+                .get()
+                .model
+                .active_session
+                .as_ref()
+                .is_some_and(|session| session.id == "session-001")
+        });
+
+        let parts = controller.state().get();
+        assert!(parts.model.detail_visible);
+        assert_eq!(
+            parts.model.nav_view.navigation_stack().n_items(),
+            stack_size
+        );
+        assert_eq!(
+            parts
+                .model
+                .nav_view
+                .visible_page()
+                .and_then(|page| page.tag())
+                .as_deref(),
+            Some("detail")
+        );
+    }
+
+    #[gtk::test]
+    fn external_session_from_analytics_clears_search_and_parent_context() {
+        if !schema_is_available() {
+            return;
+        }
+
+        let controller = App::builder().launch(Some(PathBuf::from("tests/fixtures")));
+        pump_main_context(|| !controller.state().get().model.indexing);
+        controller.emit(AppMsg::SessionSelected(
+            "session_00000000-0000-4000-8000-000000000001".to_string(),
+        ));
+        pump_main_context(|| controller.state().get().model.active_session.is_some());
+        controller.emit(AppMsg::OpenChildSession(
+            "kimi-subagent::session_00000000-0000-4000-8000-000000000001::agent-0".to_string(),
+        ));
+        pump_main_context(|| controller.state().get().model.parent_session.is_some());
+        controller.emit(AppMsg::SearchModeChanged(true));
+        controller.emit(AppMsg::SearchQueryChanged("needle".to_string()));
+        controller.emit(AppMsg::SortOrderPicked(SortOrder::OldestFirst));
+        controller.emit(AppMsg::DateFilterChanged(DateFilter::Today));
+        controller.emit(AppMsg::FiltersChanged {
+            tools: vec![AiAssistant::ClaudeCode],
+            project_filter: ProjectFilter::Pinned,
+        });
+        controller.emit(AppMsg::WorkspaceChanged(Workspace::Analytics));
+        pump_main_context(|| {
+            controller.state().get().model.active_workspace == Workspace::Analytics
+        });
+
+        controller.emit(AppMsg::OpenExternalSession("abc123".to_string()));
+        pump_main_context(|| {
+            controller
+                .state()
+                .get()
+                .model
+                .active_session
+                .as_ref()
+                .is_some_and(|session| session.id == "abc123")
+        });
+
+        let parts = controller.state().get();
+        assert_eq!(parts.model.active_workspace, Workspace::Sessions);
+        assert!(parts.model.search_query.is_empty());
+        assert!(!parts.model.search_visible);
+        assert_eq!(parts.model.search_sort_override, None);
+        assert_eq!(parts.model.sort_order, SortOrder::OldestFirst);
+        assert_eq!(parts.model.effective_sort(), Some(SortOrder::OldestFirst));
+        assert!(parts.model.parent_session.is_none());
+        assert_eq!(
+            parts.model.filter_state.tools,
+            vec![AiAssistant::ClaudeCode]
+        );
+        assert_eq!(
+            parts.model.filter_state.project_filter,
+            ProjectFilter::Pinned
+        );
+        assert_eq!(parts.model.selected_date_filter, DateFilter::Today);
+    }
+
+    #[gtk::test]
+    fn unavailable_external_targets_preserve_navigation_and_search_state() {
+        if !schema_is_available() {
+            return;
+        }
+
+        let controller = App::builder().launch(Some(PathBuf::from("tests/fixtures")));
+        pump_main_context(|| !controller.state().get().model.indexing);
+        controller.emit(AppMsg::SessionSelected(
+            "session_00000000-0000-4000-8000-000000000001".to_string(),
+        ));
+        pump_main_context(|| controller.state().get().model.active_session.is_some());
+        controller.emit(AppMsg::OpenChildSession(
+            "kimi-subagent::session_00000000-0000-4000-8000-000000000001::agent-0".to_string(),
+        ));
+        pump_main_context(|| controller.state().get().model.parent_session.is_some());
+        controller.emit(AppMsg::SearchModeChanged(true));
+        controller.emit(AppMsg::SearchQueryChanged("keep me".to_string()));
+        controller.emit(AppMsg::InspectorVisibilityChanged(true));
+        pump_main_context(|| controller.state().get().model.search_query == "keep me");
+
+        let original_active = controller
+            .state()
+            .get()
+            .model
+            .active_session
+            .as_ref()
+            .unwrap()
+            .id
+            .clone();
+        let original_parent = controller
+            .state()
+            .get()
+            .model
+            .parent_session
+            .as_ref()
+            .unwrap()
+            .id
+            .clone();
+        let original_stack_size = controller
+            .state()
+            .get()
+            .model
+            .nav_view
+            .navigation_stack()
+            .n_items();
+
+        for id in [
+            "not-an-indexed-session",
+            "kimi-subagent::session_00000000-0000-4000-8000-000000000001::agent-0",
+        ] {
+            controller.emit(AppMsg::OpenExternalSession(id.to_string()));
+            pump_main_context(|| !gtk::glib::MainContext::default().pending());
+
+            let parts = controller.state().get();
+            assert_eq!(
+                parts.model.active_session.as_ref().unwrap().id,
+                original_active
+            );
+            assert_eq!(
+                parts.model.parent_session.as_ref().unwrap().id,
+                original_parent
+            );
+            assert_eq!(parts.model.search_query, "keep me");
+            assert!(parts.model.search_visible);
+            assert!(parts.model.inspector_open);
+            assert!(parts.model.detail_visible);
+            assert_eq!(
+                parts.model.nav_view.navigation_stack().n_items(),
+                original_stack_size
+            );
+        }
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,6 +1,6 @@
 use relm4::{
-    Component, ComponentController, ComponentParts, ComponentSender, Controller, SimpleComponent,
-    WorkerController, adw, gtk, main_application,
+    Component, ComponentController, ComponentParts, ComponentSender, Controller, MessageBroker,
+    SimpleComponent, WorkerController, adw, gtk, main_application,
 };
 
 use adw::prelude::*;
@@ -158,6 +158,8 @@ pub(super) struct App {
     banner: adw::Banner,
     banner_has_issues: bool,
 }
+
+pub(super) static APP_BROKER: MessageBroker<AppMsg> = MessageBroker::new();
 
 #[derive(Debug)]
 pub(super) enum AppMsg {
@@ -1867,5 +1869,52 @@ mod tests {
                 original_stack_size
             );
         }
+    }
+
+    #[gtk::test]
+    fn typed_application_action_reaches_root_component_through_broker() {
+        use gtk::glib::variant::{StaticVariantType, ToVariant};
+        use gtk::prelude::{ActionExt, ActionGroupExt, ActionMapExt};
+
+        if !schema_is_available() {
+            return;
+        }
+
+        let app = main_application();
+        crate::register_application_actions(&app);
+        let controller =
+            App::builder().launch_with_broker(Some(PathBuf::from("tests/fixtures")), &APP_BROKER);
+        pump_main_context(|| !controller.state().get().model.indexing);
+
+        let action = app
+            .lookup_action("open-session")
+            .expect("action registered");
+        assert_eq!(
+            action.parameter_type().as_deref(),
+            Some(String::static_variant_type().as_ref())
+        );
+
+        action.activate(Some(&"abc123".to_variant()));
+        pump_main_context(|| {
+            controller
+                .state()
+                .get()
+                .model
+                .active_session
+                .as_ref()
+                .is_some_and(|session| session.id == "abc123")
+        });
+
+        assert_eq!(
+            controller
+                .state()
+                .get()
+                .model
+                .active_session
+                .as_ref()
+                .unwrap()
+                .id,
+            "abc123"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,18 +22,42 @@ mod utils;
 
 use config::{APP_ID, GETTEXT_PACKAGE, LOCALEDIR, RESOURCES_FILE};
 use gettextrs::{LocaleCategory, gettext};
-use gtk::prelude::ApplicationExt;
+use gtk::glib::variant::StaticVariantType;
+use gtk::prelude::{ActionMapExt, ApplicationExt, GtkApplicationExt, GtkWindowExt};
 use gtk::{gio, glib};
 use relm4::{RelmApp, gtk, main_application};
 use std::env;
 
-use app::App;
+use app::{APP_BROKER, App, AppMsg};
 
 use session_sources::{SessionSources, select_db_filename};
 use tracing_subscriber::EnvFilter;
 
 relm4::new_action_group!(AppActionGroup, "app");
 relm4::new_stateless_action!(QuitAction, AppActionGroup, "quit");
+
+fn present_application_window(app: &gtk::Application) {
+    if let Some(window) = app
+        .active_window()
+        .or_else(|| app.windows().into_iter().next())
+    {
+        window.present();
+    }
+}
+
+fn register_application_actions(app: &gtk::Application) {
+    let open_session = gio::SimpleAction::new("open-session", Some(&String::static_variant_type()));
+    let application = app.clone();
+    open_session.connect_activate(move |_, parameter| {
+        present_application_window(&application);
+        let Some(id) = parameter.and_then(|value| value.get::<String>()) else {
+            tracing::warn!("open-session activated without a string parameter");
+            return;
+        };
+        APP_BROKER.send(AppMsg::OpenExternalSession(id));
+    });
+    app.add_action(&open_session);
+}
 
 fn main() {
     let invocation = startup::parse_invocation(env::args()).unwrap_or_else(|error| error.exit());
@@ -72,9 +96,14 @@ fn main() {
     gtk::Window::set_default_icon_name(APP_ID);
 
     let app = main_application();
+    app.set_application_id(Some(APP_ID));
     app.set_resource_base_path(Some("/dev/maciz/sessionschronicle/"));
+    app.connect_activate(present_application_window);
+    register_application_actions(&app);
 
-    let app = RelmApp::from_app(app).with_args(invocation.gapplication_args);
+    let app = RelmApp::from_app(app)
+        .with_broker(&APP_BROKER)
+        .with_args(invocation.gapplication_args);
     app.allow_multiple_instances(startup::allow_multiple_instances(
         args.sessions_dir.as_deref(),
     ));

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod models;
 mod parsers;
 mod project_resolver;
 mod session_sources;
+mod startup;
 #[allow(dead_code)]
 mod ui;
 mod utils;
@@ -24,34 +25,19 @@ use gettextrs::{LocaleCategory, gettext};
 use gtk::prelude::ApplicationExt;
 use gtk::{gio, glib};
 use relm4::{RelmApp, gtk, main_application};
-use std::{env, path::PathBuf};
+use std::env;
 
 use app::App;
 
-use clap::Parser;
 use session_sources::{SessionSources, select_db_filename};
 use tracing_subscriber::EnvFilter;
-
-#[derive(Parser)]
-struct Args {
-    /// Override session source root directory.
-    #[arg(long, value_name = "DIR")]
-    sessions_dir: Option<PathBuf>,
-
-    /// Print the resolved SQLite database path and exit.
-    #[arg(long)]
-    print_db_path: bool,
-
-    /// Unknown arguments or everything after -- gets passed through to GTK.
-    #[arg(allow_hyphen_values = true, trailing_var_arg = true)]
-    gtk_options: Vec<String>,
-}
 
 relm4::new_action_group!(AppActionGroup, "app");
 relm4::new_stateless_action!(QuitAction, AppActionGroup, "quit");
 
 fn main() {
-    let args = Args::parse();
+    let invocation = startup::parse_invocation(env::args()).unwrap_or_else(|error| error.exit());
+    let args = invocation.local;
 
     if args.print_db_path {
         let sources = SessionSources::resolve(args.sessions_dir.as_deref());
@@ -88,13 +74,10 @@ fn main() {
     let app = main_application();
     app.set_resource_base_path(Some("/dev/maciz/sessionschronicle/"));
 
-    let program_invocation = env::args()
-        .next()
-        .unwrap_or_else(|| String::from("sessions-chronicle"));
-    let mut gtk_args = vec![program_invocation];
-    gtk_args.extend(args.gtk_options.clone());
-
-    let app = RelmApp::from_app(app).with_args(gtk_args);
+    let app = RelmApp::from_app(app).with_args(invocation.gapplication_args);
+    app.allow_multiple_instances(startup::allow_multiple_instances(
+        args.sessions_dir.as_deref(),
+    ));
 
     let data = res
         .lookup_data(

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -1,0 +1,196 @@
+use std::path::{Path, PathBuf};
+
+use clap::Parser;
+
+#[derive(Debug, Parser, PartialEq, Eq)]
+pub(crate) struct LocalArgs {
+    /// Override session source root directory.
+    #[arg(long, value_name = "DIR")]
+    pub(crate) sessions_dir: Option<PathBuf>,
+
+    /// Print the resolved SQLite database path and exit.
+    #[arg(long)]
+    pub(crate) print_db_path: bool,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct Invocation {
+    pub(crate) local: LocalArgs,
+    pub(crate) gapplication_args: Vec<String>,
+}
+
+pub(crate) fn parse_invocation(
+    args: impl IntoIterator<Item = String>,
+) -> Result<Invocation, clap::Error> {
+    let mut args = args.into_iter();
+    let program = args
+        .next()
+        .unwrap_or_else(|| "sessions-chronicle".to_string());
+    let mut local_args = vec![program.clone()];
+    let mut gapplication_args = vec![program];
+    let mut args = args.peekable();
+    let mut after_delimiter = false;
+
+    while let Some(arg) = args.next() {
+        if after_delimiter {
+            gapplication_args.push(arg);
+            continue;
+        }
+
+        match arg.as_str() {
+            "--" => {
+                after_delimiter = true;
+                gapplication_args.push(arg);
+            }
+            "--sessions-dir" => {
+                local_args.push(arg);
+                if args
+                    .peek()
+                    .is_some_and(|value| value != "--" && !value.starts_with('-'))
+                {
+                    local_args.push(args.next().unwrap());
+                }
+            }
+            "--print-db-path" | "-h" | "--help" => local_args.push(arg),
+            _ if arg.starts_with("--sessions-dir=") => local_args.push(arg),
+            _ => gapplication_args.push(arg),
+        }
+    }
+
+    Ok(Invocation {
+        local: LocalArgs::try_parse_from(local_args)?,
+        gapplication_args,
+    })
+}
+
+pub(crate) fn allow_multiple_instances(sessions_dir: Option<&Path>) -> bool {
+    sessions_dir.is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn strings(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| (*value).to_string()).collect()
+    }
+
+    #[test]
+    fn gapplication_service_is_forwarded() {
+        let invocation =
+            parse_invocation(strings(&["sessions-chronicle", "--gapplication-service"])).unwrap();
+
+        assert_eq!(
+            invocation.gapplication_args,
+            strings(&["sessions-chronicle", "--gapplication-service"])
+        );
+        assert_eq!(invocation.local.sessions_dir, None);
+        assert!(!invocation.local.print_db_path);
+    }
+
+    #[test]
+    fn sessions_dir_after_gtk_option_is_extracted() {
+        let invocation = parse_invocation(strings(&[
+            "sessions-chronicle",
+            "--display=:1",
+            "--sessions-dir",
+            "tests/fixtures",
+        ]))
+        .unwrap();
+
+        assert_eq!(
+            invocation.local.sessions_dir,
+            Some(PathBuf::from("tests/fixtures"))
+        );
+        assert_eq!(
+            invocation.gapplication_args,
+            strings(&["sessions-chronicle", "--display=:1"])
+        );
+    }
+
+    #[test]
+    fn sessions_dir_equals_form_is_extracted() {
+        let invocation = parse_invocation(strings(&[
+            "sessions-chronicle",
+            "--sessions-dir=tests/fixtures",
+        ]))
+        .unwrap();
+
+        assert_eq!(
+            invocation.local.sessions_dir,
+            Some(PathBuf::from("tests/fixtures"))
+        );
+        assert_eq!(
+            invocation.gapplication_args,
+            strings(&["sessions-chronicle"])
+        );
+    }
+
+    #[test]
+    fn print_db_path_after_service_option_stays_local() {
+        let invocation = parse_invocation(strings(&[
+            "sessions-chronicle",
+            "--gapplication-service",
+            "--print-db-path",
+        ]))
+        .unwrap();
+
+        assert!(invocation.local.print_db_path);
+        assert_eq!(
+            invocation.gapplication_args,
+            strings(&["sessions-chronicle", "--gapplication-service"])
+        );
+    }
+
+    #[test]
+    fn delimiter_forwards_every_following_argument_unchanged() {
+        let invocation = parse_invocation(strings(&[
+            "sessions-chronicle",
+            "--",
+            "--sessions-dir",
+            "tests/fixtures",
+            "--print-db-path",
+        ]))
+        .unwrap();
+
+        assert_eq!(invocation.local.sessions_dir, None);
+        assert!(!invocation.local.print_db_path);
+        assert_eq!(
+            invocation.gapplication_args,
+            strings(&[
+                "sessions-chronicle",
+                "--",
+                "--sessions-dir",
+                "tests/fixtures",
+                "--print-db-path",
+            ])
+        );
+    }
+
+    #[test]
+    fn missing_and_duplicate_local_options_remain_clap_errors() {
+        assert!(parse_invocation(strings(&["sessions-chronicle", "--sessions-dir"])).is_err());
+        assert!(
+            parse_invocation(strings(&[
+                "sessions-chronicle",
+                "--sessions-dir=one",
+                "--sessions-dir=two",
+            ]))
+            .is_err()
+        );
+        assert!(
+            parse_invocation(strings(&[
+                "sessions-chronicle",
+                "--print-db-path",
+                "--print-db-path",
+            ]))
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn only_override_mode_allows_multiple_instances() {
+        assert!(!allow_multiple_instances(None));
+        assert!(allow_multiple_instances(Some(Path::new("tests/fixtures"))));
+    }
+}

--- a/tests/cli_print_db_path.rs
+++ b/tests/cli_print_db_path.rs
@@ -48,3 +48,23 @@ fn help_describes_print_db_path_option() {
     assert!(stdout.contains("--print-db-path"));
     assert!(stdout.contains("Print the resolved SQLite database path and exit"));
 }
+
+#[test]
+fn print_db_path_after_gapplication_option_is_handled_locally() {
+    let output = run_cli(&["--gapplication-service", "--print-db-path"]);
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
+    assert!(stdout.trim_end().ends_with("sessions.db"));
+}
+
+#[test]
+fn sessions_dir_equals_form_selects_override_database() {
+    let sessions_dir = tempfile::tempdir().expect("failed to create temp sessions dir");
+    let argument = format!("--sessions-dir={}", sessions_dir.path().display());
+    let output = run_cli(&[&argument, "--print-db-path"]);
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
+    assert!(stdout.trim_end().ends_with("sessions-override.db"));
+}

--- a/tests/i18n_potfiles.rs
+++ b/tests/i18n_potfiles.rs
@@ -1,10 +1,30 @@
+use std::path::Path;
+
 #[test]
-fn potfiles_includes_rust_files_with_gettext_strings() {
+fn potfiles_lists_only_existing_sources_and_external_open_translations() {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let potfiles = include_str!("../po/POTFILES.in");
-    for path in ["src/ui/modals/shortcuts.rs", "src/ui/sort_pill.rs"] {
+    let entries: Vec<&str> = potfiles
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .collect();
+
+    for entry in &entries {
         assert!(
-            potfiles.lines().any(|line| line.trim() == path),
-            "po/POTFILES.in must include {path} for gettext extraction"
+            manifest_dir.join(entry).is_file(),
+            "po/POTFILES.in references missing path {entry}"
+        );
+    }
+
+    for required in [
+        "src/app/handlers/sessions.rs",
+        "src/ui/modals/shortcuts.rs",
+        "src/ui/sort_pill.rs",
+    ] {
+        assert!(
+            entries.contains(&required),
+            "po/POTFILES.in must include {required} for gettext extraction"
         );
     }
 }


### PR DESCRIPTION
## Summary
- separate local startup options from GTK/GApplication arguments while keeping fixture-backed instances non-unique
- expose a typed private `open-session` application action that validates top-level sessions and preserves UI state on failures
- install profile-specific desktop and D-Bus activation metadata with validation and gettext coverage

Closes #197 

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --all -- -D warnings`
- `xvfb-run -a env GDK_BACKEND=x11 GSK_RENDERER=cairo cargo test --all --no-fail-fast`
- development and stable Flatpak builds/installations
- cold and warm GApplication action activation
- invalid and subagent target handling
- fixture-instance and stable/development profile isolation